### PR TITLE
smaller fixes

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/models/preproc/ImportDescriptor.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/preproc/ImportDescriptor.java
@@ -64,7 +64,7 @@ public class ImportDescriptor extends Labeled<ImportDescriptorId> implements Ser
 			validityHashBuilder
 				.append(input.getSourceFile().length());
 		}
-		validityHashBuilder.append(15);
+		validityHashBuilder.append(16);
 		return validityHashBuilder.toHashCode();
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/types/specific/DecimalTypeScaled.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/types/specific/DecimalTypeScaled.java
@@ -2,7 +2,6 @@ package com.bakdata.conquery.models.types.specific;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.math.RoundingMode;
 
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.models.types.CType;
@@ -51,7 +50,7 @@ public class DecimalTypeScaled<NUMBER, SUB extends CType<NUMBER, IntegerType>> e
 
 	@Override
 	public boolean canStoreNull() {
-		return false;
+		return subType.canStoreNull();
 	}
 
 	public static BigInteger unscale(int scale, BigDecimal value) {

--- a/backend/src/main/java/com/bakdata/conquery/models/types/specific/IntegerType.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/types/specific/IntegerType.java
@@ -36,17 +36,22 @@ public class IntegerType extends CType<Long, IntegerType> {
 
 	@Override
 	public CType<? extends Number, IntegerType> bestSubType() {
-		if(maxValue <= Byte.MAX_VALUE && minValue >= Byte.MIN_VALUE) {
+		if(maxValue+1 <= Byte.MAX_VALUE && minValue >= Byte.MIN_VALUE) {
 			return new IntegerTypeByte(getLines(), getNullLines(), (byte)maxValue, (byte)minValue);
 		}
-		if(maxValue <= Short.MAX_VALUE && minValue >= Short.MIN_VALUE) {
+		if(maxValue+1 <= Short.MAX_VALUE && minValue >= Short.MIN_VALUE) {
 			return new IntegerTypeShort(getLines(), getNullLines(), (short)maxValue, (short)minValue);
 		}
-		if(maxValue <= Integer.MAX_VALUE && minValue >= Integer.MIN_VALUE) {
+		if(maxValue+1 <= Integer.MAX_VALUE && minValue >= Integer.MIN_VALUE) {
 			return new IntegerTypeInteger(getLines(), getNullLines(), (int)maxValue, (int)minValue);
 		}
 		else {
 			return this;
 		}
+	}
+	
+	@Override
+	public boolean canStoreNull() {
+		return true;
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/types/specific/IntegerTypeByte.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/types/specific/IntegerTypeByte.java
@@ -47,4 +47,9 @@ public class IntegerTypeByte extends MinorCType<Byte, IntegerType> {
 	public Long transformToMajorType(Byte value, IntegerType majorType) {
 		return (long)value;
 	}
+	
+	@Override
+	public boolean canStoreNull() {
+		return true;
+	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/types/specific/IntegerTypeInteger.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/types/specific/IntegerTypeInteger.java
@@ -58,4 +58,9 @@ public class IntegerTypeInteger extends MinorCType<Integer, IntegerType> {
 	public Long transformToMajorType(Integer value, IntegerType majorType) {
 		return (long)value;
 	}
+	
+	@Override
+	public boolean canStoreNull() {
+		return true;
+	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/types/specific/IntegerTypeShort.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/types/specific/IntegerTypeShort.java
@@ -47,4 +47,9 @@ public class IntegerTypeShort extends MinorCType<Short, IntegerType> {
 	public Long transformToMajorType(Short value, IntegerType majorType) {
 		return (long)value;
 	}
+	
+	@Override
+	public boolean canStoreNull() {
+		return true;
+	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/types/specific/MoneyTypeByte.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/types/specific/MoneyTypeByte.java
@@ -47,4 +47,9 @@ public class MoneyTypeByte extends MinorCType<Byte, MoneyType> {
 	public Long transformToMajorType(Byte value, MoneyType majorType) {
 		return (long)value;
 	}
+	
+	@Override
+	public boolean canStoreNull() {
+		return true;
+	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/types/specific/MoneyTypeInteger.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/types/specific/MoneyTypeInteger.java
@@ -47,4 +47,9 @@ public class MoneyTypeInteger extends MinorCType<Integer, MoneyType> {
 	public Long transformToMajorType(Integer value, MoneyType majorType) {
 		return (long)value;
 	}
+	
+	@Override
+	public boolean canStoreNull() {
+		return true;
+	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/types/specific/MoneyTypeShort.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/types/specific/MoneyTypeShort.java
@@ -47,4 +47,9 @@ public class MoneyTypeShort extends MinorCType<Short, MoneyType> {
 	public Long transformToMajorType(Short value, MoneyType majorType) {
 		return (long)value;
 	}
+	
+	@Override
+	public boolean canStoreNull() {
+		return true;
+	}
 }

--- a/backend/src/main/resources/com/bakdata/conquery/models/events/generation/BlockFactoryTemplate.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/models/events/generation/BlockFactoryTemplate.ftl
@@ -78,7 +78,7 @@ public class BlockFactory_${suffix} extends BlockFactory {
 				<#if col.type.nullLines == col.type.lines>
 				//all values of ${col.name} are null
 				<#elseif col.type.requiresExternalNullStore()>		
-				if(!nullBits.getBit(${imp.nullWidth}*eventId+${col.nullPosition})) {
+				if(block.has(eventId, ${col.position})) {
 					event.set${safeName(col.name)?cap_first}(<@t.kryoDeserialization type=col.type/>);
 				}
 				<#else>

--- a/backend/src/main/resources/com/bakdata/conquery/models/events/generation/BlockTemplate.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/models/events/generation/BlockTemplate.ftl
@@ -101,7 +101,7 @@ public class Block_${suffix} extends Block {
 		return has(event, column.getPosition());
 	}
 	
-	private boolean has(int event, int columnPosition) {
+	public boolean has(int event, int columnPosition) {
 		switch(columnPosition) {
 	<#list imp.columns as col>
 	<#import "/com/bakdata/conquery/models/events/generation/types/${col.type.class.simpleName}.ftl" as t/>

--- a/backend/src/main/resources/com/bakdata/conquery/models/events/generation/types/IntegerType.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/models/events/generation/types/IntegerType.ftl
@@ -1,4 +1,4 @@
-<#macro nullValue type><#stop "can't store null"/></#macro>
+<#macro nullValue type>${(type.maxValue+1)?c}L</#macro>
 <#macro kryoSerialization type>
 	<#if type.minValue gte 0>
 		output.writeLong(<#nested/>, true)
@@ -13,7 +13,7 @@
 		input.readLong(false)
 	</#if>
 </#macro>
-<#macro nullCheck type><#stop "Tried to generate a null check that is not generateable"/></#macro>
+<#macro nullCheck type><#nested/> == <@nullValue type=type/></#macro>
 <#macro majorTypeTransformation type><#nested></#macro>
 
 <#macro unboxValue> ((Long)<#nested>).longValue() </#macro>

--- a/backend/src/main/resources/com/bakdata/conquery/models/events/generation/types/IntegerTypeByte.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/models/events/generation/types/IntegerTypeByte.ftl
@@ -1,7 +1,7 @@
-<#macro nullValue type><#stop "can't store null"/></#macro>
+<#macro nullValue type>((byte)${(type.maxValue+1)?c})</#macro>
 <#macro kryoSerialization type>output.writeByte(<#nested/>)</#macro>
 <#macro kryoDeserialization type>input.readByte()</#macro>
-<#macro nullCheck type><#stop "Tried to generate a null check that is not generateable"/></#macro>
+<#macro nullCheck type><#nested/> == <@nullValue type=type/></#macro>
 <#macro majorTypeTransformation type>(long)<#nested></#macro>
 
 <#macro unboxValue> ((Byte)<#nested>).byteValue() </#macro>

--- a/backend/src/main/resources/com/bakdata/conquery/models/events/generation/types/IntegerTypeInteger.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/models/events/generation/types/IntegerTypeInteger.ftl
@@ -1,4 +1,4 @@
-<#macro nullValue type><#stop "can't store null"/></#macro>
+<#macro nullValue type>${(type.maxValue+1)?c}</#macro>
 <#macro kryoSerialization type>
 	<#if type.minValue gte 0>
 		output.writeInt(<#nested/>, true)
@@ -13,7 +13,7 @@
 		input.readInt(false)
 	</#if>
 </#macro>
-<#macro nullCheck type><#stop "Tried to generate a null check that is not generateable"/></#macro>
+<#macro nullCheck type><#nested/> == <@nullValue type=type/></#macro>
 <#macro majorTypeTransformation type>(long)<#nested></#macro>
 
 <#macro unboxValue> ((Integer)<#nested>).intValue() </#macro>

--- a/backend/src/main/resources/com/bakdata/conquery/models/events/generation/types/IntegerTypeShort.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/models/events/generation/types/IntegerTypeShort.ftl
@@ -1,7 +1,7 @@
-<#macro nullValue type><#stop "can't store null"/></#macro>
+<#macro nullValue type>((short) ${(type.maxValue+1)?c})</#macro>
 <#macro kryoSerialization type>output.writeShort(<#nested/>)</#macro>
 <#macro kryoDeserialization type>input.readShort()</#macro>
-<#macro nullCheck type><#stop "Tried to generate a null check that is not generateable"/></#macro>
+<#macro nullCheck type><#nested/> ==<@nullValue type=type/></#macro>
 <#macro majorTypeTransformation type>(long)<#nested></#macro>
 
 <#macro unboxValue> ((Short)<#nested>).shortValue() </#macro>

--- a/backend/src/main/resources/com/bakdata/conquery/models/events/generation/types/MoneyType.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/models/events/generation/types/MoneyType.ftl
@@ -1,17 +1,17 @@
-<#macro nullValue type><#stop "can't store null"/></#macro>
+<#macro nullValue type>
+	<#import "/com/bakdata/conquery/models/events/generation/types/IntegerType.ftl" as copy/>
+	<@copy.nullValue type=type/>
+</#macro>
 <#macro kryoSerialization type>
-	<#if type.minValue gte 0>
-		output.writeLong(<#nested/>, true)
-	<#else>
-		output.writeLong(<#nested/>, false)
-	</#if>
+	<#import "/com/bakdata/conquery/models/events/generation/types/IntegerType.ftl" as copy/>
+	<@copy.kryoSerialization type=type><#nested/></@copy.kryoSerialization>
 </#macro>
 <#macro kryoDeserialization type>
-	<#if type.minValue gte 0>
-		input.readLong(true)
-	<#else>
-		input.readLong(false)
-	</#if>
+	<#import "/com/bakdata/conquery/models/events/generation/types/IntegerType.ftl" as copy/>
+	<@copy.kryoDeserialization type=type/>
 </#macro>
-<#macro nullCheck type><#stop "Tried to generate a null check that is not generateable"/></#macro>
+<#macro nullCheck type>
+	<#import "/com/bakdata/conquery/models/events/generation/types/IntegerType.ftl" as copy/>
+	<@copy.nullCheck type=type><#nested/></@copy.nullCheck>
+</#macro>
 <#macro majorTypeTransformation type><#nested></#macro>

--- a/backend/src/main/resources/com/bakdata/conquery/models/events/generation/types/MoneyTypeByte.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/models/events/generation/types/MoneyTypeByte.ftl
@@ -1,5 +1,17 @@
-<#macro nullValue type><#stop "can't store null"/></#macro>
-<#macro kryoSerialization type>output.writeByte(<#nested/>)</#macro>
-<#macro kryoDeserialization type>input.readByte()</#macro>
-<#macro nullCheck type><#stop "Tried to generate a null check that is not generateable"/></#macro>
+<#macro nullValue type>
+	<#import "/com/bakdata/conquery/models/events/generation/types/IntegerTypeByte.ftl" as copy/>
+	<@copy.nullValue type=type/>
+</#macro>
+<#macro kryoSerialization type>
+	<#import "/com/bakdata/conquery/models/events/generation/types/IntegerTypeByte.ftl" as copy/>
+	<@copy.kryoSerialization type=type><#nested/></@copy.kryoSerialization>
+</#macro>
+<#macro kryoDeserialization type>
+	<#import "/com/bakdata/conquery/models/events/generation/types/IntegerTypeByte.ftl" as copy/>
+	<@copy.kryoDeserialization type=type/>
+</#macro>
+<#macro nullCheck type>
+	<#import "/com/bakdata/conquery/models/events/generation/types/IntegerTypeByte.ftl" as copy/>
+	<@copy.nullCheck type=type><#nested/></@copy.nullCheck>
+</#macro>
 <#macro majorTypeTransformation type>(long)<#nested></#macro>

--- a/backend/src/main/resources/com/bakdata/conquery/models/events/generation/types/MoneyTypeInteger.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/models/events/generation/types/MoneyTypeInteger.ftl
@@ -1,17 +1,17 @@
-<#macro nullValue type><#stop "can't store null"/></#macro>
+<#macro nullValue type>
+	<#import "/com/bakdata/conquery/models/events/generation/types/IntegerTypeInteger.ftl" as copy/>
+	<@copy.nullValue type=type/>
+</#macro>
 <#macro kryoSerialization type>
-	<#if type.minValue gte 0>
-		output.writeInt(<#nested/>, true)
-	<#else>
-		output.writeInt(<#nested/>, false)
-	</#if>
+	<#import "/com/bakdata/conquery/models/events/generation/types/IntegerTypeInteger.ftl" as copy/>
+	<@copy.kryoSerialization type=type><#nested/></@copy.kryoSerialization>
 </#macro>
 <#macro kryoDeserialization type>
-	<#if type.minValue gte 0>
-		input.readInt(true)
-	<#else>
-		input.readInt(false)
-	</#if>
+	<#import "/com/bakdata/conquery/models/events/generation/types/IntegerTypeInteger.ftl" as copy/>
+	<@copy.kryoDeserialization type=type/>
 </#macro>
-<#macro nullCheck type><#stop "Tried to generate a null check that is not generateable"/></#macro>
+<#macro nullCheck type>
+	<#import "/com/bakdata/conquery/models/events/generation/types/IntegerTypeInteger.ftl" as copy/>
+	<@copy.nullCheck type=type><#nested/></@copy.nullCheck>
+</#macro>
 <#macro majorTypeTransformation type>(long)<#nested></#macro>

--- a/backend/src/main/resources/com/bakdata/conquery/models/events/generation/types/MoneyTypeShort.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/models/events/generation/types/MoneyTypeShort.ftl
@@ -1,5 +1,17 @@
-<#macro nullValue type><#stop "can't store null"/></#macro>
-<#macro kryoSerialization type>output.writeShort(<#nested/>)</#macro>
-<#macro kryoDeserialization type>input.readShort()</#macro>
-<#macro nullCheck type><#stop "Tried to generate a null check that is not generateable"/></#macro>
+<#macro nullValue type>
+	<#import "/com/bakdata/conquery/models/events/generation/types/IntegerTypeShort.ftl" as copy/>
+	<@copy.nullValue type=type/>
+</#macro>
+<#macro kryoSerialization type>
+	<#import "/com/bakdata/conquery/models/events/generation/types/IntegerTypeShort.ftl" as copy/>
+	<@copy.kryoSerialization type=type><#nested/></@copy.kryoSerialization>
+</#macro>
+<#macro kryoDeserialization type>
+	<#import "/com/bakdata/conquery/models/events/generation/types/IntegerTypeShort.ftl" as copy/>
+	<@copy.kryoDeserialization type=type/>
+</#macro>
+<#macro nullCheck type>
+	<#import "/com/bakdata/conquery/models/events/generation/types/IntegerTypeShort.ftl" as copy/>
+	<@copy.nullCheck type=type><#nested/></@copy.nullCheck>
+</#macro>
 <#macro majorTypeTransformation type>(long)<#nested></#macro>


### PR DESCRIPTION
allowed integer/money types to encode null as an unused number