### PR TITLE
Feature/expand query dates and negation

### DIFF
--- a/frontend/lib/js/api/apiHelper.js
+++ b/frontend/lib/js/api/apiHelper.js
@@ -121,18 +121,14 @@ const createConcept = concept => ({
 
 const createQueryConcepts = query => {
   return query.map(group => {
-    const concepts = group.dateRange
-      ? group.elements.map(concept =>
-          createDateRestriction(group.dateRange, createQueryConcept(concept))
-        )
-      : group.elements.map(concept => createQueryConcept(concept));
+    const concepts = group.elements.map(createQueryConcept);
+    const orConcept = { type: "OR", children: [...concepts] };
 
-    var result =
-      group.elements.length > 1
-        ? { type: "OR", children: [...concepts] }
-        : concepts.reduce((acc, curr) => ({ ...acc, ...curr }), {});
+    const withDate = group.dateRange
+      ? [createDateRestriction(group.dateRange, orConcept)]
+      : orConcept;
 
-    return group.exclude ? createNegation(result) : result;
+    return group.exclude ? createNegation(withDate) : withDate;
   });
 };
 

--- a/frontend/lib/js/api/apiHelper.js
+++ b/frontend/lib/js/api/apiHelper.js
@@ -125,7 +125,7 @@ const createQueryConcepts = query => {
     const orConcept = { type: "OR", children: [...concepts] };
 
     const withDate = group.dateRange
-      ? [createDateRestriction(group.dateRange, orConcept)]
+      ? createDateRestriction(group.dateRange, orConcept)
       : orConcept;
 
     return group.exclude ? createNegation(withDate) : withDate;

--- a/frontend/lib/js/form-components/InputDateRange.js
+++ b/frontend/lib/js/form-components/InputDateRange.js
@@ -94,7 +94,11 @@ const InputDateRange = (props: PropsType) => {
     input: { value }
   } = props;
 
-  const dateFormat = T.translate("inputDateRange.dateFormat");
+  // To save the date in this format in the state
+  const dateFormat = "yyyy-MM-dd";
+
+  // To display the date depending on the locale
+  const displayDateFormat = T.translate("inputDateRange.dateFormat");
 
   const minDate = value ? parseDate(value.min, dateFormat) : null;
   const maxDate = value ? parseDate(value.max, dateFormat) : null;
@@ -118,7 +122,7 @@ const InputDateRange = (props: PropsType) => {
             scrollableYearDropdown
             tabIndex={1}
             selectsStart
-            dateFormat={dateFormat}
+            dateFormat={displayDateFormat}
             locale={"locale"}
             selected={minDate}
             startDate={minDate}

--- a/frontend/lib/js/form-components/InputDateRange.js
+++ b/frontend/lib/js/form-components/InputDateRange.js
@@ -148,7 +148,7 @@ const InputDateRange = (props: PropsType) => {
             scrollableYearDropdown
             tabIndex={2}
             selectsEnd
-            dateFormat={dateFormat}
+            dateFormat={displayDateFormat}
             locale={"locale"}
             selected={maxDate}
             startDate={minDate}

--- a/frontend/lib/js/query-runner/QueryResults.js
+++ b/frontend/lib/js/query-runner/QueryResults.js
@@ -37,9 +37,7 @@ const QueryResults = (props: PropsType) => {
   return (
     <Root>
       <Text>
-        {props.resultCount
-          ? T.translate("queryRunner.resultCount", { count: props.resultCount })
-          : T.translate("queryRunner.endSuccess")}
+        {T.translate("queryRunner.resultCount", { count: props.resultCount })}
       </Text>
       {isDownload && (
         <StyledDownloadButton frame primary url={props.resultUrl}>


### PR DESCRIPTION
This adjusts how a query was sent to the backend and how it expansion dealt with it

**Before** (frontend did some optimizations)
```
AND
  CONCEPT
  OR
    DATE_RESTRICTION
      CONCEPT
    DATE_RESTRICTION
      CONCEPT
  NEGATION
    DATE_RESTRICTION
      CONCEPT
```

**After** (frontend assumes OR every time, DATE_RESTRICTIONs wrap ORs, not CONCEPTs
```
AND
  OR
    CONCEPT
  DATE_RESTRICTION
    OR
      CONCEPT
      CONCEPT
  NEGATION
    DATE_RESTRICTION
      OR
        CONCEPT
```