### PR TITLE
DropzoneList exposes a flag to restrict number of dropzones

### DIFF
--- a/frontend/lib/js/form-components/DropzoneList.js
+++ b/frontend/lib/js/form-components/DropzoneList.js
@@ -17,6 +17,7 @@ type PropsType = {
   acceptedDropTypes: string[],
   onDrop: Function,
   onDelete: Function,
+  disallowMultipleColumns?: boolean
 };
 
 const DropzoneList = (props: PropsType) => {
@@ -46,11 +47,15 @@ const DropzoneList = (props: PropsType) => {
           }
         </div>
       }
-      <FreeDropzone
-        className={props.dropzoneClassName}
-        containsItem={false}
-        dropzoneText={props.dropzoneText}
-      />
+      {
+        // allow at least one column
+        ((props.items && props.items.length === 0) || !props.disallowMultipleColumns) &&
+        <FreeDropzone
+          className={props.dropzoneClassName}
+          containsItem={false}
+          dropzoneText={props.dropzoneText}
+        />
+      }
     </div>
   );
 };


### PR DESCRIPTION
* add the optional flag `disallowMultipleColumns`
* if absent or false DropzoneList will render any number of additional dropzones
* if true only the initial dropzone will be rendered. Then, concepts can only be added to the very first group
