### PR TITLE
Fix: Autocomplete clears previously selected options

### DIFF
--- a/frontend/lib/js/form-components/InputMultiSelect.js
+++ b/frontend/lib/js/form-components/InputMultiSelect.js
@@ -51,6 +51,7 @@ const InputMultiSelect = (props: PropsType) => (
       onInputChange={props.onInputChange || function(value) { return value; }}
       isLoading={props.isLoading}
       className={props.className}
+      matchPos="start"
     />
   </label>
 );

--- a/frontend/lib/js/standard-query-editor/reducer.js
+++ b/frontend/lib/js/standard-query-editor/reducer.js
@@ -272,6 +272,22 @@ const setNodeFilterProperties = (state, action, obj) => {
   // or empty objects
   const properties = stripObject(obj);
 
+  if (properties.options) {
+    // Options are only updated in the context of autocompletion.
+    // In this case we don't want to replace the existing options but update
+    // them with the new list, removing duplicates
+    const previousOptions = filter.options || [];
+    properties.options = properties.options
+      .concat(previousOptions)
+      .reduce(
+        (options, currentOption) =>
+          options.find(x => x.value === currentOption.value)
+            ? options
+            : [...options, currentOption],
+        []
+      );
+  }
+
   const newTable = {
     ...table,
     filters: [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,7 +45,7 @@
     "react-redux": "^5.0.2",
     "react-router": "^4.2.0",
     "react-router-redux": "^5.0.0-alpha.8",
-    "react-select": "^1.0.0-rc.4",
+    "react-select": "^1.1.0",
     "react-split-pane": "^0.1.57",
     "react-tooltip": "^3.2.9",
     "redux": "^3.6.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5288,7 +5288,7 @@ react-router@^4.2.0:
     prop-types "^15.5.4"
     warning "^3.0.0"
 
-react-select@^1.0.0-rc.4:
+react-select@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-1.1.0.tgz#626a2de839fdea2ade74dd1b143a9bde34be6c82"
   dependencies:


### PR DESCRIPTION
Because the autocomplete list of Multi Select Inputs replaced the previously loaded options, an already selected value was removed from the selection because it wasn't contained in the new  option list.

New autocomplete lists are now merged with the already existing; I've also updated react-select to the latest version.

Furthermore I've set react-select's `matchPos` property to `start` in order to only suggest options with the same prefix as the user-typed value (in contrast to the default substring-matching). This wasn't an issue before, when there were only values with the right prefix contained in the options list.