### PR TITLE
Fix external forms query runner reducer

### DIFF
--- a/frontend/lib/js/query-runner/reducer.js
+++ b/frontend/lib/js/query-runner/reducer.js
@@ -1,7 +1,8 @@
 // @flow
 
-import T                from 'i18n-react';
-import * as actionTypes from './actionTypes';
+import T                         from 'i18n-react';
+import { toUpperCaseUnderscore } from '../common/helpers';
+import * as actionTypes          from './actionTypes';
 
 type APICallType = {
   loading?: boolean,
@@ -26,7 +27,7 @@ export default function createQueryRunnerReducer(type: string): Function {
     queryResult: Object,
   };
 
-  const capitalType = type.toUpperCase();
+  const capitalType = toUpperCaseUnderscore(type);
 
   // Example1: START_STANDARD_QUERY_START
   // Example2: START_TIMEBASED_QUERY_START


### PR DESCRIPTION
Queries for external forms were not executed because we didn't correctly generate the action types that the reducer listens for (e.g. `START_EXTERNALFORM_QUERY_START` instead of `START_EXTERNAL_FORM_QUERY_START`)