### PR TITLE
Improved datepicker fix for IE11

### DIFF
--- a/frontend/lib/js/query-group-modal/QueryGroupModal.js
+++ b/frontend/lib/js/query-group-modal/QueryGroupModal.js
@@ -6,7 +6,6 @@ import classnames           from 'classnames';
 import T                    from 'i18n-react';
 import { connect }          from 'react-redux';
 import DatePicker           from 'react-datepicker';
-import ie                   from 'ie-version';
 import moment               from 'moment';
 
 import { dateTypes }        from '../common/constants';
@@ -81,9 +80,7 @@ const QueryGroupModal = (props) => {
             </span>
           }
         </p>
-        <div className={
-            `query-group-modal__dates ${ie.version && ie.version === 11 ? ' ie11' : ''}`
-          }>
+        <div className="query-group-modal__dates">
           <div className="query-group-modal__input-group">
             <label className="input-label" htmlFor="datepicker-min">
               {T.translate('queryGroupModal.dateMinLabel')}

--- a/frontend/lib/styles/components/queryGroupModal.sass
+++ b/frontend/lib/styles/components/queryGroupModal.sass
@@ -8,12 +8,12 @@
     padding: 0 0 0 5px
 
   &__dates
-    display: table
-    table-layout: fixed
+    display: flex
+    align-items: center
+    justify-content: center
     margin: 0 auto
 
   &__input-group
-    display: table-cell
     vertical-align: top
     padding: 10px
 

--- a/frontend/lib/styles/lib/react-datepicker-overrides.sass
+++ b/frontend/lib/styles/lib/react-datepicker-overrides.sass
@@ -15,18 +15,11 @@
 .react-datepicker__day--selected:hover, .react-datepicker__day--in-selecting-range:hover, .react-datepicker__day--in-range:hover
   background-color: rgba($col-blue-gray-dark, 0.9)
 
-// IE 11 fix
-.query-group-modal__dates.ie11 .react-datepicker__month-read-view--down-arrow,
-.query-group-modal__dates.ie11 .react-datepicker__month-year-read-view--down-arrow,
-.query-group-modal__dates.ie11 .react-datepicker__year-read-view--down-arrow 
+// Temporary IE 11 fix
+// https://github.com/Hacker0x01/react-datepicker/issues/1226
+.react-datepicker__month-read-view--down-arrow,
+.react-datepicker__month-year-read-view--down-arrow,
+.react-datepicker__year-read-view--down-arrow
   margin-left: -20px
   left: 20px
   top: 4px
-
-.query-group-modal__dates.ie11 .query-group-modal__input-group:nth-child(1) .react-datepicker-popper
-  left: 35px !important
-  top: 95px !important
-
-.query-group-modal__dates.ie11 .query-group-modal__input-group:nth-child(2) .react-datepicker-popper
-  left: 250px !important
-  top: 95px !important

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -96,7 +96,6 @@
     "gulp-babel": "^7.0.1",
     "html-webpack-plugin": "^2.30.1",
     "husky": "^0.14.3",
-    "ie-version": "^0.1.0",
     "ignore-styles": "^5.0.1",
     "jsdom": "^11.6.2",
     "jsdom-global": "^3.0.2",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3910,10 +3910,6 @@ icss-utils@^2.1.0:
   dependencies:
     postcss "^6.0.1"
 
-ie-version@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/ie-version/-/ie-version-0.1.0.tgz#9a05a6865ce4f8440a36bae52b40fcfc2798d6da"
-
 ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"


### PR DESCRIPTION
This is an update on the datepicker fix contained in #82.

The behavior in IE was caused by two problems:

1. Control placement inside the datepicker is off, see https://github.com/Hacker0x01/react-datepicker/issues/1226
    The CSS fix for this doesn't need to be constrained to datepickers inside the QueryGroupModal and does not need a browser detection by `ie-version`
2. Placement of the datepicker popper, related to https://github.com/FezVrasta/popper.js/issues/566
    The solution for this was to not use a `display: table` for the wrapping div in the QueryGroupModal -- I think we should generally avoid `display: table` where possible