### PR TITLE
Show descriptions for all query nodes

### DIFF
--- a/frontend/lib/js/category-trees/CategoryTreeNode.js
+++ b/frontend/lib/js/category-trees/CategoryTreeNode.js
@@ -88,9 +88,13 @@ class CategoryTreeNode extends React.Component<PropsType> {
           }}
           createQueryElement={(): DraggedNodeType => {
             const { tables, selects } = getConceptById(data.tree);
+            const description = data.description
+              ? { description: data.description }
+              : {};
 
             return {
               ids: [id],
+              ...description,
               label: data.label,
               tables,
               selects,

--- a/frontend/lib/js/standard-query-editor/QueryNode.js
+++ b/frontend/lib/js/standard-query-editor/QueryNode.js
@@ -46,12 +46,20 @@ const Node = styled("div")`
   padding-top: 2px;
 `;
 
-const Content = styled("p")`
+const Label = styled("p")`
   margin: 0;
-  line-height: 1.2;
   word-break: break-word;
+  line-height: 1.2;
   font-size: ${({ theme }) => theme.font.md};
 `;
+const Description = styled("p")`
+  margin: 3px 0 0;
+  word-break: break-word;
+  line-height: 1.2;
+  text-transform: uppercase;
+  font-size: ${({ theme }) => theme.font.xs};
+`;
+
 const PreviousQueryLabel = styled("p")`
   margin: 0 0 3px;
   line-height: 1.2;
@@ -106,10 +114,12 @@ class QueryNode extends React.Component {
           {node.error ? (
             <StyledErrorMessage message={node.error} />
           ) : (
-            <Content>
-              <span>{node.label || node.id}</span>
-              {node.description && <span> - {node.description}</span>}
-            </Content>
+            <>
+              <Label>{node.label || node.id}</Label>
+              {node.description && (
+                <Description>{node.description}</Description>
+              )}
+            </>
           )}
         </Node>
         <QueryNodeActions
@@ -170,6 +180,7 @@ const nodeSource = {
       return {
         ...draggedNode,
         ids: node.ids,
+        description: node.description,
         tree: node.tree,
         tables: node.tables,
         selects: node.selects

--- a/frontend/lib/js/standard-query-editor/reducer.js
+++ b/frontend/lib/js/standard-query-editor/reducer.js
@@ -108,6 +108,7 @@ const filterItem = (
   else
     return {
       ids: item.ids,
+      description: item.description,
       tables: withDefaultValues(item.tables),
       selects: withDefaultValues(item.selects),
       tree: item.tree,

--- a/frontend/lib/js/standard-query-editor/types.js
+++ b/frontend/lib/js/standard-query-editor/types.js
@@ -116,6 +116,7 @@ export type ConceptQueryNodeType = {
   tree: TreeNodeIdType,
 
   label: string,
+  description?: string,
   excludeTimestamps?: boolean,
   loading?: boolean,
   error?: string,


### PR DESCRIPTION
To mitigate when a concept label doesn't really speak for itself, but the description does, we'll be showing the description now. 

It will look like this:

<img width="480" alt="Bildschirmfoto 2019-05-06 um 17 04 56" src="https://user-images.githubusercontent.com/1403093/57234533-1d574100-7021-11e9-9c05-aa4fd0ad4fdc.png">


