### PR TITLE
Allow query expansion including aggregators

### DIFF
--- a/frontend/app/api/concepts.json
+++ b/frontend/app/api/concepts.json
@@ -27,13 +27,14 @@
           "description": "Die Summe berechnet sich aus X und Y und Z und example."
         },
         {
-          "id": "123456789",
+          "id": "123456789a",
           "label": "Hatte Spaß im Dreh",
           "description": "Der Spaß ist manchmal gegeben und manchmal nicht."
         }
       ],
       "tables": [
         {
+          "connectorId": "feature_films",
           "id": "feature_films",
           "label": "Feature Films",
           "selects": [
@@ -99,6 +100,7 @@
           ]
         },
         {
+          "connectorId": "tv_series",
           "id": "tv_series",
           "label": "TV Series",
           "filters": [
@@ -177,11 +179,13 @@
     "awards": {
       "label": "Awards",
       "active": true,
+      "codeListResolvable": true,
       "children": ["academy_award", "golden_globe_award"],
       "detailsAvailable": true,
       "tables": [
         {
           "id": "awards",
+          "connectorId": "awards",
           "label": "Awards",
           "filters": [
             {

--- a/frontend/app/api/dnd/concept-codes.txt
+++ b/frontend/app/api/dnd/concept-codes.txt
@@ -1,3 +1,2 @@
-academy_award
-best_supporting_actress_award
-comedies
+bla-bla
+action_movies

--- a/frontend/app/api/stored-queries/25.json
+++ b/frontend/app/api/stored-queries/25.json
@@ -43,9 +43,11 @@
                   {
                     "ids": ["action_movies"],
                     "type": "CONCEPT",
+                    "selects": ["123456789"],
                     "tables": [
                       {
                         "id": "feature_films",
+                        "selects": ["12345678"],
                         "filters": [
                           {
                             "id": "budget",

--- a/frontend/lib/js/api/apiHelper.js
+++ b/frontend/lib/js/api/apiHelper.js
@@ -33,6 +33,14 @@ export const transformFilterValueToApi = (filter: any) => {
   return value;
 };
 
+export const transformSelectsToApi = (selects?: ?(SelectedSelectorType[])) => {
+  if (!selects) return [];
+
+  return selects
+    ? selects.filter(({ selected }) => !!selected).map(({ id }) => id)
+    : [];
+};
+
 export const transformTablesToApi = (tables: TableWithFilterValueType[]) => {
   if (!tables) return [];
 
@@ -42,11 +50,7 @@ export const transformTablesToApi = (tables: TableWithFilterValueType[]) => {
       // Explicitly whitelist the tables that we allow to send to the API
       return {
         id: table.connectorId,
-        selects: table.selects
-          ? table.selects
-              .filter(({ selected }) => !!selected)
-              .map(({ id }) => id)
-          : [],
+        selects: transformSelectsToApi(table.selects),
         filters: table.filters
           ? table.filters
               .filter(filter => !isEmpty(filter.value)) // Only send filters with a value
@@ -58,14 +62,6 @@ export const transformTablesToApi = (tables: TableWithFilterValueType[]) => {
           : []
       };
     });
-};
-
-export const transformSelectsToApi = (selects?: ?(SelectedSelectorType[])) => {
-  if (!selects) return [];
-
-  return selects
-    ? selects.filter(({ selected }) => !!selected).map(({ id }) => id)
-    : [];
 };
 
 export const transformElementGroupsToApi = elementGroups =>


### PR DESCRIPTION
This resolves root-node `selects` when expanding a query.

Basically reverses more of the logic from `apiHelper`, which transforms before sending a query.
`standard-query-editor/reducer` does the reverse, when expand query is clicked.