### PR TITLE
Pass an array of children to concept_query in case of an external query

### DIFF
--- a/frontend/lib/js/api/apiHelper.js
+++ b/frontend/lib/js/api/apiHelper.js
@@ -171,7 +171,7 @@ const transformTimebasedQueryToApi = query => ({
 });
 
 const transformExternalQueryToApi = query =>
-  createConceptQuery(createExternal(query));
+  createConceptQuery([createExternal(query)]);
 
 const createExternal = (query: any) => {
   return {

--- a/frontend/lib/js/api/apiHelper.js
+++ b/frontend/lib/js/api/apiHelper.js
@@ -75,14 +75,16 @@ export const transformElementsToApi = conceptGroup =>
   conceptGroup.map(createConcept);
 
 const transformStandardQueryToApi = query =>
-  createConceptQuery(createQueryConcepts(query));
+  createConceptQuery(createAnd(createQueryConcepts(query)));
 
-const createConceptQuery = children => ({
+const createConceptQuery = root => ({
   type: "CONCEPT_QUERY",
-  root: {
-    type: "AND",
-    children: children
-  }
+  root
+});
+
+const createAnd = children => ({
+  type: "AND",
+  children
 });
 
 const createNegation = group => ({
@@ -147,28 +149,27 @@ const getDays = condition => {
   }
 };
 
-const transformTimebasedQueryToApi = query => ({
-  type: "CONCEPT_QUERY",
-  root: {
-    type: "AND",
-    children: query.conditions.map(condition => {
-      const days = getDays(condition);
+const transformTimebasedQueryToApi = query =>
+  createConceptQuery(
+    createAnd(
+      query.conditions.map(condition => {
+        const days = getDays(condition);
 
-      return {
-        type: condition.operator,
-        ...days,
-        preceding: {
-          sampler: condition.result0.timestamp,
-          child: createSavedQuery(condition.result0.id)
-        },
-        index: {
-          sampler: condition.result1.timestamp,
-          child: createSavedQuery(condition.result1.id)
-        }
-      };
-    })
-  }
-});
+        return {
+          type: condition.operator,
+          ...days,
+          preceding: {
+            sampler: condition.result0.timestamp,
+            child: createSavedQuery(condition.result0.id)
+          },
+          index: {
+            sampler: condition.result1.timestamp,
+            child: createSavedQuery(condition.result1.id)
+          }
+        };
+      })
+    )
+  );
 
 const transformExternalQueryToApi = query =>
   createConceptQuery([createExternal(query)]);

--- a/frontend/lib/js/model/query.js
+++ b/frontend/lib/js/model/query.js
@@ -3,12 +3,27 @@
 import type { ConceptQueryNodeType } from "../standard-query-editor/types";
 import { TIMEBASED_OPERATOR_TYPES } from "../common/constants/timebasedQueryOperatorTypes";
 
+function isTimebasedQuery(node) {
+  const queryString = JSON.stringify(node.query);
+
+  Object.values(TIMEBASED_OPERATOR_TYPES).some(
+    op => queryString.indexOf(op) === -1
+  );
+}
+
+// A little weird that it's nested so deeply, but well, you can't expand an external query
+function isExternalQuery(node) {
+  return (
+    node.query.type === "CONCEPT_QUERY" &&
+    node.query.root &&
+    node.query.root.children &&
+    node.query.root.children.length > 0 &&
+    node.query.root.children[0].type === "EXTERNAL"
+  );
+}
+
 export function isQueryExpandable(node: ConceptQueryNodeType) {
   if (!node.isPreviousQuery || !node.query) return false;
 
-  const queryString = JSON.stringify(node.query);
-
-  return Object.values(TIMEBASED_OPERATOR_TYPES).every(
-    op => queryString.indexOf(op) === -1
-  );
+  return !isTimebasedQuery(node) && !isExternalQuery(node);
 }

--- a/frontend/lib/js/model/query.js
+++ b/frontend/lib/js/model/query.js
@@ -16,9 +16,7 @@ function isExternalQuery(node) {
   return (
     node.query.type === "CONCEPT_QUERY" &&
     node.query.root &&
-    node.query.root.children &&
-    node.query.root.children.length > 0 &&
-    node.query.root.children[0].type === "EXTERNAL"
+    node.query.root.type === "EXTERNAL_RESOLVED"
   );
 }
 


### PR DESCRIPTION
**My goal**

Detect and external query and don't allow to "expand it".

**Current status**
Right now, in case of an external query (uploading a query result), the frontend sends a single element as children, like:

```
{
  type: "CONCEPT_QUERY",
  root: {
    type: "AND",
    children: {
      type: "EXTERNAL",
      ...
    }
  }
}
```

Somehow, the backend seems to be able to deal with that, but here, I'm suggesting to change this into:
```
{
  type: "CONCEPT_QUERY",
  root: {
    type: "AND",
    children: [{
      type: "EXTERNAL"
      ...
    }]
  }
}
```

But really, it doesn't seem to be correct to wrap this in `CONCEPT_QUERY` and `AND` in the first place. 

@manuel-hegner @awildturtok What do you think?