### PR TITLE
Refactor query editor node type flow

### DIFF
--- a/frontend/lib/js/api/api.js
+++ b/frontend/lib/js/api/api.js
@@ -8,7 +8,8 @@ import { apiUrl }              from '../environment';
 import { type DatasetIdType }  from '../dataset/reducer';
 import type {
   RootType,
-  TreeNodeIdType
+  TreeNodeIdType,
+  ConceptListResolutionResultType
 }                              from '../common/types/backend';
 
 import {
@@ -203,19 +204,6 @@ export function postPrefixForSuggestions(
       body: { text },
     }
   );
-};
-
-export type ConceptListResolutionResultType = {
-  resolvedConcepts?: String[],
-  unknownCodes?: String[],
-  resolvedFilter?: {
-    filterId: String,
-    tableId: String,
-    value: {
-      label: String,
-      value: String
-    }[]
-  }
 };
 
 export function postConceptsListToResolve(

--- a/frontend/lib/js/api/api.js
+++ b/frontend/lib/js/api/api.js
@@ -1,11 +1,16 @@
 // @flow
 
 import fetch                   from 'isomorphic-fetch';
-import { type DatasetIdType }  from '../dataset/reducer';
-import { type TreeNodeIdType } from '../category-trees/reducer';
-import { getStoredAuthToken }  from '../authorization';
 
+import { getStoredAuthToken }  from '../authorization';
 import { apiUrl }              from '../environment';
+
+import { type DatasetIdType }  from '../dataset/reducer';
+import type {
+  RootType,
+  TreeNodeIdType
+}                              from '../common/types/backend';
+
 import {
   transformQueryToApi,
 } from './apiHelper';
@@ -94,11 +99,17 @@ export function postResults(datasetId: DatasetIdType, file: any) {
   });
 };
 
-export function getConcepts(datasetId: DatasetIdType) {
+export const getConcepts = (datasetId: DatasetIdType) : Promise<RootType> => {
   return fetchJson(apiUrl() + `/datasets/${datasetId}/concepts`);
 }
 
-export function getConcept(datasetId: DatasetIdType, conceptId: TreeNodeIdType) {
+export type ConceptElementType = {
+  children: Array<TreeNodeIdType>,
+};
+
+export const getConcept =
+  (datasetId: DatasetIdType, conceptId: TreeNodeIdType)
+    : Promise<Map<TreeNodeIdType, ConceptElementType>> => {
   return fetchJson(apiUrl() + `/datasets/${datasetId}/concepts/${conceptId}`);
 }
 

--- a/frontend/lib/js/category-trees/CategoryTree.js
+++ b/frontend/lib/js/category-trees/CategoryTree.js
@@ -4,15 +4,16 @@ import React                from 'react';
 import T                    from 'i18n-react';
 
 import { ErrorMessage }     from '../error-message';
-import { type TreeNodeIdType } from '../common/types/backend';
+import type {
+  NodeType,
+  TreeNodeIdType
+}                           from '../common/types/backend';
 
 import CategoryTreeNode     from './CategoryTreeNode';
 
-import type { TreeNodeType }     from './reducer';
-
 type PropsType = {
   id: TreeNodeIdType,
-  tree: TreeNodeType,
+  tree: NodeType,
   treeId: TreeNodeIdType,
   label: string,
   depth: number,

--- a/frontend/lib/js/category-trees/CategoryTree.js
+++ b/frontend/lib/js/category-trees/CategoryTree.js
@@ -4,14 +4,16 @@ import React                from 'react';
 import T                    from 'i18n-react';
 
 import { ErrorMessage }     from '../error-message';
+import { type TreeNodeIdType } from '../common/types/backend';
 
 import CategoryTreeNode     from './CategoryTreeNode';
 
 import type { TreeNodeType }     from './reducer';
 
 type PropsType = {
-  id: string | number,
-  tree: ?TreeNodeType,
+  id: TreeNodeIdType,
+  tree: TreeNodeType,
+  treeId: TreeNodeIdType,
   label: string,
   depth: number,
   loading: boolean,
@@ -42,7 +44,7 @@ const CategoryTree = (props: PropsType) => {
       <div className="category-tree">
         <CategoryTreeNode
           id={props.id}
-          data={props.tree}
+          data={{...props.tree, tree: props.treeId }}
           depth={props.depth}
         />
       </div>

--- a/frontend/lib/js/category-trees/CategoryTreeFolder.js
+++ b/frontend/lib/js/category-trees/CategoryTreeFolder.js
@@ -46,10 +46,14 @@ const CategoryTreeFolder = (props: PropsType) => {
           id: props.treeId,
           label: props.tree.label,
           description: props.tree.description,
-          tables: props.tree.tables,
           matchingEntries: matchingEntries,
+          dateRange: props.tree.dateRange,
           additionalInfos: props.tree.additionalInfos,
           hasChildren: !!props.tree.children && props.tree.children.length > 0,
+        }}
+        createQueryElement={() => {
+          // We don't have to implement this since CategoryTreeFolders should never be
+          // dragged into the editor, hence they're 'active: false' and thus not draggable
         }}
         open={props.open || false}
         depth={props.depth}
@@ -69,6 +73,7 @@ const CategoryTreeFolder = (props: PropsType) => {
                 id={treeId}
                 label={tree.label}
                 tree={rootConcept}
+                treeId={treeId}
                 loading={tree.loading}
                 error={tree.error}
                 depth={props.depth + 1}

--- a/frontend/lib/js/category-trees/CategoryTreeFolder.js
+++ b/frontend/lib/js/category-trees/CategoryTreeFolder.js
@@ -2,21 +2,21 @@
 
 import React                         from 'react';
 
+import type {
+  NodeType,
+  TreeNodeIdType
+}                                    from '../common/types/backend';
+
 import { getConceptById }            from './globalTreeStoreHelper';
 
 import Openable                      from './Openable';
 import CategoryTree                  from './CategoryTree';
 import CategoryTreeNodeTextContainer from './CategoryTreeNodeTextContainer';
 
-import {
-  type TreeNodeType,
-  type TreeNodeIdType,
-} from './reducer';
-
 type PropsType = {
   depth: number,
   trees: Object,
-  tree: TreeNodeType,
+  tree: NodeType,
   treeId: TreeNodeIdType,
   active: boolean,
   open?: boolean,

--- a/frontend/lib/js/category-trees/CategoryTreeList.js
+++ b/frontend/lib/js/category-trees/CategoryTreeList.js
@@ -7,10 +7,7 @@ import type { StateType }   from '../app/reducers';
 
 import { getConceptById }   from './globalTreeStoreHelper';
 
-import {
-  type TreeNodeType,
-  type TreesType
-}   from './reducer';
+import { type TreesType }   from './reducer';
 
 import CategoryTree         from './CategoryTree';
 import CategoryTreeFolder   from './CategoryTreeFolder';
@@ -20,7 +17,7 @@ type PropsType = {
   activeTab: string,
 };
 
-class CategoryTreeList extends React.Component {
+class CategoryTreeList extends React.Component<PropsType> {
   props: PropsType;
 
   render() {

--- a/frontend/lib/js/category-trees/CategoryTreeList.js
+++ b/frontend/lib/js/category-trees/CategoryTreeList.js
@@ -43,7 +43,7 @@ class CategoryTreeList extends React.Component {
             .filter(treeId => !this.props.trees[treeId].parent)
             .map((treeId, i) => {
               const tree = this.props.trees[treeId];
-              const rootConcept: ?TreeNodeType = getConceptById(treeId);
+              const rootConcept = getConceptById(treeId);
 
               return tree.detailsAvailable
                 ? <CategoryTree
@@ -51,6 +51,7 @@ class CategoryTreeList extends React.Component {
                     id={treeId}
                     label={tree.label}
                     tree={rootConcept}
+                    treeId={treeId}
                     loading={!!tree.loading}
                     error={tree.error}
                     depth={0}

--- a/frontend/lib/js/category-trees/CategoryTreeNode.js
+++ b/frontend/lib/js/category-trees/CategoryTreeNode.js
@@ -2,22 +2,78 @@
 
 import React                         from 'react';
 
+<<<<<<< HEAD
 import { getConceptById }            from './globalTreeStoreHelper';
+=======
+import {
+  type TreeNodeIdType,
+  type InfoType,
+  type DateRangeType,
+  type NodeType
+}                                    from '../common/types/backend';
+import { type DraggedNodeType, type ConceptType, type TableType } from '../standard-query-editor/types';
+
+import { getConceptById } from './globalTreeStoreHelper';
+>>>>>>> d25d186... Refactor types around ConceptTrees, DnD, Standard Editor Nodes
 
 import Openable                      from './Openable';
 import CategoryTreeNodeTextContainer from './CategoryTreeNodeTextContainer';
 
+// Concept data that is necessary to display tree nodes. Includes additional infos
+// for the tooltip as well as the id of the corresponding tree
+type TreeNodeData = {
+  label: string,
+  description: string,
+  active: boolean,
+  matchingEntries: number,
+  dateRange: DateRangeType,
+  additionalInfos: Array<InfoType>,
+  children: Array<TreeNodeIdType>,
+
+  tree: TreeNodeIdType,
+}
+
 type PropsType = {
-  id: string | number,
-  data: Object,
+  id: TreeNodeIdType,
+  data: TreeNodeData,
   depth: number,
   open: boolean,
-  onToggleOpen: Function,
+  onToggleOpen: () => void,
 };
 
-class CategoryTreeNode extends React.Component {
-  props: PropsType;
+const selectTreeNodeData = (concept: NodeType, tree: TreeNodeIdType) => ({
+  label: concept.label,
+  description: concept.description,
+  active: concept.active,
+  matchingEntries: concept.matchingEntries,
+  dateRange: concept.dateRange,
+  additionalInfos: concept.additionalInfos,
+  children: concept.children,
 
+  tree,
+});
+
+// Converts a tree item into a concept that will be used as part of a Query Node in the editor
+const conceptFromTreeNodeData = (conceptId: TreeNodeIdType, treeItem: TreeNodeData): ConceptType => ({
+  id: conceptId,
+  label: treeItem.label,
+  description: treeItem.description,
+  matchingEntries: treeItem.matchingEntries,
+  dateRange: treeItem.dateRange,
+  additionalInfos: treeItem.additionalInfos,
+  hasChildren: !!treeItem.children,
+});
+
+// Creates node from a given concept that can be dragged on the editor
+const createNode = (concept: ConceptType, label: string, tables: Array<TableType>, tree: TreeNodeIdType) : DraggedNodeType => ({
+  ids: [concept.id],
+  label: concept.label,
+  tables: tables,
+  tree,
+  concepts: [concept]
+});
+
+class CategoryTreeNode extends React.Component<PropsType> {
   _onToggleOpen() {
     if (!this.props.data.children) return;
 
@@ -34,11 +90,15 @@ class CategoryTreeNode extends React.Component {
             id,
             label: data.label,
             description: data.description,
-            tables: data.tables,
             matchingEntries: data.matchingEntries,
             dateRange: data.dateRange,
             additionalInfos: data.additionalInfos,
             hasChildren: !!data.children,
+          }}
+          createQueryElement={() => {
+            const concept = conceptFromTreeNodeData(id, data);
+            const tables = getConceptById(data.tree).tables;
+            return createNode(concept, concept.label, tables, data.tree);
           }}
           open={open}
           depth={depth}
@@ -52,19 +112,14 @@ class CategoryTreeNode extends React.Component {
               data.children.map((childId, i) => {
                 const child = getConceptById(childId);
 
-                const childWithTables = {
-                  ...child,
-                  tables: data.tables
-                };
-
-                return (
+                return child ? (
                   <OpenableCategoryTreeNode
                     key={i}
                     id={childId}
-                    data={childWithTables}
+                    data={selectTreeNodeData(child, data.tree)}
                     depth={this.props.depth + 1}
                   />
-                );
+                ) : null;
               })
             }
           </div>

--- a/frontend/lib/js/category-trees/CategoryTreeNode.js
+++ b/frontend/lib/js/category-trees/CategoryTreeNode.js
@@ -8,11 +8,8 @@ import {
   type DateRangeType,
   type NodeType
 }                                    from '../common/types/backend';
-import {
-  type DraggedNodeType,
-  type ConceptType,
-  type TableType
-}                                    from '../standard-query-editor/types';
+
+import { type DraggedNodeType }      from '../standard-query-editor/types';
 
 import { getConceptById }            from './globalTreeStoreHelper';
 
@@ -53,32 +50,6 @@ const selectTreeNodeData = (concept: NodeType, tree: TreeNodeIdType) => ({
   tree,
 });
 
-// Converts a tree item into a concept that will be used as part of a Query Node in the editor
-const conceptFromTreeNodeData =
-  (conceptId: TreeNodeIdType, treeItem: TreeNodeData) : ConceptType => ({
-    id: conceptId,
-    label: treeItem.label,
-    description: treeItem.description,
-    matchingEntries: treeItem.matchingEntries,
-    dateRange: treeItem.dateRange,
-    additionalInfos: treeItem.additionalInfos,
-    hasChildren: !!treeItem.children,
-  });
-
-// Creates node from a given concept that can be dragged on the editor
-const createNode = (
-  concept: ConceptType,
-  label: string,
-  tables: Array<TableType>,
-  tree: TreeNodeIdType
-) : DraggedNodeType => ({
-  ids: [concept.id],
-  label: concept.label,
-  tables: tables,
-  tree,
-  concepts: [concept]
-});
-
 class CategoryTreeNode extends React.Component<PropsType> {
   _onToggleOpen() {
     if (!this.props.data.children) return;
@@ -99,12 +70,17 @@ class CategoryTreeNode extends React.Component<PropsType> {
             matchingEntries: data.matchingEntries,
             dateRange: data.dateRange,
             additionalInfos: data.additionalInfos,
-            hasChildren: !!data.children,
+            hasChildren: !!data.children && data.children.length > 0,
+
           }}
-          createQueryElement={() => {
-            const concept = conceptFromTreeNodeData(id, data);
+          createQueryElement={() : DraggedNodeType => {
             const tables = getConceptById(data.tree).tables;
-            return createNode(concept, concept.label, tables, data.tree);
+            return {
+              ids: [id],
+              label: data.label,
+              tables: tables,
+              tree: data.tree
+            };
           }}
           open={open}
           depth={depth}

--- a/frontend/lib/js/category-trees/CategoryTreeNode.js
+++ b/frontend/lib/js/category-trees/CategoryTreeNode.js
@@ -2,19 +2,19 @@
 
 import React                         from 'react';
 
-<<<<<<< HEAD
-import { getConceptById }            from './globalTreeStoreHelper';
-=======
 import {
   type TreeNodeIdType,
   type InfoType,
   type DateRangeType,
   type NodeType
 }                                    from '../common/types/backend';
-import { type DraggedNodeType, type ConceptType, type TableType } from '../standard-query-editor/types';
+import {
+  type DraggedNodeType,
+  type ConceptType,
+  type TableType
+}                                    from '../standard-query-editor/types';
 
-import { getConceptById } from './globalTreeStoreHelper';
->>>>>>> d25d186... Refactor types around ConceptTrees, DnD, Standard Editor Nodes
+import { getConceptById }            from './globalTreeStoreHelper';
 
 import Openable                      from './Openable';
 import CategoryTreeNodeTextContainer from './CategoryTreeNodeTextContainer';
@@ -54,18 +54,24 @@ const selectTreeNodeData = (concept: NodeType, tree: TreeNodeIdType) => ({
 });
 
 // Converts a tree item into a concept that will be used as part of a Query Node in the editor
-const conceptFromTreeNodeData = (conceptId: TreeNodeIdType, treeItem: TreeNodeData): ConceptType => ({
-  id: conceptId,
-  label: treeItem.label,
-  description: treeItem.description,
-  matchingEntries: treeItem.matchingEntries,
-  dateRange: treeItem.dateRange,
-  additionalInfos: treeItem.additionalInfos,
-  hasChildren: !!treeItem.children,
-});
+const conceptFromTreeNodeData =
+  (conceptId: TreeNodeIdType, treeItem: TreeNodeData) : ConceptType => ({
+    id: conceptId,
+    label: treeItem.label,
+    description: treeItem.description,
+    matchingEntries: treeItem.matchingEntries,
+    dateRange: treeItem.dateRange,
+    additionalInfos: treeItem.additionalInfos,
+    hasChildren: !!treeItem.children,
+  });
 
 // Creates node from a given concept that can be dragged on the editor
-const createNode = (concept: ConceptType, label: string, tables: Array<TableType>, tree: TreeNodeIdType) : DraggedNodeType => ({
+const createNode = (
+  concept: ConceptType,
+  label: string,
+  tables: Array<TableType>,
+  tree: TreeNodeIdType
+) : DraggedNodeType => ({
   ids: [concept.id],
   label: concept.label,
   tables: tables,

--- a/frontend/lib/js/category-trees/CategoryTreeNodeTextContainer.js
+++ b/frontend/lib/js/category-trees/CategoryTreeNodeTextContainer.js
@@ -8,9 +8,10 @@ import { AdditionalInfoHoverable } from '../tooltip';
 import { isEmpty }                 from '../common/helpers';
 import { dndTypes }                from '../common/constants';
 
-import { type DraggedNodeType }    from '../model/node';
-import { type TreeNodeIdType }     from '../common/types/backend';
-import { type AdditionalInfoHoverableNodeType } from '../tooltip/AdditionalInfoHoverable';
+import {
+  type AdditionalInfoHoverableNodeType
+}                                  from '../tooltip/AdditionalInfoHoverable';
+import { type DraggedNodeType }    from '../standard-query-editor/types';
 
 type PropsType = {
   node: AdditionalInfoHoverableNodeType & {

--- a/frontend/lib/js/category-trees/CategoryTreeNodeTextContainer.js
+++ b/frontend/lib/js/category-trees/CategoryTreeNodeTextContainer.js
@@ -8,20 +8,22 @@ import { AdditionalInfoHoverable } from '../tooltip';
 import { isEmpty }                 from '../common/helpers';
 import { dndTypes }                from '../common/constants';
 
+import { type DraggedNodeType }    from '../model/node';
+import { type TreeNodeIdType }     from '../common/types/backend';
+import { type AdditionalInfoHoverableNodeType } from '../tooltip/AdditionalInfoHoverable';
+
 type PropsType = {
-  node: {
-    id: number | string,
+  node: AdditionalInfoHoverableNodeType & {
     label: string,
     hasChildren: boolean,
     description?: string,
-    tables?: [],
     matchingEntries?: number,
-    additionalInfos?: [],
   },
   open: boolean,
   depth: number,
   active?: boolean,
   onTextClick?: Function,
+  createQueryElement: () => DraggedNodeType,
   connectDragSource: Function,
 };
 
@@ -70,15 +72,12 @@ const CategoryTreeNodeTextContainer = (props: PropsType) => {
 };
 
 
-const HoverableCategoryTreeNodeTextContainer = AdditionalInfoHoverable(
-  CategoryTreeNodeTextContainer
-);
 
 /**
  * Implements the drag source contract.
  */
 const nodeSource = {
-  beginDrag(props) {
+  beginDrag(props: PropsType): DraggedNodeType {
     // Return the data describing the dragged item
     // by creating a concept list
     return {
@@ -99,8 +98,10 @@ function collect(connect, monitor) {
   };
 }
 
-export default DragSource(
+const DraggableCategoryTreeNodeTextContainer = DragSource(
   dndTypes.CATEGORY_TREE_NODE,
   nodeSource,
   collect
-)(HoverableCategoryTreeNodeTextContainer);
+)(CategoryTreeNodeTextContainer);
+
+export default AdditionalInfoHoverable(DraggableCategoryTreeNodeTextContainer);

--- a/frontend/lib/js/category-trees/CategoryTreeNodeTextContainer.js
+++ b/frontend/lib/js/category-trees/CategoryTreeNodeTextContainer.js
@@ -72,32 +72,23 @@ const CategoryTreeNodeTextContainer = (props: PropsType) => {
     : props.connectDragSource(render);
 };
 
-
-
 /**
  * Implements the drag source contract.
  */
 const nodeSource = {
   beginDrag(props: PropsType): DraggedNodeType {
     // Return the data describing the dragged item
-    // by creating a concept list
-    return {
-      ids: [props.node.id],
-      label: props.node.label,
-      tables: props.node.tables
-    };
+    return props.createQueryElement();
   }
 };
 
 /**
  * Specifies the props to inject into your component.
  */
-function collect(connect, monitor) {
-  return {
-    connectDragSource: connect.dragSource(),
-    isDragging: monitor.isDragging()
-  };
-}
+const collect = (connect, monitor) => ({
+  connectDragSource: connect.dragSource(),
+  isDragging: monitor.isDragging()
+});
 
 const DraggableCategoryTreeNodeTextContainer = DragSource(
   dndTypes.CATEGORY_TREE_NODE,

--- a/frontend/lib/js/category-trees/actions.js
+++ b/frontend/lib/js/category-trees/actions.js
@@ -11,6 +11,10 @@ import {
 } from '../common/actions';
 
 import {
+  type TreeNodeIdType
+} from '../common/types/backend';
+
+import {
   resetAllTrees
 } from './globalTreeStoreHelper';
 
@@ -23,8 +27,6 @@ import {
   LOAD_TREE_ERROR,
   CLEAR_TREES
 } from './actionTypes';
-
-import { type TreeNodeIdType }    from './reducer';
 
 export const clearTrees = () => ({ type: CLEAR_TREES });
 

--- a/frontend/lib/js/category-trees/globalTreeStoreHelper.js
+++ b/frontend/lib/js/category-trees/globalTreeStoreHelper.js
@@ -2,6 +2,9 @@
 
 import { includes } from '../common/helpers';
 import {
+  type NodeType
+}                   from '../common/types/backend';
+import {
   type TreeNodeType,
   type TreeNodeIdType,
   type TreesType,
@@ -42,7 +45,14 @@ export function setTree(
 //
 // GETTER
 //
-export function getConceptById(conceptId?: TreeNodeIdType): ?TreeNodeType {
+// export function getTreeById(treeId?: TreeNodeIdType): NodeType {
+//   return window.categoryTrees[treeId];
+// }
+
+//
+// GETTER
+//
+export function getConceptById(conceptId?: TreeNodeIdType): ?NodeType {
   const keys: TreeNodeIdType[] = Object.keys(window.categoryTrees);
 
   for (let i = 0; i < keys.length; i++) {

--- a/frontend/lib/js/category-trees/globalTreeStoreHelper.js
+++ b/frontend/lib/js/category-trees/globalTreeStoreHelper.js
@@ -46,13 +46,6 @@ export function setTree(
 //
 // GETTER
 //
-// export function getTreeById(treeId?: TreeNodeIdType): NodeType {
-//   return window.categoryTrees[treeId];
-// }
-
-//
-// GETTER
-//
 export function getConceptById(conceptId?: TreeNodeIdType): ?NodeType {
   const keys: TreeNodeIdType[] = Object.keys(window.categoryTrees);
 

--- a/frontend/lib/js/category-trees/reducer.js
+++ b/frontend/lib/js/category-trees/reducer.js
@@ -1,12 +1,6 @@
 // @flow
 
-import {
-  type TableType,
-} from '../standard-query-editor/types'
-
-import {
-  type AdditionalInfosType,
-} from '../tooltip';
+import { type NodeType } from '../common/types/backend';
 
 import {
   LOAD_TREES_START,
@@ -17,27 +11,12 @@ import {
   LOAD_TREE_ERROR,
   CLEAR_TREES,
 } from './actionTypes';
+
 import {
   setTree
 } from './globalTreeStoreHelper';
 
-export type TreeNodeIdType = string;
-
-export type TreeNodeType = {
-  id: TreeNodeIdType,
-  label: string,
-  description?: string,
-  loading?: boolean,
-  error?: string,
-  parent?: TreeNodeIdType,
-  active?: boolean,
-  children?: [TreeNodeIdType],
-  tables?: TableType[],
-  additionalInfos?: AdditionalInfosType,
-  matchingEntries?: number,
-};
-
-export type TreesType = { [treeId: string]: TreeNodeType }
+export type TreesType = { [treeId: string]: NodeType }
 
 export type StateType = {
   loading: boolean,

--- a/frontend/lib/js/category-trees/reducer.js
+++ b/frontend/lib/js/category-trees/reducer.js
@@ -10,11 +10,9 @@ import {
   LOAD_TREE_SUCCESS,
   LOAD_TREE_ERROR,
   CLEAR_TREES,
-} from './actionTypes';
+}                       from './actionTypes';
 
-import {
-  setTree
-} from './globalTreeStoreHelper';
+import { setTree }      from './globalTreeStoreHelper';
 
 export type TreesType = { [treeId: string]: NodeType }
 

--- a/frontend/lib/js/common/types.js
+++ b/frontend/lib/js/common/types.js
@@ -1,6 +1,0 @@
-export type SelectOptionType = {
-  label: string,
-  value: number | string,
-};
-
-export type SelectOptionsType = SelectOptionType[];

--- a/frontend/lib/js/common/types/backend.js
+++ b/frontend/lib/js/common/types/backend.js
@@ -10,21 +10,19 @@ export type SelectOptionType = {
 
 export type SelectOptionsType = SelectOptionType[];
 
-export type DateRangeType = {
-}
+export type DateRangeType = ?{ min?: string, max?: string }
 
 export type InfoType = {
   key: string,
   value: string,
 }
 
-type RangeFilterValueType = { min?: number, max?: number, exact?: number }
+export type RangeFilterValueType = { min?: number, max?: number, exact?: number }
 export type RangeFilterType = {
   id: number,
   label: string,
   description?: string,
   type: 'INTEGER_RANGE' | 'REAL_RANGE',
-//   value: ?RangeFilterValueType,
   unit?: string,
   mode: 'range' | 'exact',
   precision?: number,
@@ -33,25 +31,23 @@ export type RangeFilterType = {
   defaultValue: ?RangeFilterValueType
 }
 
-type MultiSelectFilterValueType = (string | number)[];
+export type MultiSelectFilterValueType = (string | number)[];
 export type MultiSelectFilterType = {
   id: number,
   label: string,
   description?: string,
   type: 'MULTI_SELECT',
-//   value: ?MultiSelectFilterValueType,
   unit?: string,
   options: SelectOptionsType,
   defaultValue: ?MultiSelectFilterValueType
 }
 
-type SelectFilterValueType = string | number;
+export type SelectFilterValueType = string | number;
 export type SelectFilterType = {
   id: number,
   label: string,
   description?: string,
   type: 'SELECT',
-//   value: ?SelectFilterValueType,
   unit?: string,
   options: SelectOptionsType,
   defaultValue: ?SelectFilterValueType

--- a/frontend/lib/js/common/types/backend.js
+++ b/frontend/lib/js/common/types/backend.js
@@ -1,0 +1,89 @@
+// @flow
+
+// This file specifies data types that are provided by the backend api
+// and subsequently stored in window.categoryTrees (see globalTreeStoreHelper)
+
+export type SelectOptionType = {
+  label: string,
+  value: number | string,
+};
+
+export type SelectOptionsType = SelectOptionType[];
+
+export type DateRangeType = {
+}
+
+export type InfoType = {
+  key: string,
+  value: string,
+}
+
+type RangeFilterValueType = { min?: number, max?: number, exact?: number }
+export type RangeFilterType = {
+  id: number,
+  label: string,
+  description?: string,
+  type: 'INTEGER_RANGE' | 'REAL_RANGE',
+//   value: ?RangeFilterValueType,
+  unit?: string,
+  mode: 'range' | 'exact',
+  precision?: number,
+  min?: number,
+  max?: number,
+  defaultValue: ?RangeFilterValueType
+}
+
+type MultiSelectFilterValueType = (string | number)[];
+export type MultiSelectFilterType = {
+  id: number,
+  label: string,
+  description?: string,
+  type: 'MULTI_SELECT',
+//   value: ?MultiSelectFilterValueType,
+  unit?: string,
+  options: SelectOptionsType,
+  defaultValue: ?MultiSelectFilterValueType
+}
+
+type SelectFilterValueType = string | number;
+export type SelectFilterType = {
+  id: number,
+  label: string,
+  description?: string,
+  type: 'SELECT',
+//   value: ?SelectFilterValueType,
+  unit?: string,
+  options: SelectOptionsType,
+  defaultValue: ?SelectFilterValueType
+}
+
+export type FilterType = SelectFilterType | MultiSelectFilterType | RangeFilterType;
+
+export type TreeNodeIdType = string;
+export type QueryIdType = string;
+
+export type TableType = {
+    id: number,
+    label: string,
+    exclude?: boolean,
+    filters: ?FilterType[],
+  };
+
+export type NodeType = {
+  parent: TreeNodeIdType,
+  label: string,
+  description: string,
+  active?: boolean,
+  children: Array<TreeNodeIdType>,
+  additionalInfos?: Array<InfoType>,
+  matchingEntries?: number,
+  dateRange?: DateRangeType,
+  tables: Array<TableType>,
+  detailsAvailable?: boolean,
+  codeListResolvable?: boolean,
+}
+
+export type RootType = {
+  concepts: Map<TreeNodeIdType, NodeType>,
+  version: number
+};

--- a/frontend/lib/js/common/types/backend.js
+++ b/frontend/lib/js/common/types/backend.js
@@ -87,3 +87,16 @@ export type RootType = {
   concepts: Map<TreeNodeIdType, NodeType>,
   version: number
 };
+
+export type ConceptListResolutionResultType = {
+  resolvedConcepts?: string[],
+  unknownCodes?: string[],
+  resolvedFilter?: {
+    filterId: string,
+    tableId: string,
+    value: {
+    label: string,
+    value: string
+    }[]
+  }
+};

--- a/frontend/lib/js/form-components/AsyncInputMultiSelect.js
+++ b/frontend/lib/js/form-components/AsyncInputMultiSelect.js
@@ -3,7 +3,7 @@
 import React                      from 'react';
 import { type FieldPropsType }    from 'redux-form';
 
-import { type SelectOptionsType } from '../common/types';
+import { type SelectOptionsType } from '../common/types/backend';
 import InputMultiSelect           from './InputMultiSelect';
 
 type PropsType = FieldPropsType & {

--- a/frontend/lib/js/form-components/InputMultiSelect.js
+++ b/frontend/lib/js/form-components/InputMultiSelect.js
@@ -6,7 +6,7 @@ import Select                  from 'react-select';
 import classnames              from 'classnames';
 import { type FieldPropsType } from 'redux-form';
 
-import { type SelectOptionsType } from '../common/types';
+import { type SelectOptionsType } from '../common/types/backend';
 import { isEmpty }                from '../common/helpers';
 
 import InfoTooltip from '../tooltip/InfoTooltip';

--- a/frontend/lib/js/form-components/InputSelect.js
+++ b/frontend/lib/js/form-components/InputSelect.js
@@ -9,7 +9,7 @@ import { type FieldPropsType }    from 'redux-form';
 import 'react-select/dist/react-select.css';
 
 import { isEmpty }                from '../common/helpers';
-import { type SelectOptionsType } from '../common/types';
+import { type SelectOptionsType } from '../common/types/backend';
 import InfoTooltip                from '../tooltip/InfoTooltip';
 
 type PropsType = FieldPropsType & {

--- a/frontend/lib/js/model/node.js
+++ b/frontend/lib/js/model/node.js
@@ -1,20 +1,32 @@
 // @flow
 
-import type { QueryNodeType, TableType }       from '../standard-query-editor/types';
+import type {
+  ConceptQueryNodeType,
+  TableType
+}                                 from '../standard-query-editor/types';
 
-import { tablesHaveActiveFilter }            from './table';
+import { tablesHaveActiveFilter } from './table';
 
-export const nodeHasActiveFilters = (node: QueryNodeType, tables: Array<TableType> = node.tables) =>
+export const nodeHasActiveFilters = (
+  node: ConceptQueryNodeType,
+  tables: Array<TableType> = node.tables
+) =>
   node.excludeTimestamps ||
     nodeHasActiveTableFilters(node, tables) ||
     nodeHasExludedTable(node, tables);
 
-export const nodeHasActiveTableFilters = (node: QueryNodeType, tables: Array<TableType> = node.tables) => {
+export const nodeHasActiveTableFilters = (
+  node: ConceptQueryNodeType,
+  tables: Array<TableType> = node.tables
+) => {
   if (!tables) return false;
   return tablesHaveActiveFilter(tables);
 };
 
-export const nodeHasExludedTable = (node: QueryNodeType, tables: Array<TableType> = node.tables) => {
+export const nodeHasExludedTable = (
+  node: ConceptQueryNodeType,
+  tables: Array<TableType> = node.tables
+) => {
   if (!tables) return false;
   return tables.some(table => table.exclude);
 }

--- a/frontend/lib/js/model/node.js
+++ b/frontend/lib/js/model/node.js
@@ -1,20 +1,20 @@
 // @flow
 
-import type { ElementType }       from '../standard-query-editor/types';
+import type { QueryNodeType, TableType }       from '../standard-query-editor/types';
 
-import { tablesHaveActiveFilter } from './table';
+import { tablesHaveActiveFilter }            from './table';
 
-export const nodeHasActiveFilters = (node, tables = node.tables) =>
+export const nodeHasActiveFilters = (node: QueryNodeType, tables: Array<TableType> = node.tables) =>
   node.excludeTimestamps ||
     nodeHasActiveTableFilters(node, tables) ||
     nodeHasExludedTable(node, tables);
 
-export const nodeHasActiveTableFilters = (node: ElementType, tables = node.tables) => {
+export const nodeHasActiveTableFilters = (node: QueryNodeType, tables: Array<TableType> = node.tables) => {
   if (!tables) return false;
   return tablesHaveActiveFilter(tables);
 };
 
-export const nodeHasExludedTable = (node: ElementType, tables = node.tables) => {
+export const nodeHasExludedTable = (node: QueryNodeType, tables: Array<TableType> = node.tables) => {
   if (!tables) return false;
   return tables.some(table => table.exclude);
 }

--- a/frontend/lib/js/model/table.js
+++ b/frontend/lib/js/model/table.js
@@ -14,9 +14,6 @@ export const tableHasActiveFilters = (table: TableType) =>
 export const resetAllFiltersInTables = (tables: TableType[]) => {
   return (tables || []).map(table => {
     const filters = table.filters
-      // It's actually a FilterType, but flow can't decide which one
-      // of the intersections it is
-      // $FlowFixMe
       ? table.filters.map((filter) => ({
           ...filter,
           value: filter.defaultValue

--- a/frontend/lib/js/previous-queries/list/PreviousQuery.js
+++ b/frontend/lib/js/previous-queries/list/PreviousQuery.js
@@ -26,6 +26,10 @@ import {
 }                           from '../delete-modal/actions'
 
 import {
+  type DraggedQueryType
+}                           from '../../standard-query-editor/types';
+
+import {
   sharePreviousQuery,
   renamePreviousQuery,
   retagPreviousQuery,
@@ -36,7 +40,7 @@ import {
 import PreviousQueryTags    from './PreviousQueryTags';
 
 const nodeSource = {
-  beginDrag(props) {
+  beginDrag(props): DraggedQueryType {
     // Return the data describing the dragged item
     return {
       id: props.query.id,

--- a/frontend/lib/js/scrollable-list/ScrollableList.js
+++ b/frontend/lib/js/scrollable-list/ScrollableList.js
@@ -6,7 +6,7 @@ import ReactList                 from 'react-list';
 
 type PropsType = {
   items: Array,
-  maxVisibleItems?: Number,
+  maxVisibleItems?: number,
   fullWidth?: boolean,
   minWidth?: boolean
 };
@@ -20,7 +20,7 @@ const ScrollableList = (props: PropsType) => {
     );
   }
 
-  const itemHeight = '34'; // pixels, as defined in scrollableList.sass
+  const itemHeight = 34; // pixels, as defined in scrollableList.sass
 
   // If the number of visible items is specified here,
   // make an additional element half-visible at the end to indicate

--- a/frontend/lib/js/standard-query-editor/Query.js
+++ b/frontend/lib/js/standard-query-editor/Query.js
@@ -30,19 +30,19 @@ import {
   expandPreviousQuery,
   selectNodeForEditing,
 }                                 from './actions'
-import type { StandardQueryType } from './types';
+import type { StandardQueryType, DateRangeType, DraggedNodeType, DraggedQueryType, DraggedFileType } from './types';
 
-import QueryEditorDropzone        from './QueryEditorDropzone';
+import { QueryEditorDropzone }    from './QueryEditorDropzone';
 import QueryGroup                 from './QueryGroup';
 
 
 type PropsType = {
   query: StandardQueryType,
   isEmptyQuery: boolean,
-  dropAndNode: Function,
-  dropConceptListFile: Function,
-  dropOrNode: Function,
-  dropOrConceptListFile: Function,
+  dropAndNode: (DraggedNodeType | DraggedQueryType, ?DateRangeType) => void,
+  dropConceptListFile: (DraggedFileType, ?DateRangeType) => void,
+  dropOrNode: (DraggedNodeType | DraggedQueryType, number) => void,
+  dropOrConceptListFile: (DraggedFileType, number) => void,
   deleteNode: Function,
   deleteGroup: Function,
   toggleExcludeGroup: Function,
@@ -61,7 +61,7 @@ const Query = (props: PropsType) => {
         // Render a large Dropzone
         <QueryEditorDropzone
           isInitial
-          onDropNode={props.dropAndNode}
+          onDropNode={item => props.dropAndNode(item, null)}
           onDropFiles={props.dropConceptListFile}
           onLoadPreviousQuery={props.loadPreviousQuery}
         />
@@ -117,30 +117,28 @@ function mapStateToProps(state) {
   };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<*>) {
-  return {
-    dropAndNode: (item, dateRange) => dispatch(dropAndNode(item, dateRange)),
-    dropConceptListFile: (item, dateRange) => dispatch(dropConceptListFile(item, { dateRange })),
-    dropOrConceptListFile: (item, andIdx) => dispatch(dropOrConceptListFile(item, andIdx)),
-    dropOrNode: (item, andIdx) => dispatch(dropOrNode(item, andIdx)),
-    deleteNode: (andIdx, orIdx) => dispatch(deleteNode(andIdx, orIdx)),
-    deleteGroup: (andIdx) => dispatch(deleteGroup(andIdx)),
-    toggleExcludeGroup: (andIdx) => dispatch(toggleExcludeGroup(andIdx)),
-    selectNodeForEditing: (andIdx, orIdx) =>
-      dispatch(selectNodeForEditing(andIdx, orIdx)),
-    queryGroupModalSetNode: (andIdx) =>
-      dispatch(queryGroupModalSetNode(andIdx)),
-    expandPreviousQuery: (datasetId, rootConcepts, groups, queryId) => {
-      dispatch(expandPreviousQuery(rootConcepts, groups));
+const mapDispatchToProps = (dispatch: Dispatch<*>) => ({
+  dropAndNode: (item, dateRange) => dispatch(dropAndNode(item, dateRange)),
+  dropConceptListFile: (item, dateRange) => dispatch(dropConceptListFile(item, { dateRange })),
+  dropOrConceptListFile: (item, andIdx) => dispatch(dropOrConceptListFile(item, andIdx)),
+  dropOrNode: (item, andIdx) => dispatch(dropOrNode(item, andIdx)),
+  deleteNode: (andIdx, orIdx) => dispatch(deleteNode(andIdx, orIdx)),
+  deleteGroup: (andIdx) => dispatch(deleteGroup(andIdx)),
+  toggleExcludeGroup: (andIdx) => dispatch(toggleExcludeGroup(andIdx)),
+  selectNodeForEditing: (andIdx, orIdx) =>
+    dispatch(selectNodeForEditing(andIdx, orIdx)),
+  queryGroupModalSetNode: (andIdx) =>
+    dispatch(queryGroupModalSetNode(andIdx)),
+  expandPreviousQuery: (datasetId, rootConcepts, groups, queryId) => {
+    dispatch(expandPreviousQuery(rootConcepts, groups));
 
-      dispatch(loadAllPreviousQueriesInGroups(groups, datasetId));
+    dispatch(loadAllPreviousQueriesInGroups(groups, datasetId));
 
-      dispatch(replace(toQuery(datasetId, queryId)));
-    },
-    loadPreviousQuery: (datasetId, queryId) =>
-      dispatch(loadPreviousQuery(datasetId, queryId)),
-  };
-}
+    dispatch(replace(toQuery(datasetId, queryId)));
+  },
+  loadPreviousQuery: (datasetId, queryId) =>
+    dispatch(loadPreviousQuery(datasetId, queryId)),
+});
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   ...stateProps,

--- a/frontend/lib/js/standard-query-editor/Query.js
+++ b/frontend/lib/js/standard-query-editor/Query.js
@@ -30,7 +30,13 @@ import {
   expandPreviousQuery,
   selectNodeForEditing,
 }                                 from './actions'
-import type { StandardQueryType, DateRangeType, DraggedNodeType, DraggedQueryType, DraggedFileType } from './types';
+import type {
+  StandardQueryType,
+  DateRangeType,
+  DraggedNodeType,
+  DraggedQueryType,
+  DraggedFileType
+}                                 from './types';
 
 import { QueryEditorDropzone }    from './QueryEditorDropzone';
 import QueryGroup                 from './QueryGroup';

--- a/frontend/lib/js/standard-query-editor/QueryEditorDropzone.js
+++ b/frontend/lib/js/standard-query-editor/QueryEditorDropzone.js
@@ -1,35 +1,29 @@
+// @flow
+
 import React                  from 'react';
-import PropTypes              from 'prop-types';
 import classnames             from 'classnames';
 import T                      from 'i18n-react';
-import { DropTarget }         from 'react-dnd';
+import { DropTarget, type ConnectDropTarget }         from 'react-dnd';
 import { NativeTypes }        from 'react-dnd-html5-backend';
 import { dndTypes }           from '../common/constants';
+import type { QueryIdType }   from '../common/types/backend';
+import type { DraggedNodeType, DraggedQueryType, DraggedFileType } from './types';
 
+type PropsType = {
+  isInitial: ?boolean,
+  isAnd: ?boolean,
+  onDropNode: (DraggedNodeType | DraggedQueryType) => void,
+  onDropFiles: (DraggedFileType) => void,
+  onLoadPreviousQuery: (QueryIdType) => void,
 
-const dropzoneTarget = {
-  drop(props, monitor) {
-    const item = monitor.getItem();
-
-    if (item.files)
-      props.onDropFiles(item);
-    else
-      props.onDropNode(item);
-
-    if (item.isPreviousQuery)
-      props.onLoadPreviousQuery(item.id);
-  }
+  connectDropTarget: ConnectDropTarget,
+  isOver: boolean
 };
 
-function collect(connect, monitor) {
-  return {
-    connectDropTarget: connect.dropTarget(),
-    isOver: monitor.isOver()
-  };
-}
-
-const QueryEditorDropzone = (props) => {
-  return props.connectDropTarget(
+const InnerQueryEditorDropzone =
+  // When instantiating the QueryEditorDropzone, flow doesn't recognize that
+  // connectDropTarget and isOver are being injected by react-dnd :(
+  (props: PropsType) => props.connectDropTarget(
     <div className={classnames(
       'query-editor-dropzone', {
         'query-editor-dropzone--initial': props.isInitial,
@@ -51,19 +45,27 @@ const QueryEditorDropzone = (props) => {
       </div>
     </div>
   );
+
+const dropzoneTarget = {
+  drop(props: PropsType, monitor) {
+    const item: DraggedNodeType | DraggedQueryType | DraggedFileType = monitor.getItem();
+
+    if (item.files) {
+      props.onDropFiles(item);
+    } else {
+      props.onDropNode(item);
+      if (item.isPreviousQuery)
+        props.onLoadPreviousQuery(item.id);
+    }
+  }
 };
 
-QueryEditorDropzone.propTypes = {
-  isInitial: PropTypes.bool,
-  isAnd: PropTypes.bool,
-  connectDropTarget: PropTypes.func.isRequired,
-  isOver: PropTypes.bool.isRequired,
-  onDropNode: PropTypes.func.isRequired,
-  onDropFiles: PropTypes.func.isRequired,
-  onLoadPreviousQuery: PropTypes.func.isRequired,
-};
+const collect = (connect, monitor) => ({
+  connectDropTarget: connect.dropTarget(),
+  isOver: monitor.isOver()
+});
 
-export default DropTarget(
+export const QueryEditorDropzone = DropTarget(
   [
     dndTypes.CATEGORY_TREE_NODE,
     dndTypes.QUERY_NODE,
@@ -72,4 +74,4 @@ export default DropTarget(
   ],
   dropzoneTarget,
   collect
-)(QueryEditorDropzone);
+)(InnerQueryEditorDropzone);

--- a/frontend/lib/js/standard-query-editor/QueryEditorDropzone.js
+++ b/frontend/lib/js/standard-query-editor/QueryEditorDropzone.js
@@ -3,7 +3,10 @@
 import React                  from 'react';
 import classnames             from 'classnames';
 import T                      from 'i18n-react';
-import { DropTarget, type ConnectDropTarget }         from 'react-dnd';
+import {
+  DropTarget,
+  type ConnectDropTarget
+}                             from 'react-dnd';
 import { NativeTypes }        from 'react-dnd-html5-backend';
 import { dndTypes }           from '../common/constants';
 import type { QueryIdType }   from '../common/types/backend';

--- a/frontend/lib/js/standard-query-editor/QueryGroup.js
+++ b/frontend/lib/js/standard-query-editor/QueryGroup.js
@@ -3,7 +3,9 @@
 import React                   from 'react';
 import T                       from 'i18n-react';
 
-import QueryEditorDropzone     from './QueryEditorDropzone';
+import { type DraggedNodeType } from '../model/node';
+
+import { QueryEditorDropzone } from './QueryEditorDropzone';
 import QueryNode               from './QueryNode';
 import QueryGroupActions       from './QueryGroupActions';
 import type { QueryGroupType } from './types';
@@ -11,7 +13,7 @@ import type { QueryGroupType } from './types';
 type PropsType = {
   group: QueryGroupType,
   andIdx: number,
-  onDropNode: Function,
+  onDropNode: (DraggedNodeType) => void,
   onDropFiles: Function,
   onDeleteNode: Function,
   onFilterClick: Function,

--- a/frontend/lib/js/standard-query-editor/QueryNode.js
+++ b/frontend/lib/js/standard-query-editor/QueryNode.js
@@ -2,7 +2,10 @@
 
 import React                       from 'react';
 import T                           from 'i18n-react';
-import { DragSource, type ConnectDragSource }              from 'react-dnd';
+import {
+  DragSource,
+  type ConnectDragSource
+}                                  from 'react-dnd';
 
 import { dndTypes }                from '../common/constants';
 import { AdditionalInfoHoverable } from '../tooltip';
@@ -11,7 +14,11 @@ import { nodeHasActiveFilters }    from '../model/node';
 
 import QueryNodeActions            from './QueryNodeActions';
 
-import type { QueryNodeType, DraggedNodeType, DraggedQueryType }        from './types';
+import type {
+  QueryNodeType,
+  DraggedNodeType,
+  DraggedQueryType
+}                                  from './types';
 
 type PropsType =  {
   node: QueryNodeType,
@@ -101,7 +108,6 @@ const nodeSource = {
       return {
         ...draggedNode,
         ids: node.ids,
-        concepts: node.concepts,
         tree: node.tree,
         tables: node.tables,
       }
@@ -111,13 +117,10 @@ const nodeSource = {
 /**
  * Specifies the dnd-related props to inject into the component.
  */
-function collect(connect, monitor) {
-  return {
-    connectDragSource: connect.dragSource(),
-    isDragging: monitor.isDragging()
-  };
-}
-
+const collect = (connect, monitor) => ({
+  connectDragSource: connect.dragSource(),
+  isDragging: monitor.isDragging()
+});
 
 const DraggableQueryNode = DragSource(
   dndTypes.QUERY_NODE,

--- a/frontend/lib/js/standard-query-editor/actions.js
+++ b/frontend/lib/js/standard-query-editor/actions.js
@@ -6,6 +6,8 @@ import api                             from '../api';
 
 import { uploadConceptListModalOpen }  from '../upload-concept-list-modal/actions';
 
+import { type DateRangeType }          from '../common/types/backend';
+
 import {
   defaultSuccess,
   defaultError
@@ -13,7 +15,8 @@ import {
 
 import type {
   DraggedNodeType,
-  DraggedQueryType
+  DraggedQueryType,
+  DraggedFileType
 }                                      from './types';
 
 import {
@@ -39,10 +42,12 @@ import {
   LOAD_FILTER_SUGGESTIONS_SUCCESS,
   LOAD_FILTER_SUGGESTIONS_ERROR,
 } from './actionTypes';
-import { type DateRange, DraggedFileType } from './types';
 
 
-export const dropAndNode = (item: DraggedNodeType | DraggedQueryType, dateRange: ?DateRange) => ({
+export const dropAndNode = (
+  item: DraggedNodeType | DraggedQueryType,
+  dateRange: ?DateRangeType
+) => ({
   type: DROP_AND_NODE,
   payload: { item, dateRange }
 });

--- a/frontend/lib/js/standard-query-editor/actions.js
+++ b/frontend/lib/js/standard-query-editor/actions.js
@@ -6,6 +6,8 @@ import api                             from '../api';
 
 import { uploadConceptListModalOpen }  from '../upload-concept-list-modal/actions';
 
+import type { DraggedNodeType, DraggedQueryType }        from './types';
+
 import {
   defaultSuccess,
   defaultError
@@ -34,9 +36,10 @@ import {
   LOAD_FILTER_SUGGESTIONS_SUCCESS,
   LOAD_FILTER_SUGGESTIONS_ERROR,
 } from './actionTypes';
+import { type DateRange, DraggedFileType } from './types';
 
 
-export const dropAndNode = (item, dateRange) => ({
+export const dropAndNode = (item: DraggedNodeType | DraggedQueryType, dateRange: ?DateRange) => ({
   type: DROP_AND_NODE,
   payload: { item, dateRange }
 });
@@ -67,8 +70,8 @@ const parseConceptListFile = (fileContents) => {
     .filter(row => row.length > 0);
 };
 
-export const dropConceptListFile = (item, queryContext = {}) => {
-  return (dispatch) => {
+export const dropConceptListFile = (item: DraggedFileType, queryContext: Object = {}) => {
+  return (dispatch: Dispatch) => {
     dispatch(loadFilesStart());
 
     // Ignore all dropped files except the first
@@ -98,24 +101,24 @@ export const dropConceptListFile = (item, queryContext = {}) => {
   }
 };
 
-export const dropOrConceptListFile = (item, andIdx) => dropConceptListFile(item, { andIdx });
+export const dropOrConceptListFile = (item: DraggedFileType, andIdx: number) => dropConceptListFile(item, { andIdx });
 
-export const dropOrNode = (item, andIdx) => ({
+export const dropOrNode = (item: DraggedNodeType | DraggedQueryType, andIdx: number) => ({
   type: DROP_OR_NODE,
   payload: { item, andIdx }
 });
 
-export const deleteNode = (andIdx, orIdx) => ({
+export const deleteNode = (andIdx: number, orIdx: number) => ({
   type: DELETE_NODE,
   payload: { andIdx, orIdx }
 });
 
-export const deleteGroup = (andIdx, orIdx) => ({
+export const deleteGroup = (andIdx: number, orIdx: number) => ({
   type: DELETE_GROUP,
   payload: { andIdx, orIdx }
 });
 
-export const toggleExcludeGroup = (andIdx) => ({
+export const toggleExcludeGroup = (andIdx: number) => ({
   type: TOGGLE_EXCLUDE_GROUP,
   payload: { andIdx }
 });
@@ -132,7 +135,7 @@ export const expandPreviousQuery = (rootConcepts, groups) => ({
   payload: { rootConcepts, groups }
 });
 
-export const selectNodeForEditing = (andIdx, orIdx) => ({
+export const selectNodeForEditing = (andIdx: number, orIdx: number) => ({
   type: SELECT_NODE_FOR_EDITING,
   payload: { andIdx, orIdx }
 });
@@ -149,7 +152,7 @@ export const setFilterValue = (tableIdx, filterIdx, value) => ({
   payload: { tableIdx, filterIdx, value }
 });
 
-export const resetAllFilters = (andIdx, orIdx) => ({
+export const resetAllFilters = (andIdx: number, orIdx: number) => ({
   type: RESET_ALL_FILTERS,
   payload: { andIdx, orIdx }
 });

--- a/frontend/lib/js/standard-query-editor/actions.js
+++ b/frontend/lib/js/standard-query-editor/actions.js
@@ -6,12 +6,15 @@ import api                             from '../api';
 
 import { uploadConceptListModalOpen }  from '../upload-concept-list-modal/actions';
 
-import type { DraggedNodeType, DraggedQueryType }        from './types';
-
 import {
   defaultSuccess,
   defaultError
-} from '../common/actions';
+}                                      from '../common/actions';
+
+import type {
+  DraggedNodeType,
+  DraggedQueryType
+}                                      from './types';
 
 import {
   DROP_AND_NODE,
@@ -101,7 +104,8 @@ export const dropConceptListFile = (item: DraggedFileType, queryContext: Object 
   }
 };
 
-export const dropOrConceptListFile = (item: DraggedFileType, andIdx: number) => dropConceptListFile(item, { andIdx });
+export const dropOrConceptListFile = (item: DraggedFileType, andIdx: number) =>
+  dropConceptListFile(item, { andIdx });
 
 export const dropOrNode = (item: DraggedNodeType | DraggedQueryType, andIdx: number) => ({
   type: DROP_OR_NODE,

--- a/frontend/lib/js/standard-query-editor/reducer.js
+++ b/frontend/lib/js/standard-query-editor/reducer.js
@@ -11,10 +11,9 @@ import {
   stripObject
 } from '../common/helpers';
 
-import type {
-  TreeNodeIdType,
-  NodeType
-} from '../common/types/backend';
+import {
+  type DateRangeType
+} from '../common/types/backend'
 
 import {
   resetAllFiltersInTables
@@ -34,7 +33,8 @@ import {
 } from '../previous-queries/list/actionTypes';
 
 import {
-  UPLOAD_CONCEPT_LIST_MODAL_ACCEPT, type UploadConceptListModalResultType
+  UPLOAD_CONCEPT_LIST_MODAL_ACCEPT,
+  type UploadConceptListModalResultType
 } from '../upload-concept-list-modal/actionTypes'
 
 import {
@@ -64,13 +64,11 @@ import {
 
 import type
 {
-  DateRangeType,
   QueryNodeType,
   QueryGroupType,
   StandardQueryType,
   DraggedNodeType,
-  DraggedQueryType,
-  ConceptType
+  DraggedQueryType
 } from './types';
 
 
@@ -97,7 +95,6 @@ const filterItem = (item: DraggedNodeType | DraggedQueryType): QueryNodeType => 
   else
     return {
       ids: item.ids,
-      concepts: item.concepts,
       tables: item.tables,
       tree: item.tree,
 
@@ -454,7 +451,7 @@ const expandPreviousQuery = (state, action: { payload: { groups: QueryGroupType[
   return groups.map((group) => {
     return {
       ...group,
-      elements: group.elements.map((element: QueryNodeType) => {
+      elements: group.elements.map((element) => {
         if (element.type === 'QUERY') {
           return {
             ...element,
@@ -481,7 +478,7 @@ const expandPreviousQuery = (state, action: { payload: { groups: QueryGroupType[
             label,
             ids,
             tables,
-            concepts: lookupResult.concepts,
+            tree: lookupResult.root
           };
         }
       })
@@ -579,16 +576,6 @@ const loadFilterSuggestionsSuccess = (state, action) =>
 const loadFilterSuggestionsError = (state, action) =>
   setNodeFilterProperties(state, action, { isLoading: false, options: [] });
 
-const selectConceptFromNodeData = (concept: NodeType & { id: TreeNodeIdType }) : ConceptType => ({
-  id: concept.id,
-  label: concept.label,
-  description: concept.description,
-  matchingEntries: concept.matchingEntries,
-  dateRange: concept.dateRange,
-  additionalInfos: concept.additionalInfos,
-  hasChildren: !!concept.children,
-});
-
 const createQueryNodeFromConceptListUploadResult = (
     result: UploadConceptListModalResultType
   ) : DraggedNodeType => {
@@ -602,8 +589,7 @@ const createQueryNodeFromConceptListUploadResult = (
         label,
         ids: resolutionResult.conceptList,
         tables: lookupResult.tables,
-        tree: lookupResult.root,
-        concepts: lookupResult.concepts.map(concept => selectConceptFromNodeData(concept))
+        tree: lookupResult.root
       };
   } else if (resolutionResult.filter) {
     const [conceptRoot] =
@@ -625,8 +611,7 @@ const createQueryNodeFromConceptListUploadResult = (
       label,
       ids: [conceptRoot.id],
       tables,
-      tree: conceptRoot.id,
-      concepts: [selectConceptFromNodeData(conceptRoot)],
+      tree: conceptRoot.id
     };
   }
 

--- a/frontend/lib/js/standard-query-editor/types.js
+++ b/frontend/lib/js/standard-query-editor/types.js
@@ -3,7 +3,13 @@
 import type {
   TreeNodeIdType,
   QueryIdType,
-  FilterType
+  DateRangeType,
+  RangeFilterType,
+  RangeFilterValueType,
+  MultiSelectFilterType,
+  MultiSelectFilterValueType,
+  SelectFilterType,
+  SelectFilterValueType
 } from '../common/types/backend';
 
 // A concept that is part of a query node in the editor
@@ -14,11 +20,41 @@ export type ConceptType =  {
   matchingEntries?: number
 };
 
-export type TableType = {
+
+export type SelectOptionType = {
+  label: string,
+  value: number | string,
+};
+
+export type SelectOptionsType = SelectOptionType[];
+
+export type InfoType = {
+  key: string,
+  value: string,
+}
+
+export type RangeFilterWithValueType = RangeFilterType & {
+  value?: RangeFilterValueType,
+}
+
+export type MultiSelectFilterWithValueType = MultiSelectFilterType & {
+  value?: MultiSelectFilterValueType,
+}
+
+export type SelectFilterWithValueType = SelectFilterType & {
+  value?: SelectFilterValueType,
+}
+
+export type FilterWithValueType =
+  SelectFilterWithValueType
+  | MultiSelectFilterWithValueType
+  | RangeFilterWithValueType;
+
+export type TableWithFilterValueType = {
   id: number,
   label: string,
   exclude?: boolean,
-  filters: ?FilterType[],
+  filters: ?FilterWithValueType[],
 };
 
 export type DraggedFileType = {
@@ -47,8 +83,7 @@ export type DraggedQueryType = {
 // Corresponds to CATEGORY_TREE_NODE and QUERY_NODE drag-and-drop types.
 export type DraggedNodeType = {
   ids: Array<TreeNodeIdType>,
-  concepts: Array<ConceptType>,
-  tables: Array<TableType>,
+  tables: Array<TableWithFilterValueType>,
   tree: TreeNodeIdType,
   label: string,
   excludeTimestamps?: boolean,
@@ -65,8 +100,7 @@ export type DraggedNodeType = {
 
 export type ConceptQueryNodeType = {
   ids: Array<TreeNodeIdType>,
-  concepts: Array<ConceptType>,
-  tables: TableType[],
+  tables: TableWithFilterValueType[],
   tree: TreeNodeIdType,
 
   label: string,
@@ -75,7 +109,7 @@ export type ConceptQueryNodeType = {
   error?: string,
 
   isEditing?: boolean,
-  isPreviousQuery: void | false,
+  isPreviousQuery?: void | false,
 }
 
 export type PreviousQueryQueryNodeType = {
@@ -91,8 +125,6 @@ export type PreviousQueryQueryNodeType = {
 }
 
 export type QueryNodeType = ConceptQueryNodeType | PreviousQueryQueryNodeType;
-
-export type DateRangeType = ?{ min?: string, max?: string }
 
 export type QueryGroupType = {
   elements: QueryNodeType[],

--- a/frontend/lib/js/standard-query-editor/types.js
+++ b/frontend/lib/js/standard-query-editor/types.js
@@ -1,43 +1,14 @@
 // @flow
-import { type SelectOptionsType } from '../common/types';
 
-type RangeFilterValueType = { min?: number, max?: number, exact?: number }
-export type RangeFilterType = {
-  id: number,
+import type { TreeNodeIdType, QueryIdType } from "../common/types/backend";
+
+// A concept that is part of a query node in the editor
+export type ConceptType =  {
+  id: string,
   label: string,
-  description?: string,
-  type: 'INTEGER_RANGE' | 'REAL_RANGE',
-  value: ?RangeFilterValueType,
-  unit?: string,
-  mode: 'range' | 'exact',
-  precision?: number,
-  min?: number,
-  max?: number,
-}
-
-type MultiSelectFilterValueType = (string | number)[];
-export type MultiSelectFilterType = {
-  id: number,
-  label: string,
-  description?: string,
-  type: 'MULTI_SELECT',
-  value: ?MultiSelectFilterValueType,
-  unit?: string,
-  options: SelectOptionsType
-}
-
-type SelectFilterValueType = string | number;
-export type SelectFilterType = {
-  id: number,
-  label: string,
-  description?: string,
-  type: 'SELECT',
-  value: ?SelectFilterValueType,
-  unit?: string,
-  options: SelectOptionsType
-}
-
-export type FilterType = SelectFilterType | MultiSelectFilterType | RangeFilterType;
+  description: string,
+  matchingEntries: number
+};
 
 export type TableType = {
   id: number,
@@ -46,31 +17,87 @@ export type TableType = {
   filters: ?FilterType[],
 };
 
-export type ElementType = {
-  id: number,
-  label: string,
-  description: string,
-  tables: TableType[],
-  additionalInfos: [],
-  matchingEntries: number,
-  isPreviousQuery: boolean,
-  hasActiveFilters: boolean,
-  excludeTimestamps: boolean,
+export type DraggedFileType = {
+  files: File[],
+  isPreviousQuery?: void,
+}
+
+export type DraggedQueryType = {
+  id: QueryIdType,
   // eslint-disable-next-line no-use-before-define
-  query?: PreviousQuery,
+  query?: PreviousQueryType,
+  label: string,
+  excludeTimestamps?: boolean,
+
+  moved?: boolean,
+  andIdx?: number, orIdx?: number,  // These two only exist if moved === true
+
   loading?: boolean,
   error?: string,
-  isEditing?: boolean
+
+  files?: void,
+  isPreviousQuery: true
 };
+
+// A Query Node that is being dragged from the tree or within the standard editor.
+// Corresponds to CATEGORY_TREE_NODE and QUERY_NODE drag-and-drop types.
+export type DraggedNodeType = {
+  ids: Array<TreeNodeIdType>,
+  concepts: Array<ConceptType>,
+  tables: Array<TableType>,
+  tree: TreeNodeIdType,
+  label: string,
+  excludeTimestamps?: boolean,
+
+  moved?: boolean,
+  andIdx?: number, orIdx?: number,  // These two only exist if moved === true
+
+  loading?: boolean,
+  error?: string,
+
+  files?: void,
+  isPreviousQuery?: void,
+};
+
+type ConceptQueryNodeType = {
+  ids: Array<TreeNodeIdType>,
+  concepts: Array<ConceptType>,
+  tables: TableType[],
+  tree: TreeNodeIdType,
+
+  label: string,
+  excludeTimestamps?: boolean,
+  loading?: boolean,
+  error?: string,
+
+  isEditing?: boolean,
+  isPreviousQuery: void | false,
+}
+
+type PreviousQueryQueryNodeType = {
+  label: string,
+  excludeTimestamps?: boolean,
+  loading?: boolean,
+  error?: string,
+
+  id: QueryIdType,
+  // eslint-disable-next-line no-use-before-define
+  query?: PreviousQueryType,
+  isPreviousQuery: true,
+}
+
+export type QueryNodeType = ConceptQueryNodeType | PreviousQueryQueryNodeType;
+
+export type DateRangeType = ?{ min?: string, max?: string }
 
 export type QueryGroupType = {
-  elements: ElementType[],
-  dateRange?: ?{ min?: string, max?: string },
+  elements: QueryNodeType[],
+  dateRange?: DateRangeType,
+  exclude?: boolean
 };
 
-type PreviousQuery = {
+type PreviousQueryType = {
   groups: QueryGroupType[]
 };
-
 
 export type StandardQueryType = QueryGroupType[];

--- a/frontend/lib/js/standard-query-editor/types.js
+++ b/frontend/lib/js/standard-query-editor/types.js
@@ -1,13 +1,17 @@
 // @flow
 
-import type { TreeNodeIdType, QueryIdType } from "../common/types/backend";
+import type {
+  TreeNodeIdType,
+  QueryIdType,
+  FilterType
+} from '../common/types/backend';
 
 // A concept that is part of a query node in the editor
 export type ConceptType =  {
   id: string,
   label: string,
-  description: string,
-  matchingEntries: number
+  description?: string,
+  matchingEntries?: number
 };
 
 export type TableType = {
@@ -59,7 +63,7 @@ export type DraggedNodeType = {
   isPreviousQuery?: void,
 };
 
-type ConceptQueryNodeType = {
+export type ConceptQueryNodeType = {
   ids: Array<TreeNodeIdType>,
   concepts: Array<ConceptType>,
   tables: TableType[],
@@ -74,7 +78,7 @@ type ConceptQueryNodeType = {
   isPreviousQuery: void | false,
 }
 
-type PreviousQueryQueryNodeType = {
+export type PreviousQueryQueryNodeType = {
   label: string,
   excludeTimestamps?: boolean,
   loading?: boolean,

--- a/frontend/lib/js/tooltip/AdditionalInfoHoverable.js
+++ b/frontend/lib/js/tooltip/AdditionalInfoHoverable.js
@@ -27,7 +27,10 @@ export type AdditionalInfoHoverableNodeType = {
 const AdditionalInfoHoverable = (Component: any) => {
   const mapStateToProps = () => ({});
 
-  const mapDispatchToProps = (dispatch: Dispatch, ownProps: { node: AdditionalInfoHoverableNodeType }) => ({
+  const mapDispatchToProps = (
+    dispatch: Dispatch,
+    ownProps: { node: AdditionalInfoHoverableNodeType }
+  ) => ({
     onDisplayAdditionalInfos: () => {
       const node = ownProps.node;
 

--- a/frontend/lib/js/tooltip/AdditionalInfoHoverable.js
+++ b/frontend/lib/js/tooltip/AdditionalInfoHoverable.js
@@ -3,9 +3,22 @@
 import { connect }          from 'react-redux';
 import { type Dispatch }    from 'redux-thunk';
 
+import type {
+  DateRangeType,
+  InfoType
+}                           from '../common/types/backend';
+
 import { isEmpty }          from '../common/helpers';
 import * as actions         from './actions';
 import HoverableBase        from './HoverableBase';
+
+export type AdditionalInfoHoverableNodeType = {
+  label: string,
+  description: string,
+  matchingEntries: number,
+  dateRange: DateRangeType,
+  additionalInfos: Array<InfoType>
+}
 
 // Decorates a component with a hoverable node.
 // On mouse enter, additional infos about the component are saved in the state
@@ -14,7 +27,7 @@ import HoverableBase        from './HoverableBase';
 const AdditionalInfoHoverable = (Component: any) => {
   const mapStateToProps = () => ({});
 
-  const mapDispatchToProps = (dispatch: Dispatch, ownProps) => ({
+  const mapDispatchToProps = (dispatch: Dispatch, ownProps: { node: AdditionalInfoHoverableNodeType }) => ({
     onDisplayAdditionalInfos: () => {
       const node = ownProps.node;
 

--- a/frontend/lib/js/tooltip/reducer.js
+++ b/frontend/lib/js/tooltip/reducer.js
@@ -10,7 +10,6 @@ type InfoType = {
   value: string,
 };
 
-// TODO: Deprecate?
 export type AdditionalInfosType = {
   label: ?string,
   description: ?string,

--- a/frontend/lib/js/tooltip/reducer.js
+++ b/frontend/lib/js/tooltip/reducer.js
@@ -10,6 +10,7 @@ type InfoType = {
   value: string,
 };
 
+// TODO: Deprecate?
 export type AdditionalInfosType = {
   label: ?string,
   description: ?string,

--- a/frontend/lib/js/upload-concept-list-modal/UploadConceptListModal.js
+++ b/frontend/lib/js/upload-concept-list-modal/UploadConceptListModal.js
@@ -34,7 +34,7 @@ type PropsType = {
   selectedConceptRootNode: Object,
   selectConceptRootNode: Function,
   selectedDatasetId: DatasetIdType,
-  conceptCodesFromFile: Array<String>,
+  conceptCodesFromFile: Array<string>,
   updateLabel: Function,
   resolved: Object,
   hasResolvedItems: boolean,

--- a/frontend/lib/js/upload-concept-list-modal/actionTypes.js
+++ b/frontend/lib/js/upload-concept-list-modal/actionTypes.js
@@ -1,5 +1,7 @@
 // @flow
 
+import { type TreeNodeIdType } from '../common/types/backend';
+
 export const UPLOAD_CONCEPT_LIST_MODAL_UPDATE_LABEL =
   "upload-concept-list-modal/UPLOAD_CONCEPT_LIST_MODAL_UPDATE_LABEL";
 
@@ -15,3 +17,21 @@ export const UPLOAD_CONCEPT_LIST_MODAL_CLOSE  =
   "upload-concept-list-modal/UPLOAD_CONCEPT_LIST_MODAL_CLOSE";
 export const UPLOAD_CONCEPT_LIST_MODAL_ACCEPT =
   "upload-concept-list-modal/UPLOAD_CONCEPT_LIST_MODAL_ACCEPT";
+
+export type UploadConceptListModalResultType = {
+  label: string,
+  rootConcepts: any,
+  resolutionResult: {
+    conceptList?: string[],
+    filter?: {
+      filterId: string,
+      tableId: string,
+      value: {
+      label: string,
+      value: string
+      }[]
+    },
+    selectedRoot: TreeNodeIdType
+  },
+  queryContext: any
+}


### PR DESCRIPTION
This PR is an addition to the changes made in #88 and a dependency for the new query node editor.

Now that we've changed the properties of query nodes to represent concept lists instead of single concepts, I wanted to use this opportunity to formalize their types using flow.

This is especially important because we have several places in the app where nodes are added by drag-and-drop (i.e. from the concept tree, from the previous queries list, from a dropped concept list file, from within the editor itself). We have to make sure that in all these places, nodes are created with the correct properties filled.

In doing that, I've also slightly cleaned up the properties of components in the category tree (e.g. the root tree id is passed on to every node instead of providing the tree object itself or its tables).