### PR TITLE
Perform concept search entirely in frontend

### DIFF
--- a/frontend/app/api/index.js
+++ b/frontend/app/api/index.js
@@ -319,36 +319,6 @@ module.exports = function(app, port) {
     }
   );
 
-  /*
-    SEARCH
-  */
-  app.post("/api/datasets/:datasetId/concepts/search", (req, res) => {
-    setTimeout(() => {
-      res.setHeader("Content-Type", "application/json");
-
-      const { query, limit } = req.body;
-
-      const result = [];
-
-      const allConcepts = glob
-        .sync(path.join(__dirname, "./concepts/**/*.json"))
-        .map(file => {
-          const content = require(path.resolve(file));
-
-          result.push(...findConcepts(content, query));
-        });
-
-      const returnedResult = result.slice(0, limit);
-
-      // see type SearchResult
-      res.send({
-        limit,
-        result: returnedResult,
-        size: result.length
-      });
-    }, NO_DELAY);
-  });
-
   app.get("/api/config/frontend", (req, res) => {
     res.setHeader("Content-Type", "application/json");
 
@@ -360,41 +330,3 @@ module.exports = function(app, port) {
   });
 };
 
-const findConcepts = (concepts, query) => {
-  const matches = Object.keys(concepts)
-    .map(key => ({
-      id: key,
-      label: concepts[key].label,
-      description: concepts[key].description
-    }))
-    .filter(co => {
-      // The actual backend search also uses the additional infos
-      return (
-        co.label.toLowerCase().includes(query.toLowerCase()) ||
-        (co.description &&
-          co.description.toLowerCase().includes(query.toLowerCase()))
-      );
-    })
-    .map(({ id }) => id);
-
-  return [...new Set(fetchParents(concepts, matches))];
-};
-
-const fetchParents = (concepts, matches) => {
-  for (var ma in matches) {
-    // Updates matches as a side-effect
-    visitParentOf(matches[ma], concepts, matches);
-  }
-
-  return matches;
-};
-
-const visitParentOf = (id, concepts, matches) => {
-  const concept = concepts[id];
-
-  if (concept && concept.parent) {
-    matches.push(concept.parent);
-
-    return visitParentOf(concept.parent, concepts, matches);
-  }
-};

--- a/frontend/lib/js/api/api.js
+++ b/frontend/lib/js/api/api.js
@@ -232,17 +232,3 @@ export function postFilterValuesResolve(
     }
   );
 }
-
-export const searchConcepts = (
-  datasetId: DatasetIdType,
-  query: string,
-  limit?: number
-) => {
-  return fetchJson(apiUrl() + `/datasets/${datasetId}/concepts/search`, {
-    method: "POST",
-    body: {
-      query,
-      limit
-    }
-  });
-};

--- a/frontend/lib/js/category-trees/CategoryTreeNode.js
+++ b/frontend/lib/js/category-trees/CategoryTreeNode.js
@@ -66,9 +66,11 @@ class CategoryTreeNode extends React.Component<PropsType> {
   render() {
     const { id, data, depth, open, search } = this.props;
 
-    // const shouldRender = isNodeInSearchResult(id, data.children, search);
+    if (!search.showMismatches) {
+      const shouldRender = isNodeInSearchResult(id, data.children, search);
 
-    // if (!shouldRender) return null;
+      if (!shouldRender) return null;
+    }
 
     const isOpen = open || search.allOpen;
 

--- a/frontend/lib/js/category-trees/CategoryTreeNode.js
+++ b/frontend/lib/js/category-trees/CategoryTreeNode.js
@@ -66,9 +66,9 @@ class CategoryTreeNode extends React.Component<PropsType> {
   render() {
     const { id, data, depth, open, search } = this.props;
 
-    const shouldRender = isNodeInSearchResult(id, data.children, search);
+    // const shouldRender = isNodeInSearchResult(id, data.children, search);
 
-    if (!shouldRender) return null;
+    // if (!shouldRender) return null;
 
     const isOpen = open || search.allOpen;
 

--- a/frontend/lib/js/category-trees/CategoryTreeNodeTextContainer.js
+++ b/frontend/lib/js/category-trees/CategoryTreeNodeTextContainer.js
@@ -52,7 +52,7 @@ const ResultsNumber = styled("span")`
   justify-content: center;
   line-height: 1;
   padding: 2px 4px;
-  margin-left: 5px;
+  margin-right: 5px;
   font-size: ${({ theme }) => theme.font.xs};
   border-radius: 3px;
   color: ${({ theme }) => theme.col.blueGrayDark};
@@ -116,6 +116,9 @@ class CategoryTreeNodeTextContainer extends React.Component {
           {hasChildren && (
             <StyledFaIcon active icon={!!open ? "folder-open" : "folder"} />
           )}
+          {showNumber && (
+            <ResultsNumber>{search.result[node.id]}</ResultsNumber>
+          )}
           <span>
             {search.words ? (
               <Highlighter
@@ -135,9 +138,6 @@ class CategoryTreeNodeTextContainer extends React.Component {
             />
           ) : (
             node.description && description
-          )}
-          {showNumber && (
-            <ResultsNumber>{search.result[node.id]}</ResultsNumber>
           )}
         </Text>
       </Root>

--- a/frontend/lib/js/category-trees/CategoryTreeSearchBox.js
+++ b/frontend/lib/js/category-trees/CategoryTreeSearchBox.js
@@ -50,7 +50,9 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  onSearch: (datasetId, query) => dispatch(searchTrees(datasetId, query)),
+  onSearch: (datasetId, query) => {
+    if (query.length > 1) dispatch(searchTrees(datasetId, query));
+  },
   onChange: query => dispatch(changeSearchQuery(query)),
   onClearQuery: () => dispatch(clearSearchQuery()),
   onToggleAllOpen: () => dispatch(toggleAllOpen())

--- a/frontend/lib/js/category-trees/CategoryTreeSearchBox.js
+++ b/frontend/lib/js/category-trees/CategoryTreeSearchBox.js
@@ -47,7 +47,7 @@ const CategoryTreeSearchBox = ({
 const mapStateToProps = state => ({
   areTreesAvailable: getAreTreesAvailable(state),
   allOpen: state.categoryTrees.search.allOpen,
-  searchResult: state.categoryTrees.search
+  search: state.categoryTrees.search
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/frontend/lib/js/category-trees/CategoryTreeSearchBox.js
+++ b/frontend/lib/js/category-trees/CategoryTreeSearchBox.js
@@ -32,6 +32,7 @@ const CategoryTreeSearchBox = ({
   return (
     <SearchBox
       {...props}
+      placeholder={T.translate("categoryTreeList.searchPlaceholder")}
       textAppend={
         <StyledButton tiny onClick={onToggleAllOpen}>
           {allOpen

--- a/frontend/lib/js/category-trees/CategoryTreeSearchBox.js
+++ b/frontend/lib/js/category-trees/CategoryTreeSearchBox.js
@@ -12,10 +12,13 @@ import {
   searchTrees,
   changeSearchQuery,
   clearSearchQuery,
-  toggleAllOpen
+  toggleAllOpen,
+  toggleShowMismatches
 } from "./actions";
 
 import TransparentButton from "../button/TransparentButton";
+
+const OPENABLE_AT = 500;
 
 const StyledButton = styled(TransparentButton)`
   margin: 3px 0 3px 5px;
@@ -23,6 +26,8 @@ const StyledButton = styled(TransparentButton)`
 
 const CategoryTreeSearchBox = ({
   allOpen,
+  showMismatches,
+  onToggleShowMismatches,
   onToggleAllOpen,
   areTreesAvailable,
   ...props
@@ -34,11 +39,20 @@ const CategoryTreeSearchBox = ({
       {...props}
       placeholder={T.translate("categoryTreeList.searchPlaceholder")}
       textAppend={
-        <StyledButton tiny onClick={onToggleAllOpen}>
-          {allOpen
-            ? T.translate("categoryTreeList.closeAll")
-            : T.translate("categoryTreeList.openAll")}
-        </StyledButton>
+        <>
+          <StyledButton tiny onClick={onToggleShowMismatches}>
+            {showMismatches
+              ? T.translate("categoryTreeList.dontShowMismatches")
+              : T.translate("categoryTreeList.showMismatches")}
+          </StyledButton>
+          {!showMismatches && props.search.resultCount < OPENABLE_AT && (
+            <StyledButton tiny onClick={onToggleAllOpen}>
+              {allOpen
+                ? T.translate("categoryTreeList.closeAll")
+                : T.translate("categoryTreeList.openAll")}
+            </StyledButton>
+          )}
+        </>
       }
     />
   );
@@ -47,6 +61,7 @@ const CategoryTreeSearchBox = ({
 const mapStateToProps = state => ({
   areTreesAvailable: getAreTreesAvailable(state),
   allOpen: state.categoryTrees.search.allOpen,
+  showMismatches: state.categoryTrees.search.showMismatches,
   search: state.categoryTrees.search
 });
 
@@ -56,7 +71,8 @@ const mapDispatchToProps = dispatch => ({
   },
   onChange: query => dispatch(changeSearchQuery(query)),
   onClearQuery: () => dispatch(clearSearchQuery()),
-  onToggleAllOpen: () => dispatch(toggleAllOpen())
+  onToggleAllOpen: () => dispatch(toggleAllOpen()),
+  onToggleShowMismatches: () => dispatch(toggleShowMismatches())
 });
 
 export default connect(

--- a/frontend/lib/js/category-trees/actionTypes.js
+++ b/frontend/lib/js/category-trees/actionTypes.js
@@ -18,3 +18,4 @@ export const CHANGE_SEARCH_QUERY = "category-trees/CHANGE_SEARCH_QUERY";
 export const CLEAR_SEARCH_QUERY = "category-trees/CLEAR_SEARCH_QUERY";
 
 export const TOGGLE_ALL_OPEN = "category-trees/TOGGLE_ALL_OPEN";
+export const TOGGLE_SHOW_MISMATCHES = "category-trees/TOGGLE_SHOW_MISMATCHES";

--- a/frontend/lib/js/category-trees/actions.js
+++ b/frontend/lib/js/category-trees/actions.js
@@ -22,7 +22,8 @@ import {
   SEARCH_TREES_ERROR,
   CHANGE_SEARCH_QUERY,
   CLEAR_SEARCH_QUERY,
-  TOGGLE_ALL_OPEN
+  TOGGLE_ALL_OPEN,
+  TOGGLE_SHOW_MISMATCHES
 } from "./actionTypes";
 
 export const clearTrees = () => ({ type: CLEAR_TREES });
@@ -117,3 +118,4 @@ export const changeSearchQuery = (query: string) => ({
 });
 
 export const toggleAllOpen = () => ({ type: TOGGLE_ALL_OPEN });
+export const toggleShowMismatches = () => ({ type: TOGGLE_SHOW_MISMATCHES });

--- a/frontend/lib/js/category-trees/actions.js
+++ b/frontend/lib/js/category-trees/actions.js
@@ -5,7 +5,7 @@ import { type Dispatch } from "redux-thunk";
 import { type DatasetIdType } from "../dataset/reducer";
 import api from "../api";
 import { defaultSuccess, defaultError } from "../common/actions";
-import type { TreeNodeIdType, SearchResult } from "../common/types/backend";
+import type { TreeNodeIdType } from "../common/types/backend";
 import { isEmpty } from "../common/helpers";
 
 import { resetAllTrees, search } from "./globalTreeStoreHelper";
@@ -24,8 +24,6 @@ import {
   CLEAR_SEARCH_QUERY,
   TOGGLE_ALL_OPEN
 } from "./actionTypes";
-
-const SEARCH_LIMIT = 500;
 
 export const clearTrees = () => ({ type: CLEAR_TREES });
 
@@ -92,12 +90,9 @@ export const searchTreesStart = (query: string) => ({
   type: SEARCH_TREES_START,
   payload: { query }
 });
-export const searchTreesSuccess = (
-  query: string,
-  searchResult: SearchResult
-) => ({
+export const searchTreesSuccess = (query: string, result: Object) => ({
   type: SEARCH_TREES_SUCCESS,
-  payload: { query, searchResult }
+  payload: { query, result }
 });
 export const searchTreesError = (query: string, err: any) =>
   defaultError(SEARCH_TREES_ERROR, err, { query });
@@ -109,9 +104,6 @@ export const searchTrees = (datasetId: DatasetIdType, query: string) => {
     if (isEmpty(query)) return;
 
     return search(query).then(
-      // return api
-      //   .searchConcepts(datasetId, query, SEARCH_LIMIT)
-      // .then(
       r => dispatch(searchTreesSuccess(query, r)),
       e => dispatch(searchTreesError(query, e))
     );
@@ -119,7 +111,7 @@ export const searchTrees = (datasetId: DatasetIdType, query: string) => {
 };
 
 export const clearSearchQuery = () => ({ type: CLEAR_SEARCH_QUERY });
-export const changeSearchQuery = query => ({
+export const changeSearchQuery = (query: string) => ({
   type: CHANGE_SEARCH_QUERY,
   payload: { query }
 });

--- a/frontend/lib/js/category-trees/actions.js
+++ b/frontend/lib/js/category-trees/actions.js
@@ -108,13 +108,13 @@ export const searchTrees = (datasetId: DatasetIdType, query: string) => {
 
     if (isEmpty(query)) return;
 
-    // return search(query).then(
-    return api
-      .searchConcepts(datasetId, query, SEARCH_LIMIT)
-      .then(
-        r => dispatch(searchTreesSuccess(query, r)),
-        e => dispatch(searchTreesError(query, e))
-      );
+    return search(query).then(
+      // return api
+      //   .searchConcepts(datasetId, query, SEARCH_LIMIT)
+      // .then(
+      r => dispatch(searchTreesSuccess(query, r)),
+      e => dispatch(searchTreesError(query, e))
+    );
   };
 };
 

--- a/frontend/lib/js/category-trees/globalTreeStoreHelper.js
+++ b/frontend/lib/js/category-trees/globalTreeStoreHelper.js
@@ -137,42 +137,6 @@ export const search = async (query: string) => {
   });
 };
 
-const findConcepts = (treeId, nodeId, node, query, intermediateResult) => {
-  const isNodeIncluded = doesQueryMatchNode(node, query);
-
-  let sum = isNodeIncluded ? 1 : 0;
-
-  if (node.children) {
-    for (let child of node.children) {
-      const result = findConcepts(
-        treeId,
-        child,
-        window.categoryTrees[treeId][child],
-        query,
-        intermediateResult
-      );
-
-      sum += result[child] || 0;
-    }
-  } else {
-    if (isNodeIncluded) {
-      intermediateResult[nodeId] = 1;
-
-      return intermediateResult;
-    } else {
-      return intermediateResult;
-    }
-  }
-
-  if (sum === 0) {
-    return intermediateResult;
-  } else {
-    intermediateResult[nodeId] = sum;
-
-    return intermediateResult;
-  }
-};
-
 const doesQueryMatchNode = (node, query) => {
   const lowerQuery = query.toLowerCase();
 
@@ -186,4 +150,65 @@ const doesQueryMatchNode = (node, query) => {
         .toLowerCase()
         .includes(lowerQuery))
   );
+};
+
+/*
+  This is a recursive algorithm to search through the trees
+  It counts results and stores the count in "intermediateResult".
+
+  The code might look a little bit "clumsy", but
+  - it's been optimized to _not_ use object spread, because that slowed it down
+  - it's been optimized to have a time complexity of O(n)
+
+  treeId: the root tree id
+  nodeId: the id of the concept node, because node doesn't include it itself
+  node: the current node to check for match,
+    includes all information needed, eg: label, description, additionalInfos and children
+  query: the search query
+  intermediateResult: to avoid building new objects in every iteration, we carry
+    this object through the recursion and define new properties as we go (side effects)
+*/
+const findConcepts = (
+  treeId: string,
+  nodeId: TreeNodeIdType,
+  node: NodeType,
+  query: string,
+  intermediateResult: { [TreeNodeIdType]: number }
+) => {
+  const isNodeIncluded = doesQueryMatchNode(node, query);
+
+  // Early return if there are no children
+  if (!node.children) {
+    if (isNodeIncluded) {
+      intermediateResult[nodeId] = 1;
+
+      return intermediateResult;
+    } else {
+      return intermediateResult;
+    }
+  }
+
+  // Count node as 1 already, if it matches
+  let sum = isNodeIncluded ? 1 : 0;
+
+  for (let child of node.children) {
+    const result = findConcepts(
+      treeId,
+      child,
+      window.categoryTrees[treeId][child],
+      query,
+      intermediateResult
+    );
+
+    sum += result[child] || 0;
+  }
+
+  if (sum === 0) {
+    // Leave node out from the result, if it doesn't match itself, and no child matches
+    return intermediateResult;
+  } else {
+    intermediateResult[nodeId] = sum;
+
+    return intermediateResult;
+  }
 };

--- a/frontend/lib/js/category-trees/globalTreeStoreHelper.js
+++ b/frontend/lib/js/category-trees/globalTreeStoreHelper.js
@@ -121,6 +121,10 @@ export const hasConceptChildren = node => {
   return concept && concept.children && concept.children.length > 0;
 };
 
+/*
+  This is async because ... we might want to parallelize this very soon,
+  as there are up to 200k concepts that need to be searched.
+*/
 export const search = async (query: string) => {
   const result = Object.keys(window.categoryTrees).reduce(
     (all, key) => ({
@@ -130,11 +134,7 @@ export const search = async (query: string) => {
     {}
   );
 
-  return Promise.resolve({
-    size: Object.keys(result).length,
-    limit: 500,
-    result
-  });
+  return result;
 };
 
 const doesQueryMatchNode = (node, query) => {

--- a/frontend/lib/js/category-trees/reducer.js
+++ b/frontend/lib/js/category-trees/reducer.js
@@ -122,8 +122,8 @@ const setSearchTreesSuccess = (state: StateType, action: Object): StateType => {
     searchResult: { result, size, limit }
   } = action.payload;
 
-  const nextResult = result ? resultWithCounts(state.trees, result, query) : {};
-  // const nextResult = result;
+  // const nextResult = result ? resultWithCounts(state.trees, result, query) : {};
+  const nextResult = result;
 
   return {
     ...state,

--- a/frontend/lib/js/category-trees/reducer.js
+++ b/frontend/lib/js/category-trees/reducer.js
@@ -60,18 +60,18 @@ const initialState: StateType = {
 };
 
 const treeWithCounts = (tree, result, searchTerm) => {
+  const lowerSearchTerm = searchTerm.toLowerCase();
+
   const isNodeIncluded =
-    includes(tree.label.toLowerCase(), searchTerm.toLowerCase()) ||
+    tree.label.toLowerCase().includes(lowerSearchTerm) ||
     (tree.description &&
-      includes(tree.description.toLowerCase(), searchTerm.toLowerCase())) ||
+      tree.description.toLowerCase().includes(lowerSearchTerm)) ||
     (tree.additionalInfos &&
-      includes(
-        tree.additionalInfos
-          .map(({ value }) => value)
-          .join("")
-          .toLowerCase(),
-        searchTerm.toLowerCase()
-      ));
+      tree.additionalInfos
+        .map(({ value }) => value)
+        .join("")
+        .toLowerCase()
+        .includes(lowerSearchTerm));
 
   const children = tree.children
     ? tree.children.filter(key => includes(result, key))

--- a/frontend/lib/js/category-trees/reducer.js
+++ b/frontend/lib/js/category-trees/reducer.js
@@ -63,7 +63,15 @@ const treeWithCounts = (tree, result, searchTerm) => {
   const isNodeIncluded =
     includes(tree.label.toLowerCase(), searchTerm.toLowerCase()) ||
     (tree.description &&
-      includes(tree.description.toLowerCase(), searchTerm.toLowerCase()));
+      includes(tree.description.toLowerCase(), searchTerm.toLowerCase())) ||
+    (tree.additionalInfos &&
+      includes(
+        tree.additionalInfos
+          .map(({ value }) => value)
+          .join("")
+          .toLowerCase(),
+        searchTerm.toLowerCase()
+      ));
 
   const children = tree.children
     ? tree.children.filter(key => includes(result, key))
@@ -115,6 +123,7 @@ const setSearchTreesSuccess = (state: StateType, action: Object): StateType => {
   } = action.payload;
 
   const nextResult = result ? resultWithCounts(state.trees, result, query) : {};
+  // const nextResult = result;
 
   return {
     ...state,

--- a/frontend/lib/js/common/helpers/commonHelper.js
+++ b/frontend/lib/js/common/helpers/commonHelper.js
@@ -1,5 +1,9 @@
 // @flow
 
+export const concat = (arr: []) => arr.reduce((a, b) => a.concat(b), []);
+
+export const flatmap = (ar: [], map: Function) => concat(ar.map(map));
+
 export const objectWithoutKey = (key: string) => (obj: Object) => {
   if (!obj.hasOwnProperty(key)) return obj;
 

--- a/frontend/lib/js/form-components/SearchBox.js
+++ b/frontend/lib/js/form-components/SearchBox.js
@@ -53,7 +53,8 @@ const Row = styled("div")`
 `;
 
 type PropsType = {
-  search: string[],
+  // TODO: Disentangle Concept search from PreviousQuery search
+  search: string[] | Object,
   onSearch: string => void,
   onChange: () => void,
   onClearQuery: () => void,
@@ -61,16 +62,14 @@ type PropsType = {
   textAppend?: React.Node,
   placeholder?: string,
   isMulti: boolean,
-  searchResult: Object,
   datasetId: string
 };
 
 const SearchBox = (props: PropsType) => {
   const {
     datasetId,
-    searchResult,
-    isMulti,
     search,
+    isMulti,
     options,
     placeholder,
     textAppend,
@@ -98,7 +97,7 @@ const SearchBox = (props: PropsType) => {
         <div>
           <StyledBaseInput
             placeholder={placeholder || T.translate("search.placeholder")}
-            value={searchResult.query || ""}
+            value={search.query || ""}
             onChange={value => {
               return isEmpty(value)
                 ? onClearQuery()
@@ -112,26 +111,25 @@ const SearchBox = (props: PropsType) => {
               }
             }}
           />
-          {!isEmpty(searchResult.query) && (
+          {!isEmpty(search.query) && (
             <Right>
               <StyledIconButton
                 icon="search"
                 aria-hidden="true"
-                onClick={() => onSearch(datasetId, searchResult.query)}
+                onClick={() => onSearch(datasetId, search.query)}
               />
             </Right>
           )}
-          {searchResult.loading ? (
+          {search.loading ? (
             <AnimatedDots />
           ) : (
-            searchResult.result &&
-            searchResult.totalResults >= 0 && (
+            search.result &&
+            search.resultCount >= 0 && (
               <Row>
                 <TinyText>
                   {T.translate("search.resultLabel", {
-                    numResults: Object.keys(searchResult.result).length,
-                    totalResults: searchResult.totalResults,
-                    duration: (searchResult.duration / 1000.0).toFixed(2)
+                    totalResults: search.resultCount,
+                    duration: (search.duration / 1000.0).toFixed(2)
                   })}
                 </TinyText>
                 {textAppend}

--- a/frontend/lib/js/form-components/SearchBox.js
+++ b/frontend/lib/js/form-components/SearchBox.js
@@ -59,6 +59,7 @@ type PropsType = {
   onClearQuery: () => void,
   options: string[],
   textAppend?: React.Node,
+  placeholder?: string,
   isMulti: boolean,
   searchResult: Object,
   datasetId: string
@@ -71,6 +72,7 @@ const SearchBox = (props: PropsType) => {
     isMulti,
     search,
     options,
+    placeholder,
     textAppend,
     onSearch,
     onChange,
@@ -87,13 +89,15 @@ const SearchBox = (props: PropsType) => {
           value={search.map(t => ({ label: t, value: t }))}
           options={options ? options.map(t => ({ label: t, value: t })) : []}
           onChange={values => onSearch(values.map(v => v.value))}
-          placeholder={T.translate("reactSelect.searchPlaceholder")}
+          placeholder={
+            placeholder || T.translate("reactSelect.searchPlaceholder")
+          }
           noOptionsMessage={() => T.translate("reactSelect.noResults")}
         />
       ) : (
         <div>
           <StyledBaseInput
-            placeholder={T.translate("search.placeholder")}
+            placeholder={placeholder || T.translate("search.placeholder")}
             value={searchResult.query || ""}
             onChange={value => {
               return isEmpty(value)

--- a/frontend/lib/localization/de.yml
+++ b/frontend/lib/localization/de.yml
@@ -246,4 +246,4 @@ authorization:
 
 search:
   placeholder: "Suchen ..."
-  resultLabel: "Zeige {numResults} von {totalResults} Ergebnissen ({duration} s)"
+  resultLabel: "{totalResults} Ergebnisse gefunden ({duration} s)"

--- a/frontend/lib/localization/de.yml
+++ b/frontend/lib/localization/de.yml
@@ -17,6 +17,7 @@ categoryTreeList:
   noTreesExplanation: "Wahrscheinlich ist beim Laden etwas schiefgelaufen. Bitte erneut laden."
   openAll: "Alle aufklappen"
   closeAll: "Einzeln aufklappen"
+  searchPlaceholder: "Konzepte durchsuchen ..."
 
 queryRunner:
   start: "Anfrage starten"

--- a/frontend/lib/localization/de.yml
+++ b/frontend/lib/localization/de.yml
@@ -18,6 +18,8 @@ categoryTreeList:
   openAll: "Alle aufklappen"
   closeAll: "Einzeln aufklappen"
   searchPlaceholder: "Konzepte durchsuchen ..."
+  showMismatches: "Vollständig anzeigen"
+  dontShowMismatches: "Nur Treffer zeigen"
 
 queryRunner:
   start: "Anfrage starten"

--- a/frontend/lib/localization/en.yml
+++ b/frontend/lib/localization/en.yml
@@ -17,6 +17,7 @@ categoryTreeList:
   noTreesExplanation: "Probably due to a network issue. Please try to refresh."
   openAll: "Open all"
   closeAll: "Open individually"
+  searchPlaceholder: "Search concepts ..."
 
 queryRunner:
   start: "Start Query"

--- a/frontend/lib/localization/en.yml
+++ b/frontend/lib/localization/en.yml
@@ -245,4 +245,4 @@ authorization:
 
 search:
   placeholder: "Search ..."
-  resultLabel: "Showing {numResults} of {totalResults} results ({duration} s)"
+  resultLabel: "{totalResults} results found ({duration} s)"

--- a/frontend/lib/localization/en.yml
+++ b/frontend/lib/localization/en.yml
@@ -18,6 +18,8 @@ categoryTreeList:
   openAll: "Open all"
   closeAll: "Open individually"
   searchPlaceholder: "Search concepts ..."
+  showMismatches: "Show all"
+  dontShowMismatches: "Show hits only"
 
 queryRunner:
   start: "Start Query"


### PR DESCRIPTION
This moves searching the concepts into the frontend.

**Why does this work?**
In general, this works because all concepts are lying in the frontend anyways.

It works **in particular**, because the results remain folded with result number indications. That means that not too much has to be rendered directly after searching.

And it's also quite fast.

- I've tested it with roughly ~150,000 concepts and the search is almost instant for me (~0.3s).
- Even with ~80000 results when searching, e.g: "an", the search doesn't take longer than 0.8s.
- Throttling my CPU by 6x, even the longest search didn't take longer than 2.8s.

**Why is it so fast?**
I've made sure the search algorithm has linear time complexity (O(n)) and avoids costly Javascript features, such as object spread.

**Why is that so cool?**
1) Backend search can be removed @awildturtok @thoniTUB. We won't need to maintain the search full-stack anymore.
2) We save a little traffic (we've been pushing ~50k strings through the wire)
3) We save costly backend calculations, which directly translates to: saving hosting costs :-)

**And what's the coolest thing about all of that?**
<img width="154" alt="Bildschirmfoto 2019-04-15 um 21 43 31" src="https://user-images.githubusercontent.com/1403093/56160482-94bc2680-5fc7-11e9-8f20-12ce45e66ce5.png">
