### PR TITLE
Support default aggregators

### DIFF
--- a/frontend/app/api/concepts.json
+++ b/frontend/app/api/concepts.json
@@ -18,12 +18,18 @@
         {
           "id": "12345678",
           "label": "Filme gespielt Gesamt",
-          "description": "Beispieldescription"
+          "description": "Beispieldescription",
+          "default": true
         },
         {
           "id": "123456789",
           "label": "Summe Gage",
           "description": "Die Summe berechnet sich aus X und Y und Z und example."
+        },
+        {
+          "id": "123456789",
+          "label": "Hatte Spaß im Dreh",
+          "description": "Der Spaß ist manchmal gegeben und manchmal nicht."
         }
       ],
       "tables": [
@@ -34,7 +40,8 @@
             {
               "id": "12345678",
               "label": "Anzahl unterschiedliche Studios",
-              "description": "Beispieldescription"
+              "description": "Beispieldescription",
+              "default": true
             },
             {
               "id": "123456789",

--- a/frontend/lib/js/common/types/backend.js
+++ b/frontend/lib/js/common/types/backend.js
@@ -81,7 +81,8 @@ export type TableType = {
 export type SelectorType = {
   id: string,
   label: string,
-  description: string
+  description: string,
+  default?: boolean
 };
 
 export type TreeNodeIdType = string;

--- a/frontend/lib/js/model/node.js
+++ b/frontend/lib/js/model/node.js
@@ -3,19 +3,14 @@
 import type { ConceptQueryNodeType } from "../standard-query-editor/types";
 
 import { tablesHaveActiveFilter } from "./table";
+import { objectHasSelectedSelects } from "./select";
 
 export const nodeHasActiveFilters = (node: ConceptQueryNodeType) =>
   node.excludeTimestamps ||
   node.includeSubnodes ||
-  nodeHasSelectedSelects(node) ||
+  objectHasSelectedSelects(node) ||
   nodeHasActiveTableFilters(node) ||
   nodeHasExludedTable(node);
-
-export const nodeHasSelectedSelects = (node: ConceptQueryNodeType) => {
-  if (!node.selects) return false;
-
-  return node.selects.some(select => select.selected);
-};
 
 export const nodeHasActiveTableFilters = (node: ConceptQueryNodeType) => {
   if (!node.tables) return false;

--- a/frontend/lib/js/model/select.js
+++ b/frontend/lib/js/model/select.js
@@ -1,0 +1,13 @@
+// flow
+
+export function objectHasSelectedSelects(obj) {
+  return (
+    obj &&
+    obj.selects &&
+    obj.selects.some(
+      select =>
+        (select.selected && !select.default) ||
+        (!select.selected && !!select.default)
+    )
+  );
+}

--- a/frontend/lib/js/model/table.js
+++ b/frontend/lib/js/model/table.js
@@ -4,11 +4,13 @@ import type { TableWithFilterValueType } from "../standard-query-editor/types";
 
 import { isEmpty } from "../common/helpers";
 
+import { objectHasSelectedSelects } from "./select";
+
 export const tablesHaveActiveFilter = (tables: TableWithFilterValueType[]) =>
   tables.some(table => tableHasActiveFilters(table));
 
 export const tableHasActiveFilters = (table: TableWithFilterValueType) =>
-  (table.selects && table.selects.some(select => !!select.selected)) ||
+  objectHasSelectedSelects(table) ||
   (table.filters &&
     table.filters.some(
       filter => !isEmpty(filter.value) && filter.value !== filter.defaultValue

--- a/frontend/lib/js/standard-query-editor/QueryNode.js
+++ b/frontend/lib/js/standard-query-editor/QueryNode.js
@@ -144,7 +144,8 @@ const nodeSource = {
         ...draggedNode,
         ids: node.ids,
         tree: node.tree,
-        tables: node.tables
+        tables: node.tables,
+        selects: node.selects
       };
   }
 };

--- a/frontend/lib/js/standard-query-editor/reducer.js
+++ b/frontend/lib/js/standard-query-editor/reducer.js
@@ -70,6 +70,18 @@ import type {
 
 const initialState: StandardQueryType = [];
 
+const withDefaultValues = arr => {
+  if (!arr) return arr;
+
+  return arr.map(obj => {
+    // Tables passed
+    if (obj.selects) return { ...obj, selects: withDefaultValues(obj.selects) };
+
+    // Selects passed
+    return { ...obj, selected: !!obj.default };
+  });
+};
+
 const filterItem = (
   item: DraggedNodeType | DraggedQueryType
 ): QueryNodeType => {
@@ -92,8 +104,8 @@ const filterItem = (
   else
     return {
       ids: item.ids,
-      tables: item.tables,
-      selects: item.selects,
+      tables: withDefaultValues(item.tables),
+      selects: withDefaultValues(item.selects),
       tree: item.tree,
 
       label: item.label,


### PR DESCRIPTION
This uses `default: true` to pre-select aggregators by default. 

Default aggregators are allowd on both, node-level and table-level.

It's still allowed to de-select the default aggregators. Doing so, or adding another aggregator results in the `Edit` button to be highlighted.