### PR TITLE
Query Node Editor fixes

### DIFF
--- a/frontend/lib/js/api/apiHelper.js
+++ b/frontend/lib/js/api/apiHelper.js
@@ -49,8 +49,9 @@ export const transformElementsToApi = (conceptGroup) => conceptGroup.map(concept
     : [];
 
   return {
-    id: concept.id,
-    type: 'CONCEPT',
+    ids: concept.ids,
+    type: 'CONCEPT_LIST',
+    label: concept.label,
     tables,
   };
 });

--- a/frontend/lib/js/external-forms/form-query-node-editor/FormQueryNodeEditor.js
+++ b/frontend/lib/js/external-forms/form-query-node-editor/FormQueryNodeEditor.js
@@ -1,5 +1,7 @@
 // @flow
 
+import React                               from 'react';
+
 import { createConnectedQueryNodeEditor }  from '../../query-node-editor';
 
 import {
@@ -15,6 +17,9 @@ import { toUpperCaseUnderscore }           from '../../common/helpers';
 import { createFormSuggestionActions }     from '../form-suggestions/actions';
 
 export type PropsType = {
+  formType: string,
+  fieldName: string,
+
   name: string,
   node: ?Object,
   showTables: boolean,
@@ -30,80 +35,83 @@ export type PropsType = {
   onResetAllFilters: Function
 };
 
-export const createConnectedFormQueryNodeEditor = (formType: string, fieldName: string) => {
-  const mapStateToProps = (state, ownProps) => {
-    const reduxFormState = selectReduxFormState(state);
-    const conceptPosition = selectEditedConceptPosition(
-      reduxFormState,
-      formType,
-      fieldName
-    );
-
-    const node = conceptPosition
-      ? selectEditedConcept(reduxFormState, formType, fieldName, conceptPosition)
-      : null;
-
-    const { andIdx, orIdx } = conceptPosition || {};
-
-    const showTables = node && node.tables && (
-      node.tables.length > 1 ||
-      node.tables.some(table => table.filters && table.filters.length > 0)
-    );
-
-    const formState = selectFormState(state, formType);
-    const suggestions = conceptPosition
-      ? selectSuggestions(formState, fieldName, conceptPosition)
-      : null;
-
-    return {
-      node,
-      andIdx,
-      orIdx,
-      editorState: formState[fieldName],
-      isExcludeTimestampsPossible: false,
-      showTables,
-      suggestions,
-
-      onToggleTimestamps: () => {},
-      onCloseModal: () => ownProps.onCloseModal(andIdx, orIdx),
-      onUpdateLabel: (label) => ownProps.onUpdateLabel(andIdx, orIdx, label),
-      onDropConcept: (concept) => ownProps.onDropConcept(andIdx, orIdx, concept),
-      onRemoveConcept: (conceptId) => ownProps.onRemoveConcept(andIdx, orIdx, conceptId),
-      onToggleTable: (...props) => ownProps.onToggleTable(andIdx, orIdx, ...props),
-      onSetFilterValue: (...props) => ownProps.onSetFilterValue(andIdx, orIdx, ...props),
-      onSwitchFilterMode: (...props) => ownProps.onSwitchFilterMode(andIdx, orIdx, ...props),
-      onResetAllFilters: () => ownProps.onResetAllFilters(andIdx, orIdx),
-    };
-  }
-
-  const mapDispatchToProps = (dispatch) => {
-    const {
-      loadFormFilterSuggestions
-    } = createFormSuggestionActions(formType, fieldName);
-
-    return {
-      onLoadFilterSuggestions: (...params) =>
-        dispatch(loadFormFilterSuggestions(formType, fieldName, ...params))
-    };
-  };
-
-  const mergeProps = (stateProps, dispatchProps, ownProps) => ({
-    ...ownProps,
-    ...stateProps,
-    ...dispatchProps,
-    onLoadFilterSuggestions: (datasetId, ...rest) =>
-      dispatchProps.onLoadFilterSuggestions(
-        datasetId,
-        stateProps.andIdx,
-        stateProps.orIdx,
-        ...rest
-      ),
-  });
-
-  return createConnectedQueryNodeEditor(
-    `${formType}_${toUpperCaseUnderscore(fieldName)}`,
-    mapStateToProps,
-    mapDispatchToProps,
-    mergeProps
+const mapStateToProps = (state, ownProps) => {
+  const reduxFormState = selectReduxFormState(state);
+  const conceptPosition = selectEditedConceptPosition(
+    reduxFormState,
+    ownProps.formType,
+    ownProps.fieldName
   );
+
+  const node = conceptPosition
+    ? selectEditedConcept(reduxFormState, ownProps.formType, ownProps.fieldName, conceptPosition)
+    : null;
+
+  const { andIdx, orIdx } = conceptPosition || {};
+
+  const showTables = node && node.tables && (
+    node.tables.length > 1 ||
+    node.tables.some(table => table.filters && table.filters.length > 0)
+  );
+
+  const formState = selectFormState(state, ownProps.formType);
+  const suggestions = conceptPosition
+    ? selectSuggestions(formState, ownProps.fieldName, conceptPosition)
+    : null;
+
+  return {
+    node,
+    andIdx,
+    orIdx,
+    editorState: formState[ownProps.fieldName],
+    isExcludeTimestampsPossible: false,
+    showTables,
+    suggestions,
+
+    onToggleTimestamps: () => {},
+    onCloseModal: () => ownProps.onCloseModal(andIdx, orIdx),
+    onUpdateLabel: (label) => ownProps.onUpdateLabel(andIdx, orIdx, label),
+    onDropConcept: (concept) => ownProps.onDropConcept(andIdx, orIdx, concept),
+    onRemoveConcept: (conceptId) => ownProps.onRemoveConcept(andIdx, orIdx, conceptId),
+    onToggleTable: (...props) => ownProps.onToggleTable(andIdx, orIdx, ...props),
+    onSetFilterValue: (...props) => ownProps.onSetFilterValue(andIdx, orIdx, ...props),
+    onSwitchFilterMode: (...props) => ownProps.onSwitchFilterMode(andIdx, orIdx, ...props),
+    onResetAllFilters: () => ownProps.onResetAllFilters(andIdx, orIdx),
+  };
 }
+
+const mapDispatchToProps = (dispatch, ownProps) => {
+  const {
+    loadFormFilterSuggestions
+  } = createFormSuggestionActions(ownProps.formType, ownProps.fieldName);
+
+  return {
+    onLoadFilterSuggestions: (...params) =>
+      dispatch(loadFormFilterSuggestions(ownProps.formType, ownProps.fieldName, ...params))
+  };
+};
+
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  ...ownProps,
+  ...stateProps,
+  ...dispatchProps,
+  onLoadFilterSuggestions: (datasetId, ...rest) =>
+    dispatchProps.onLoadFilterSuggestions(
+      datasetId,
+      stateProps.andIdx,
+      stateProps.orIdx,
+      ...rest
+    ),
+});
+
+const QueryNodeEditor = createConnectedQueryNodeEditor(
+  mapStateToProps,
+  mapDispatchToProps,
+  mergeProps
+);
+
+export const FormQueryNodeEditor = (props: PropsType) =>
+  <QueryNodeEditor
+    type={`${props.formType}_${toUpperCaseUnderscore(props.fieldName)}`}
+    {...props}
+  />

--- a/frontend/lib/js/external-forms/form-query-node-editor/index.js
+++ b/frontend/lib/js/external-forms/form-query-node-editor/index.js
@@ -1,3 +1,3 @@
 // @flow
-export { createConnectedFormQueryNodeEditor } from './FormQueryNodeEditor';
+export { FormQueryNodeEditor }                from './FormQueryNodeEditor';
 export { createFormQueryNodeEditorReducer }   from './reducer';

--- a/frontend/lib/js/query-node-editor/NodeDetailsView.js
+++ b/frontend/lib/js/query-node-editor/NodeDetailsView.js
@@ -67,7 +67,7 @@ const ConceptDropzone =
           }
         )}>
           <p className="dropzone__text">
-            Drop another concept here
+            {T.translate('queryNodeEditor.dropConcept')}
           </p>
         </div>
       </div>

--- a/frontend/lib/js/query-node-editor/QueryNodeEditor.js
+++ b/frontend/lib/js/query-node-editor/QueryNodeEditor.js
@@ -84,21 +84,20 @@ const QueryNodeEditor = (props: PropsType) => {
 };
 
 export const createConnectedQueryNodeEditor = (
-  type: string,
   mapStateToProps: Function,
   mapDispatchToProps: Function,
   mergeProps: Function
 ) => {
-  const {
-    setDetailsViewActive,
-    toggleEditLabel,
-    setInputTableViewActive,
-    setFocusedInput,
-    reset,
-  } = createQueryNodeEditorActions(type);
-
   const mapDispatchToPropsInternal = (dispatch: Dispatch, ownProps) => {
     const externalDispatchProps = mapDispatchToProps ? mapDispatchToProps(dispatch, ownProps) : {};
+
+    const {
+      setDetailsViewActive,
+      toggleEditLabel,
+      setInputTableViewActive,
+      setFocusedInput,
+      reset,
+    } = createQueryNodeEditorActions(ownProps.type);
 
     return {
       ...externalDispatchProps,

--- a/frontend/lib/js/standard-query-editor/StandardQueryNodeEditor.js
+++ b/frontend/lib/js/standard-query-editor/StandardQueryNodeEditor.js
@@ -1,5 +1,7 @@
 // @flow
 
+import React                              from 'react';
+
 import { createConnectedQueryNodeEditor } from '../query-node-editor';
 
 import {
@@ -74,6 +76,8 @@ const mapDispatchToProps = (dispatch) => ({
         filterId,
         prefix
     )),
-})
+});
 
-export default createConnectedQueryNodeEditor('standard', mapStateToProps, mapDispatchToProps);
+const QueryNodeEditor = createConnectedQueryNodeEditor(mapStateToProps, mapDispatchToProps);
+
+export default (props) => <QueryNodeEditor type="standard" {...props} />;

--- a/frontend/lib/localization/de.yml
+++ b/frontend/lib/localization/de.yml
@@ -58,6 +58,7 @@ queryNodeEditor:
   description: "Beschreibung"
   noDescriptionProvided: "Keine Beschreibung verfügbar."
   selectAFilter: "Kein Filter ausgewählt."
+  dropConcept: "Füge ein weiteres Konzept hinzu"
 
 queryGroupModal:
   explanation: "Zeitlich einschränken"

--- a/frontend/lib/localization/en.yml
+++ b/frontend/lib/localization/en.yml
@@ -56,6 +56,7 @@ queryNodeEditor:
   description: "Description"
   noDescriptionProvided: "No description provided."
   selectAFilter: "Select a filter to see its description here."
+  dropConcept: "Drop another concept here"
 
 queryGroupModal:
   explanation: "Set time frame"


### PR DESCRIPTION
This fixes the following issues with the QueryNodeEditor:

- "Drop another concept here" string was not localized
- Concept nodes weren't always sent as concept lists to the backend (related to the concept-list-only migration)
- FormQueryNodeEditor component was recreated on every form field update, resulting in loss of keyboard focus on every typed character when editing filters