### PR TITLE
introduces a new class to provide more information about a selector

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/CQElement.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/CQElement.java
@@ -34,10 +34,10 @@ public interface CQElement {
 		return set;
 	}
 
-	default void collectSelects(Deque<Select> select) {}
+	default void collectSelects(Deque<SelectDescriptor> select) {}
 	
-	default List<Select> collectSelects() {
-		ArrayDeque<Select> deque = new ArrayDeque<>();
+	default List<SelectDescriptor> collectSelects() {
+		ArrayDeque<SelectDescriptor> deque = new ArrayDeque<>();
 		this.collectSelects(deque);
 		return new ArrayList<>(deque);
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/ConceptQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/ConceptQuery.java
@@ -1,9 +1,7 @@
 package com.bakdata.conquery.models.query.concept;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import javax.validation.Valid;
@@ -13,7 +11,6 @@ import com.bakdata.conquery.ConqueryConstants;
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.models.concepts.select.Select;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedQueryId;
-import com.bakdata.conquery.models.identifiable.ids.specific.SelectId;
 import com.bakdata.conquery.models.query.IQuery;
 import com.bakdata.conquery.models.query.QueryPlanContext;
 import com.bakdata.conquery.models.query.QueryResolveContext;
@@ -48,35 +45,25 @@ public class ConceptQuery implements IQuery {
 		return this;
 	}
 	
-	public List<Select> collectSelects() {
+	public List<SelectDescriptor> collectSelects() {
 		return root.collectSelects();
 	}
 	
 	@Override
 	public List<ResultInfo> collectResultInfos() {
 
-		List<Select> selects = this.collectSelects();
+		List<SelectDescriptor> selects = this.collectSelects();
 		List<ResultInfo> header = new ArrayList<>(selects.size() + 1);
+		
 		header.add(ConqueryConstants.DATES_INFO);
-
-		Map<SelectId, Boolean> collisions = new HashMap<>();
-
-		// find all select ids that occur multiple times
-		for(Select select : selects) {
-			collisions.compute(select.getId(), (key, value) -> value != null);
-		}
-
-		Map<SelectId, Integer> occurences = new HashMap<>();
-
-		for(Select select : selects) {
-			final Integer occurence = occurences.compute(select.getId(), (id, n) -> n == null ? 0 : n + 1);
-
-			if (!collisions.getOrDefault(select.getId(), false)) {
-				header.add(new ResultInfo(select.getId().toStringWithoutDataset(), select.getResultType()));
-			}
-			else {
-				header.add(new ResultInfo(select.getId().toStringWithoutDataset() + "_" + occurence, select.getResultType()));
-			}
+		/*
+		 * Column name is constructed from the most specific concept id the CQConcept has and the selector.
+		 */
+		for(SelectDescriptor selectDescriptor : selects) {
+			Select select = selectDescriptor.getSelect();
+			header.add(new ResultInfo(
+				selectDescriptor.getCqConcept().getIds().get(0) + "_" + select.getId().toStringWithoutDataset(),
+				select.getResultType()));
 		}
 		return header;
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/SelectDescriptor.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/SelectDescriptor.java
@@ -1,0 +1,18 @@
+package com.bakdata.conquery.models.query.concept;
+
+import com.bakdata.conquery.models.concepts.select.Select;
+import com.bakdata.conquery.models.query.concept.specific.CQConcept;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Bundles a {@link Select} of a Query with the {@link CQConcept}, it occured in. 
+ * This is needed for generating more descriptive and individual column names in a CSV.
+ */
+@Data @AllArgsConstructor
+public class SelectDescriptor {
+	private Select select;
+	private CQConcept cqConcept;
+
+}

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQAnd.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQAnd.java
@@ -15,6 +15,7 @@ import com.bakdata.conquery.models.identifiable.ids.specific.ManagedQueryId;
 import com.bakdata.conquery.models.query.QueryPlanContext;
 import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.concept.CQElement;
+import com.bakdata.conquery.models.query.concept.SelectDescriptor;
 import com.bakdata.conquery.models.query.queryplan.QPNode;
 import com.bakdata.conquery.models.query.queryplan.QueryPlan;
 import com.bakdata.conquery.models.query.queryplan.specific.AndNode;
@@ -50,7 +51,7 @@ public class CQAnd implements CQElement {
 	}
 	
 	@Override
-	public void collectSelects(Deque<Select> select) {
+	public void collectSelects(Deque<SelectDescriptor> select) {
 		for(CQElement c:children) {
 			c.collectSelects(select);
 		}

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQConcept.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQConcept.java
@@ -20,6 +20,7 @@ import com.bakdata.conquery.models.identifiable.CentralRegistry;
 import com.bakdata.conquery.models.identifiable.ids.specific.ConceptElementId;
 import com.bakdata.conquery.models.query.QueryPlanContext;
 import com.bakdata.conquery.models.query.concept.CQElement;
+import com.bakdata.conquery.models.query.concept.SelectDescriptor;
 import com.bakdata.conquery.models.query.concept.filter.CQTable;
 import com.bakdata.conquery.models.query.concept.filter.FilterValue;
 import com.bakdata.conquery.models.query.concept.filter.FilterValue.CQSelectFilter;
@@ -152,10 +153,10 @@ public class CQConcept implements CQElement {
 	}
 
 	@Override
-	public void collectSelects(Deque<Select> select) {
-		select.addAll(this.selects);
+	public void collectSelects(Deque<SelectDescriptor> select) {
+		selects.forEach(sel -> select.add(new SelectDescriptor(sel,this)));
 		for (CQTable table : tables) {
-			select.addAll(table.getSelects());
+			table.getSelects().forEach(sel -> select.add(new SelectDescriptor(sel,this)));
 		}
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQDateRestriction.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQDateRestriction.java
@@ -17,6 +17,7 @@ import com.bakdata.conquery.models.concepts.select.Select;
 import com.bakdata.conquery.models.query.QueryPlanContext;
 import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.concept.CQElement;
+import com.bakdata.conquery.models.query.concept.SelectDescriptor;
 import com.bakdata.conquery.models.query.queryplan.QPNode;
 import com.bakdata.conquery.models.query.queryplan.QueryPlan;
 import com.bakdata.conquery.models.query.queryplan.specific.DateRestrictingNode;
@@ -71,7 +72,7 @@ public class CQDateRestriction implements CQElement {
 	}
 	
 	@Override
-	public void collectSelects(Deque<Select> select) {
+	public void collectSelects(Deque<SelectDescriptor> select) {
 		child.collectSelects(select);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQNegation.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQNegation.java
@@ -10,6 +10,7 @@ import com.bakdata.conquery.models.concepts.select.Select;
 import com.bakdata.conquery.models.query.QueryPlanContext;
 import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.concept.CQElement;
+import com.bakdata.conquery.models.query.concept.SelectDescriptor;
 import com.bakdata.conquery.models.query.queryplan.QPNode;
 import com.bakdata.conquery.models.query.queryplan.QueryPlan;
 import com.bakdata.conquery.models.query.queryplan.specific.NegatingNode;
@@ -37,7 +38,7 @@ public class CQNegation implements CQElement {
 	}
 	
 	@Override
-	public void collectSelects(Deque<Select> select) {
+	public void collectSelects(Deque<SelectDescriptor> select) {
 		child.collectSelects(select);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQOr.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQOr.java
@@ -15,6 +15,7 @@ import com.bakdata.conquery.models.identifiable.ids.specific.ManagedQueryId;
 import com.bakdata.conquery.models.query.QueryPlanContext;
 import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.concept.CQElement;
+import com.bakdata.conquery.models.query.concept.SelectDescriptor;
 import com.bakdata.conquery.models.query.queryplan.QPNode;
 import com.bakdata.conquery.models.query.queryplan.QueryPlan;
 import com.bakdata.conquery.models.query.queryplan.specific.OrNode;
@@ -50,7 +51,7 @@ public class CQOr implements CQElement {
 	}
 	
 	@Override
-	public void collectSelects(Deque<Select> select) {
+	public void collectSelects(Deque<SelectDescriptor> select) {
 		for(CQElement c:children) {
 			c.collectSelects(select);
 		}


### PR DESCRIPTION
Before column names in CSVs weren't really unique. Multiple occurences of a column name were post-fixed with a index, which didn't helped the identification of the specific concept/select.

Here both are brought together:
datasetid.concept.conceptChild(....conceptSubChild)_concept.(connector.)select