### PR TITLE
Fix heroku deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_script:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
+  - wget -qO- https://toolbelt.heroku.com/install.sh | sh
 
 cache:
   directories:
@@ -27,6 +28,8 @@ deploy:
     script: bash frontend/scripts/deploy-heroku-docker.sh conquery-dev
     on:
       branch: develop
+  - provider: script
+    script: bash frontend/scripts/deploy-heroku-docker.sh conquery-dev
   - provider: script
     script: bash frontend/scripts/deploy-heroku-docker.sh conquery
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ deploy:
       branch: develop
   - provider: script
     script: bash frontend/scripts/deploy-heroku-docker.sh conquery-dev
+    on:
+      branch: feature/fix-heroku-deployments
   - provider: script
     script: bash frontend/scripts/deploy-heroku-docker.sh conquery
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,6 @@ deploy:
     on:
       branch: develop
   - provider: script
-    script: bash frontend/scripts/deploy-heroku-docker.sh conquery-dev
-    on:
-      branch: feature/fix-heroku-deployments
-  - provider: script
     script: bash frontend/scripts/deploy-heroku-docker.sh conquery
     on:
       branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
-  - wget -qO- https://toolbelt.heroku.com/install.sh | sh
+  - curl https://cli-assets.heroku.com/install.sh | sh
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,13 @@ before_script:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
-  - curl https://cli-assets.heroku.com/install.sh | sh
+  
+addons:
+  apt:
+    sources:
+    - heroku
+    packages:
+    - heroku-toolbelt
 
 cache:
   directories:

--- a/frontend/scripts/deploy-heroku-docker.sh
+++ b/frontend/scripts/deploy-heroku-docker.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 APP_NAME=$1
 cd ${TRAVIS_BUILD_DIR}/frontend/
-docker login -u _ -p "$HEROKU_TOKEN" registry.heroku.com
-docker build -t registry.heroku.com/$APP_NAME/web .
-docker push registry.heroku.com/$APP_NAME/web
+/usr/local/heroku/bin/heroku container:push web -a $APP_NAME
+/usr/local/heroku/bin/heroku container:release web -a $APP_NAME


### PR DESCRIPTION
Pushing a new image to the Heroku docker registry doesn't automatically create a new release to the website.

We need the Heroku CLI to be installed inside the Travis build job to trigger this.

Because travis won't run deployments for this branch, I wasn't able to confirm that this works, however I'm pretty confident it does.