### PR TITLE
Merge value label for multi-select in query expansion

### DIFF
--- a/frontend/app/api/stored-queries/25.json
+++ b/frontend/app/api/stored-queries/25.json
@@ -50,7 +50,7 @@
                         "selects": ["12345678"],
                         "filters": [
                           {
-                            "id": "budget",
+                            "filter": "budget",
                             "value": {
                               "min": 10000000,
                               "max": 150000000
@@ -71,7 +71,7 @@
                         "id": "feature_films",
                         "filters": [
                           {
-                            "id": "studio",
+                            "filter": "studio",
                             "value": "universal"
                           }
                         ]
@@ -93,7 +93,7 @@
                     "id": "awards",
                     "filters": [
                       {
-                        "id": "award_type",
+                        "filter": "award_type",
                         "type": "MULTI_SELECT",
                         "value": ["won"]
                       }
@@ -109,7 +109,7 @@
                     "id": "awards",
                     "filters": [
                       {
-                        "id": "award_type",
+                        "filter": "award_type",
                         "type": "MULTI_SELECT",
                         "value": ["won"]
                       }

--- a/frontend/lib/js/standard-query-editor/reducer.js
+++ b/frontend/lib/js/standard-query-editor/reducer.js
@@ -455,9 +455,20 @@ const mergeFiltersFromSavedConcept = (savedTable, table) => {
           : { mode: "range", value: matchingFilter.value }
         : matchingFilter;
 
+    // If value is an array, there must be (multi-select) options to get other attributes from
+    const filterModeWithMappedValue =
+      filterModeWithValue.value && filterModeWithValue.value instanceof Array
+        ? {
+            ...filterModeWithValue,
+            value: filterModeWithValue.value.map(val =>
+              filter.options.find(op => op.value === val)
+            )
+          }
+        : filterModeWithValue;
+
     return {
       ...filter,
-      ...filterModeWithValue // => this one may contain a "value" property
+      ...filterModeWithMappedValue // => this one may contain a "value" property
     };
   });
 };


### PR DESCRIPTION
```
value: ["A", "B"]
```

is sent to the API within a query for a multi-select.

During expansion, this needs to be expanded to:
```
value: [{ label: "Aha", value: "A" }, {label: "Boha", value: "B"}]
```
with the `label`s coming from the original filter `options`, so that labels are actually displayed in the multi-select again.

But that expansion of an array of strings into an array of objects was not happening yet, so the simple string array was used.

This PR fixes that.