### PR TITLE
Fix empty values not being set as node filter properties

### DIFF
--- a/frontend/lib/js/common/helpers/commonHelper.js
+++ b/frontend/lib/js/common/helpers/commonHelper.js
@@ -24,11 +24,7 @@ export const isEmptyObject = (variable: any) => {
 export const stripObject = (obj: Object) => {
   return Object.keys(obj).reduce((acc, k) => ({
     ...acc,
-    ...(
-      (isEmpty(obj[k]) || isEmptyObject(obj[k]))
-        ? {}
-        : { [k]: obj[k] }
-    )
+    [k]: (isEmpty(obj[k]) || isEmptyObject(obj[k])) ? undefined : obj[k]
   }), {});
 }
 

--- a/frontend/lib/js/standard-query-editor/reducer.js
+++ b/frontend/lib/js/standard-query-editor/reducer.js
@@ -275,12 +275,15 @@ const setNodeFilterProperties = (state, action, obj) => {
   // or empty objects
   const properties = stripObject(obj);
 
-  if (properties.options) {
+  if ('options' in properties) {
     // Options are only updated in the context of autocompletion.
     // In this case we don't want to replace the existing options but update
     // them with the new list, removing duplicates
     const previousOptions = filter.options || [];
-    properties.options = properties.options
+    // The properties object contains an 'options' key, but its value might
+    // be undefined (because of stripObject above)
+    const newOptions = (properties.options || []);
+    properties.options = newOptions
       .concat(previousOptions)
       .reduce(
         (options, currentOption) =>


### PR DESCRIPTION
This fix is related to the changes made in #7 and #17.

Now that stripObject removed all keys with value == undefined from the properties dictionary, these values did no longer update the filter properties. This prevented an empty selection to be set as the filter value. As a result, I reverted stripObject back to its original behavior.

I'll set up a separate PR with a test for this fix (currently our test setup is broken).