### PR TITLE
Fix iteration over concept trees when setting default filter values

### DIFF
--- a/frontend/lib/js/category-trees/actions.js
+++ b/frontend/lib/js/category-trees/actions.js
@@ -46,12 +46,11 @@ export const loadTrees = (datasetId: DatasetIdType) => {
           dispatch(loadTreesSuccess(r));
 
           // Assign default select filter values
-          Object.values(r.concepts).forEach(concept => concept.tables.forEach(table =>
-            table.filters.forEach(filter => {
-              if (filter.defaultValue)
-                filter.value = filter.defaultValue;
-            })
-          ));
+          for (const concept of Object.values(r.concepts))
+            for (const table of concept.tables || [])
+              for (let filter of table.filters || [])
+                if (filter.defaultValue)
+                  filter.value = filter.defaultValue;
 
           // In the future: Data could be cached, version could be checked and
           // further data only loaded when necessary

--- a/frontend/lib/js/category-trees/actions.js
+++ b/frontend/lib/js/category-trees/actions.js
@@ -48,7 +48,7 @@ export const loadTrees = (datasetId: DatasetIdType) => {
           // Assign default select filter values
           for (const concept of Object.values(r.concepts))
             for (const table of concept.tables || [])
-              for (let filter of table.filters || [])
+              for (const filter of table.filters || [])
                 if (filter.defaultValue)
                   filter.value = filter.defaultValue;
 


### PR DESCRIPTION
This fixes an error when iterating over concept tree tables and filters: Sometimes the tables of a concept are not set (undefined) which caused the forEach call to fail.

As a result, the startup process didn't proceed to load the remaining concept trees. 

CC @nstrelow 
