### PR TITLE
Delete .npmrc pointing to private npm repo

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,2 +1,0 @@
-registry=https://asfn7n79ca.execute-api.eu-west-1.amazonaws.com/prod/registry/
-always-auth=true


### PR DESCRIPTION
Switch to public npm repo.
Closes #25.