### PR TITLE
Make localization extensible/overridable for apps

### DIFF
--- a/frontend/app/src/js/forms/example-form/ExampleForm.js
+++ b/frontend/app/src/js/forms/example-form/ExampleForm.js
@@ -4,7 +4,7 @@ import './exampleForm.sass'
 
 import React                from 'react';
 import { Field, reduxForm } from 'redux-form';
-import T                    from 'i18n-react';
+import { T }                from '../../../../../lib/js/localization';
 
 import {
   InputWithLabel

--- a/frontend/app/src/js/main.js
+++ b/frontend/app/src/js/main.js
@@ -1,7 +1,13 @@
 // @flow
 
 import conquery                   from '../../../lib/js';
+import { initializeLocalization } from '../../../lib/js/localization';
+import de                         from '../../../lib/localization/de.yml';
+import appDE                      from '../localization/de.yml';
 import exampleForm                from './forms/example-form';
+
+
+initializeLocalization(de, appDE);
 
 const forms = {
   [exampleForm.type]: exampleForm

--- a/frontend/app/src/localization/de.yml
+++ b/frontend/app/src/localization/de.yml
@@ -1,0 +1,3 @@
+externalForms:
+  exampleForm:
+    headline: "Example form"

--- a/frontend/lib/js/common/helpers/commonHelper.js
+++ b/frontend/lib/js/common/helpers/commonHelper.js
@@ -49,3 +49,25 @@ export const toUpperCaseUnderscore = (str: string) => str.replace(
   /[A-Z]/g,
   (upperCaseChar) => '_' + upperCaseChar.toLowerCase()
 ).toUpperCase();
+
+export const isObject = (item: any) =>
+  item && typeof item === 'object' && !Array.isArray(item);
+
+export const mergeDeep = (...elements: Object[]) => {
+  return elements
+    .filter(isObject)
+    .reduce((aggregate, current) => {
+      const nonObjectKeys = Object.keys(current).filter(key => !isObject(current[key]));
+      const objectKeys = Object.keys(current).filter(key => isObject(current[key]));
+      const newKeys = objectKeys.filter(key => !(key in aggregate));
+      const mergeKeys = objectKeys.filter(key => key in aggregate);
+
+      return Object.assign(
+        {},
+        aggregate,
+        ...nonObjectKeys.map(key => ({ [key]: current[key] })),
+        ...newKeys.map(key => ({ [key]: current[key] })),
+        ...mergeKeys.map(key => ({ [key]: mergeDeep(aggregate[key], current[key]) }))
+      );
+    }, {});
+};

--- a/frontend/lib/js/index.js
+++ b/frontend/lib/js/index.js
@@ -14,7 +14,6 @@ import {
 import { Provider }               from 'react-redux';
 import createHistory              from 'history/createBrowserHistory';
 
-import './localization'; // To initialize locales
 import './app/actions'; //  To initialize parameterized actions
 
 import { BASENAME, isProduction } from './environment';

--- a/frontend/lib/js/localization/index.js
+++ b/frontend/lib/js/localization/index.js
@@ -1,17 +1,13 @@
-// This module only needs to be imported to run.
-// This makes it easier to handle, since other
-// imported modules might already depend on a set language
+import _T                 from 'i18n-react';
+import moment             from 'moment';
 
-import T from 'i18n-react';
-import moment from 'moment';
+import { mergeDeep }      from '../common/helpers';
 
-import de from './de.yml';
-// Translation to English possible
-// import en from './locales/en';
+export const T = _T;
 
+export const initializeLocalization = (...texts) => {
+  T.setTexts(mergeDeep(...texts));
 
-// Here could be a detection logic (e.g. check browser language, ... )
-T.setTexts(de);
-
-// Set moment locale
-moment.locale('de');
+  // Set moment locale
+  moment.locale('de');
+};

--- a/frontend/lib/js/pane/TabNavigation.js
+++ b/frontend/lib/js/pane/TabNavigation.js
@@ -2,6 +2,7 @@
 
 import React                from 'react';
 import classnames           from 'classnames';
+import T                    from 'i18n-react';
 import type { TabType }     from './reducer';
 
 type PropsType = {
@@ -28,7 +29,7 @@ const TabNavigation = (props: PropsType) => {
                 props.onClickTab(tab);
             }}
           >
-            {label}
+            {T.translate(label)}
           </h2>
         ))
       }

--- a/frontend/lib/js/pane/reducer.js
+++ b/frontend/lib/js/pane/reducer.js
@@ -1,6 +1,5 @@
 // @flow
 
-import T                   from 'i18n-react';
 import { CLICK_PANE_TAB }  from './actionTypes';
 
 
@@ -24,16 +23,16 @@ const initialState: StateType = {
   left: {
     activeTab: 'categoryTrees',
     tabs: [
-      { label: T.translate('leftPane.categoryTrees'), tab: 'categoryTrees' },
-      { label: T.translate('leftPane.previousQueries'), tab: 'previousQueries' },
+      { label: 'leftPane.categoryTrees', tab: 'categoryTrees' },
+      { label: 'leftPane.previousQueries', tab: 'previousQueries' },
     ]
   },
   right: {
     activeTab: 'queryEditor',
     tabs: [
-      { label: T.translate('rightPane.queryEditor'), tab: 'queryEditor' },
-      { label: T.translate('rightPane.timebasedQueryEditor'), tab: 'timebasedQueryEditor' },
-      { label: T.translate('rightPane.externalForms'), tab: 'externalForms' },
+      { label: 'rightPane.queryEditor', tab: 'queryEditor' },
+      { label: 'rightPane.timebasedQueryEditor', tab: 'timebasedQueryEditor' },
+      { label: 'rightPane.externalForms', tab: 'externalForms' },
     ]
   }
 };

--- a/frontend/lib/localization/de.yml
+++ b/frontend/lib/localization/de.yml
@@ -180,9 +180,6 @@ externalForms:
       random: "ZUFÄLLIG"
     filter: "Filter"
 
-  exampleForm:
-    headline: "Example form"
-
 uploadQueryResultsModal:
   headline: "Lade ein Anfrageergebnis hoch"
   dropzone: "Lege eine CSV-Datei hier ab"


### PR DESCRIPTION
This depends on external forms (PR #6).

We have to provide apps with the ability to override strings defined in conquery as well as a method to define additional strings for their custom components/forms.

Instead of directly depending on i18n-react, apps should use the `T` that is re-exported from the conquery lib. This ensures that the underlying translation dictionary is globally applied.

The dictionaries have to be initialized early in the application startup process by calling `initializeLocalizations`. 

Furthermore, we have to ensure that these dictionaries are not accessed (through `T`) before the mentioned method call happened. Specifically we cannot rely on the dictionaries to be initialized before static component initialization code runs (i.e. as a result of a `require`).