### PR TITLE
Load previous queries iteratively again

### DIFF
--- a/frontend/app/api/stored-queries/25.json
+++ b/frontend/app/api/stored-queries/25.json
@@ -32,13 +32,8 @@
                 "type": "OR",
                 "children": [
                   {
-                    "id": 25602,
-                    "type": "SAVED_QUERY",
-                    "label": "Example query",
-                    "createdAt": "2016-12-02T14:19:09Z",
-                    "status": "DONE",
-                    "numberOfResults": 2465,
-                    "resultUrl": "/api/results/1234-123123123-123123-1231.csv"
+                    "query": "25602",
+                    "type": "SAVED_QUERY"
                   },
                   {
                     "ids": ["action_movies"],

--- a/frontend/lib/js/standard-query-editor/Query.js
+++ b/frontend/lib/js/standard-query-editor/Query.js
@@ -138,8 +138,8 @@ const mapDispatchToProps = (dispatch: Dispatch<*>) => ({
   selectNodeForEditing: (andIdx, orIdx) =>
     dispatch(selectNodeForEditing(andIdx, orIdx)),
   queryGroupModalSetNode: andIdx => dispatch(queryGroupModalSetNode(andIdx)),
-  expandPreviousQuery: (rootConcepts, query) =>
-    dispatch(expandPreviousQuery(rootConcepts, query)),
+  expandPreviousQuery: (datasetId, rootConcepts, queryId) =>
+    dispatch(expandPreviousQuery(datasetId, rootConcepts, queryId)),
   loadPreviousQuery: (datasetId, queryId) =>
     dispatch(loadPreviousQuery(datasetId, queryId))
 });
@@ -150,8 +150,12 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   ...ownProps,
   loadPreviousQuery: queryId =>
     dispatchProps.loadPreviousQuery(ownProps.selectedDatasetId, queryId),
-  expandPreviousQuery: query =>
-    dispatchProps.expandPreviousQuery(stateProps.rootConcepts, query)
+  expandPreviousQuery: queryId =>
+    dispatchProps.expandPreviousQuery(
+      ownProps.selectedDatasetId,
+      stateProps.rootConcepts,
+      queryId
+    )
 });
 
 export default connect(

--- a/frontend/lib/js/standard-query-editor/QueryNodeActions.js
+++ b/frontend/lib/js/standard-query-editor/QueryNodeActions.js
@@ -27,8 +27,9 @@ const Actions = styled("div")`
 `;
 
 const StyledFaIcon = styled(FaIcon)`
-  padding: 4px 6px;
+  margin: 7px 6px 4px;
 `;
+
 const StyledIconButton = styled(IconButton)`
   padding: 4px 6px;
 `;

--- a/frontend/lib/js/standard-query-editor/reducer.js
+++ b/frontend/lib/js/standard-query-editor/reducer.js
@@ -530,7 +530,6 @@ const expandNode = (rootConcepts, node) => {
       return {
         ...node,
         id: node.query,
-        query: node.resolvedQuery,
         isPreviousQuery: true
       };
     case "DATE_RESTRICTION":
@@ -573,15 +572,8 @@ const expandNode = (rootConcepts, node) => {
 // a) merge elements with concept data from category trees (esp. "tables")
 // b) load nested previous queries contained in that query,
 //    so they can also be expanded
-const expandPreviousQuery = (
-  state,
-  action: { payload: { groups: QueryGroupType[] } }
-) => {
+const expandPreviousQuery = (state, action) => {
   const { rootConcepts, query } = action.payload;
-
-  if (!query.root || query.root.type !== "AND") {
-    throw new Error("Cant expand query, because root is not AND");
-  }
 
   return query.root.children.map(child => expandNode(rootConcepts, child));
 };


### PR DESCRIPTION
Doesn't rely on `resolvedQuery` anymore, which was a mistake https://github.com/bakdata/conquery/issues/539

This loads queries iteratively again, when they're expanded