### PR TITLE
PreviousQuery: Select all text when editing name

### DIFF
--- a/frontend/lib/js/form-components/EditableText.js
+++ b/frontend/lib/js/form-components/EditableText.js
@@ -10,7 +10,7 @@ class EditableText extends React.Component {
           className={this.props.className}
           loading={this.props.loading}
           text={this.props.text}
-          selectTextOnEdit={this.props.selectTextOnEdit}
+          selectTextOnMount={this.props.selectTextOnMount}
           onSubmit={this.props.onSubmit}
           onCancel={this.props.onToggleEdit}
         />
@@ -33,7 +33,7 @@ EditableText.propTypes = {
   loading: PropTypes.bool.isRequired,
   editing: PropTypes.bool.isRequired,
   text: PropTypes.string.isRequired,
-  selectTextOnEdit: PropTypes.bool.isRequired,
+  selectTextOnMount: PropTypes.bool.isRequired,
   onSubmit: PropTypes.func.isRequired,
   onToggleEdit: PropTypes.func.isRequired,
 };

--- a/frontend/lib/js/form-components/EditableTextForm.js
+++ b/frontend/lib/js/form-components/EditableTextForm.js
@@ -11,7 +11,7 @@ type PropsType = {
   className?: string,
   text: string,
   loading: boolean,
-  selectTextOnEdit: boolean,
+  selectTextOnMount: boolean,
   onSubmit: Function,
   onCancel: Function,
 };
@@ -22,7 +22,7 @@ class EditableTextForm extends React.Component {
   componentDidMount() {
     this.refs.input.focus();
     this.refs.input.value = this.props.text;
-    if (this.props.selectTextOnEdit)
+    if (this.props.selectTextOnMount)
       this.refs.input.select();
   }
 

--- a/frontend/lib/js/previous-queries/list/PreviousQuery.js
+++ b/frontend/lib/js/previous-queries/list/PreviousQuery.js
@@ -125,7 +125,7 @@ const PreviousQuery = (props) => {
               className="previous-query__label"
               loading={!!query.loading}
               text={label}
-              selectTextOnEdit={true}
+              selectTextOnMount={true}
               editing={!!query.editingLabel}
               onSubmit={onRenamePreviousQuery}
               onToggleEdit={onToggleEditPreviousQueryLabel}


### PR DESCRIPTION
Adds some usability, if people do not know the CTRL+A shortcut.