### PR TITLE
Upgrade node to 8.12

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.9-alpine
+FROM node:8.12-alpine
 
 RUN mkdir /conquery
 WORKDIR /conquery

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -56,8 +56,8 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <nodeVersion>v8.9.0</nodeVersion>
-                            <yarnVersion>v1.3.2</yarnVersion>
+                            <nodeVersion>v8.12.0</nodeVersion>
+                            <yarnVersion>v1.9.4</yarnVersion>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
This updates node from `8.9` to `8.12` (required for the latest `eslint` package).

Forgot this and pre-maturely merged #340 , sorry 🤕 

Now we should be good again, cc @manuel-hegner .