### PR TITLE
Add test for #38

### DIFF
--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -1,8 +1,18 @@
 {
-  "presets": [
-    ["es2015", {"modules": false}],
-    "stage-0",
-    "react"
-  ],
-  "plugins": ["react-hot-loader/babel"]
+  "env": {
+    "development": {
+      "presets": [
+        ["es2015", {"modules": false}],
+        "stage-0",
+        "react"
+      ],
+      "plugins": ["react-hot-loader/babel"]
+    },
+    "test": {
+      "presets": ["es2015", "stage-0", "react" ]
+    },
+    "production": {
+      "presets": ["es2015", "stage-0", "react" ]
+    }
+  }
 }

--- a/frontend/lib/js/index.js
+++ b/frontend/lib/js/index.js
@@ -11,7 +11,7 @@ import createHistory                   from 'history/createBrowserHistory';
 
 import './app/actions'; //  To initialize parameterized actions
 import { makeStore }                   from './store'
-import AppRoot                         from "./AppRoot";
+import AppRoot                         from './AppRoot';
 
 import {
   initializeEnvironment,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,8 +17,8 @@
     "build-app": "cd app && rimraf dist && NODE_ENV=production webpack --config ./webpack.production.config.js --progress --profile --colors",
     "heroku-postbuild": "yarn run build-app",
     "flow": "flow; test $? -eq 0 -o $? -eq 2",
-    "test": "rimraf coverage && nyc _mocha test",
-    "test-watch": "mocha test --watch",
+    "test": "rimraf coverage && NODE_ENV=test nyc _mocha test",
+    "test-watch": "NODE_ENV=test mocha test --watch",
     "debug-test": "node-debug --debug-brk --hidden node_modules _mocha test",
     "prepush": "npm run lint"
   },

--- a/frontend/test/standard-query-editor/reducer.spec.js
+++ b/frontend/test/standard-query-editor/reducer.spec.js
@@ -25,6 +25,20 @@ const createQueryStateWithOneBigMultiSelect = () => ([{
 }]);
 
 describe('standard query editor', () => {
+  describe('clearing a filter\'s value', () => {
+    it('sets the filter value to undefined', () => {
+      const state = createQueryStateWithOneBigMultiSelect();
+      state[0].elements[0].tables[0].filters[0].options = [{value: 1, label: '1'}];
+      state[0].elements[0].tables[0].filters[0].value = [1];
+
+      const { setStandardFilterValue } = createQueryNodeModalActions('standard');
+      const action = setStandardFilterValue(0, 0, 0, 0, []);
+      const updatedState = reducer(state, action);
+
+      expect(updatedState[0].elements[0].tables[0].filters[0].value).to.equal(undefined);
+    });
+  });
+
   describe('receiving a list of autocomplete suggestions', () => {
     it('updates the filter\'s options list', () => {
       const state = createQueryStateWithOneBigMultiSelect();


### PR DESCRIPTION
In addition to adding the test, I fixed the .babelrc so that test were runnable at all (the modules: false option necessary for hot reloading conflicts with what we need for test execution).

The dupliation in the .babelrc is a little verbose, but necessary until babel 7 is released.

Maybe we should also consider running the tests during our CI builds.