### PR TITLE
Refactor right pane state, less nesting, more flat structure

### DIFF
--- a/frontend/app/src/js/main.js
+++ b/frontend/app/src/js/main.js
@@ -1,8 +1,8 @@
 // @flow
 
 import conquery from "../../../lib/js";
-import { StandardQueryEditorTab } from "../../../lib/js/standard-query-editor";
-import { TimebasedQueryEditorTab } from "../../../lib/js/timebased-query-editor";
+import StandardQueryEditorTab from "../../../lib/js/standard-query-editor";
+import TimebasedQueryEditorTab from "../../../lib/js/timebased-query-editor";
 
 import theme from "../styles/theme";
 

--- a/frontend/lib/js/AppRoot.js
+++ b/frontend/lib/js/AppRoot.js
@@ -4,16 +4,19 @@ import React from "react";
 import { Provider } from "react-redux";
 import { hot } from "react-hot-loader";
 
+import type { TabType } from "./common/types/tabs";
+
 import AppRouter from "./app/AppRouter";
 
 type PropsType = {
   store: Object,
-  browserHistory: Object
+  browserHistory: Object,
+  rightTabs: TabType[]
 };
 
-const AppRoot = ({ store, browserHistory }: PropsType) => (
+const AppRoot = ({ store, browserHistory, rightTabs }: PropsType) => (
   <Provider store={store}>
-    <AppRouter history={browserHistory} />
+    <AppRouter history={browserHistory} rightTabs={rightTabs} />
   </Provider>
 );
 

--- a/frontend/lib/js/app/App.js
+++ b/frontend/lib/js/app/App.js
@@ -14,11 +14,11 @@ const Root = styled("div")`
   position: relative;
 `;
 
-const App = () => (
+const App = props => (
   <Root>
     <Startup />
     <Header />
-    <Content />
+    <Content {...props} />
     <SnackMessage />
   </Root>
 );

--- a/frontend/lib/js/app/AppRouter.js
+++ b/frontend/lib/js/app/AppRouter.js
@@ -2,23 +2,28 @@
 
 import React from "react";
 import { Route, Switch, Router } from "react-router";
+import type { TabType } from "../common/types/tabs";
 
 import { Unauthorized, WithAuthToken } from "../authorization";
 
 import App from "./App";
 
 type PropsType = {
-  history: Object
+  history: Object,
+  rightTabs: TabType[]
 };
 
 const AppWithAuthToken = WithAuthToken(App);
 
-const AppRouter = (props: PropsType) => {
+const AppRouter = ({ history, ...rest }: PropsType) => {
   return (
-    <Router history={props.history}>
+    <Router history={history}>
       <Switch>
         <Route path="/unauthorized" component={Unauthorized} />
-        <Route path="/*" component={AppWithAuthToken} />
+        <Route
+          path="/*"
+          render={routeProps => <AppWithAuthToken {...routeProps} {...rest} />}
+        />
       </Switch>
     </Router>
   );

--- a/frontend/lib/js/app/Content.js
+++ b/frontend/lib/js/app/Content.js
@@ -46,7 +46,7 @@ type PropsType = {
   displayTooltip: boolean
 };
 
-const Content = ({ displayTooltip }: PropsType) => {
+const Content = ({ displayTooltip, rightTabs }: PropsType) => {
   return (
     <Root>
       <SplitPane
@@ -65,7 +65,7 @@ const Content = ({ displayTooltip }: PropsType) => {
           defaultSize="39%"
         >
           <LeftPane />
-          <RightPane />
+          <RightPane tabs={rightTabs} />
         </SplitPane>
       </SplitPane>
       <Preview generator={generatePreview} />

--- a/frontend/lib/js/app/RightPane.js
+++ b/frontend/lib/js/app/RightPane.js
@@ -2,18 +2,23 @@
 
 import React from "react";
 import { connect } from "react-redux";
+import type { TabType } from "../common/types/tabs";
 
 import { Pane } from "../pane";
-import { getRightPaneTabComponent } from "../pane/reducer";
 
 type PropsType = {
+  tabs: TabType[],
   activeTab: string,
   selectedDatasetId: ?string
 };
 
-const RightPane = (props: PropsType) => {
-  const tab = React.createElement(getRightPaneTabComponent(props.activeTab), {
-    selectedDatasetId: props.selectedDatasetId
+const RightPane = ({ tabs, activeTab, selectedDatasetId }: PropsType) => {
+  // Won't be null, since the activeTabs string is built from tabs
+  // during setup
+  const theActiveTab = tabs.find(tab => tab.key === activeTab);
+
+  const tab = React.createElement(theActiveTab.component, {
+    selectedDatasetId: selectedDatasetId
   });
 
   return <Pane right>{tab}</Pane>;

--- a/frontend/lib/js/app/reducers.js
+++ b/frontend/lib/js/app/reducers.js
@@ -35,6 +35,7 @@ import { reducer as snackMessage } from "../snack-message";
 
 import { createQueryNodeEditorReducer } from "../query-node-editor";
 
+// TODO: Introduce more StateTypes gradually
 export type StateType = {
   categoryTrees: CategoryTreesStateType,
   datasets: DatasetsStateType,
@@ -43,8 +44,8 @@ export type StateType = {
   uploadConceptListModal: UploadConceptListModalStateType
 };
 
-const buildAppReducer = tabs =>
-  combineReducers({
+const buildAppReducer = tabs => {
+  return combineReducers({
     startup,
     categoryTrees,
     uploadConceptListModal,
@@ -59,7 +60,12 @@ const buildAppReducer = tabs =>
     previousQueriesFilter,
     uploadQueryResults,
     deletePreviousQueryModal,
-    snackMessage
+    snackMessage,
+    ...tabs.reduce((all, tab) => {
+      all[tab.key] = tab.reducer;
+      return all;
+    }, {})
   });
+};
 
 export default buildAppReducer;

--- a/frontend/lib/js/authorization/WithAuthToken.js
+++ b/frontend/lib/js/authorization/WithAuthToken.js
@@ -24,7 +24,9 @@ const WithAuthToken = (Component: any) => {
     }
 
     render() {
-      return <Component />;
+      const { location, ...rest } = this.props;
+
+      return <Component {...rest} />;
     }
   }
 

--- a/frontend/lib/js/common/types/tabs.js
+++ b/frontend/lib/js/common/types/tabs.js
@@ -1,0 +1,11 @@
+// @flow
+
+import * as React from "react";
+
+// Used for right pane tabs at the moment
+export type TabType = {
+  key: string,
+  label: string, // Translatable key
+  reducer: Function, // combineReducers({ ... }) will be spread on root, see app/reducers.js
+  component: React.ComponentType<any> // The tab contents
+};

--- a/frontend/lib/js/dataset/DatasetSelector.js
+++ b/frontend/lib/js/dataset/DatasetSelector.js
@@ -59,7 +59,7 @@ const mapStateToProps = state => ({
   selectedDatasetId: state.datasets.selectedDatasetId,
   datasets: state.datasets.data,
   error: state.datasets.error,
-  query: state.panes.right.tabs.queryEditor.query
+  query: state.queryEditor.query
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/frontend/lib/js/index.js
+++ b/frontend/lib/js/index.js
@@ -38,7 +38,7 @@ const renderRoot = (tabs: Object, theme) => {
 
   ReactDOM.render(
     <ThemeProvider theme={theme}>
-      <AppRoot store={store} browserHistory={browserHistory} />
+      <AppRoot store={store} browserHistory={browserHistory} rightTabs={tabs} />
     </ThemeProvider>,
     document.getElementById("root")
   );

--- a/frontend/lib/js/pane/reducer.js
+++ b/frontend/lib/js/pane/reducer.js
@@ -1,7 +1,5 @@
 // @flow
 
-import { combineReducers } from "redux";
-
 import { CLICK_PANE_TAB } from "./actionTypes";
 
 export type TabType = {
@@ -16,38 +14,11 @@ export type StateType = {
   },
   right: {
     activeTab: string,
-    tabs: Object
+    tabs: TabType[]
   }
 };
 
-// Keep a map of React components for the available tabs outside the Redux state
-// Kai's comment: This is really ugly, but at least, this keeps all of the "tabs" magic in this one file
-// TODO: Think about some other way
-const registerRightPaneTabComponents = components => {
-  window.rightPaneTabComponents = components;
-};
-
-export const getRightPaneTabComponent = tab => {
-  return window.rightPaneTabComponents[tab];
-};
-
 export const buildPanesReducer = tabs => {
-  // Collect reducers
-  const tabsReducers = tabs.reduce((all, tab) => {
-    all[tab.description.key] = tab.reducer;
-
-    return all;
-  }, {});
-  const tabsComponents = tabs.reduce((all, tab) => {
-    all[tab.description.key] = tab.component;
-
-    return all;
-  }, {});
-
-  registerRightPaneTabComponents(tabsComponents);
-
-  const defaultTab = tabs[0];
-
   const initialState: StateType = {
     left: {
       activeTab: "categoryTrees",
@@ -57,11 +28,10 @@ export const buildPanesReducer = tabs => {
       ]
     },
     right: {
-      activeTab: defaultTab.description.key
+      activeTab: tabs[0].key,
+      tabs: tabs.map(tab => ({ label: tab.label, key: tab.key }))
     }
   };
-
-  const rightPaneTabsReducer = combineReducers(tabsReducers);
 
   return (state: StateType = initialState, action: Object): StateType => {
     switch (action.type) {
@@ -76,13 +46,7 @@ export const buildPanesReducer = tabs => {
           }
         };
       default:
-        return {
-          ...state,
-          right: {
-            ...state.right,
-            tabs: rightPaneTabsReducer(state.right.tabs, action)
-          }
-        };
+        return state;
     }
   };
 };

--- a/frontend/lib/js/query-group-modal/QueryGroupModal.js
+++ b/frontend/lib/js/query-group-modal/QueryGroupModal.js
@@ -105,10 +105,7 @@ function findGroup(query, andIdx) {
 }
 
 const mapStateToProps = state => ({
-  group: findGroup(
-    state.panes.right.tabs.queryEditor.query,
-    state.queryGroupModal.andIdx
-  ),
+  group: findGroup(state.queryEditor.query, state.queryGroupModal.andIdx),
   andIdx: state.queryGroupModal.andIdx
 });
 

--- a/frontend/lib/js/standard-query-editor/Query.js
+++ b/frontend/lib/js/standard-query-editor/Query.js
@@ -117,8 +117,8 @@ const Query = (props: PropsType) => {
 
 function mapStateToProps(state) {
   return {
-    query: state.panes.right.tabs.queryEditor.query,
-    isEmptyQuery: state.panes.right.tabs.queryEditor.query.length === 0,
+    query: state.queryEditor.query,
+    isEmptyQuery: state.queryEditor.query.length === 0,
 
     // only used by other actions
     rootConcepts: state.categoryTrees.trees

--- a/frontend/lib/js/standard-query-editor/QueryClearButton.js
+++ b/frontend/lib/js/standard-query-editor/QueryClearButton.js
@@ -32,7 +32,7 @@ const QueryClearButton = (props: PropsType) => {
 };
 
 const mapStateToProps = state => ({
-  isVisible: state.panes.right.tabs.queryEditor.query.length !== 0
+  isVisible: state.queryEditor.query.length !== 0
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/frontend/lib/js/standard-query-editor/StandardQueryNodeEditor.js
+++ b/frontend/lib/js/standard-query-editor/StandardQueryNodeEditor.js
@@ -28,7 +28,7 @@ const findNodeBeingEdited = query =>
     .find(element => element.isEditing);
 
 const mapStateToProps = state => {
-  const node = findNodeBeingEdited(state.panes.right.tabs.queryEditor.query);
+  const node = findNodeBeingEdited(state.queryEditor.query);
 
   const showTables =
     node &&

--- a/frontend/lib/js/standard-query-editor/StandardQueryRunner.js
+++ b/frontend/lib/js/standard-query-editor/StandardQueryRunner.js
@@ -12,20 +12,20 @@ function isButtonEnabled(state, ownProps) {
   return !!// Return true or false even if all are undefined / null
   (
     ownProps.datasetId !== null &&
-    !state.panes.right.tabs.queryEditor.queryRunner.startQuery.loading &&
-    !state.panes.right.tabs.queryEditor.queryRunner.stopQuery.loading &&
-    state.panes.right.tabs.queryEditor.query.length > 0
+    !state.queryEditor.queryRunner.startQuery.loading &&
+    !state.queryEditor.queryRunner.stopQuery.loading &&
+    state.queryEditor.query.length > 0
   );
 }
 
 const mapStateToProps = (state, ownProps) => ({
-  queryRunner: state.panes.right.tabs.queryEditor.queryRunner,
+  queryRunner: state.queryEditor.queryRunner,
   isButtonEnabled: isButtonEnabled(state, ownProps),
-  isQueryRunning: !!state.panes.right.tabs.queryEditor.queryRunner.runningQuery,
+  isQueryRunning: !!state.queryEditor.queryRunner.runningQuery,
   // Following ones only needed in dispatch functions
-  queryId: state.panes.right.tabs.queryEditor.queryRunner.runningQuery,
+  queryId: state.queryEditor.queryRunner.runningQuery,
   version: state.categoryTrees.version,
-  query: state.panes.right.tabs.queryEditor.query
+  query: state.queryEditor.query
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/frontend/lib/js/standard-query-editor/index.js
+++ b/frontend/lib/js/standard-query-editor/index.js
@@ -1,22 +1,22 @@
 // @flow
 
+import { combineReducers } from "redux";
+import type { TabType } from "../common/types/tabs";
+
 import { createQueryRunnerReducer } from "../query-runner";
 import { default as queryReducer } from "./reducer";
 import StandardQueryEditorTab from "./StandardQueryEditorTab";
 
 const queryRunnerReducer = createQueryRunnerReducer("standard");
 
-const standardQueryEditorTabDescription = {
+const Tab: TabType = {
   key: "queryEditor",
-  label: "rightPane.queryEditor"
-};
-
-export default {
-  description: standardQueryEditorTabDescription,
-  reducer: (state = standardQueryEditorTabDescription, action) => ({
-    ...state,
-    query: queryReducer(state.query, action),
-    queryRunner: queryRunnerReducer(state.queryRunner, action)
+  label: "rightPane.queryEditor",
+  reducer: combineReducers({
+    query: queryReducer,
+    queryRunner: queryRunnerReducer
   }),
   component: StandardQueryEditorTab
 };
+
+export default Tab;

--- a/frontend/lib/js/timebased-query-editor/TimebasedQueryClearButton.js
+++ b/frontend/lib/js/timebased-query-editor/TimebasedQueryClearButton.js
@@ -36,11 +36,8 @@ const TimebasedQueryClearButton = (props: PropsType) => {
 
 const mapStateToProps = state => ({
   isEnabled:
-    state.panes.right.tabs.timebasedQueryEditor.timebasedQuery.conditions
-      .length > 1 ||
-    anyConditionFilled(
-      state.panes.right.tabs.timebasedQueryEditor.timebasedQuery
-    )
+    state.timebasedQueryEditor.timebasedQuery.conditions.length > 1 ||
+    anyConditionFilled(state.timebasedQueryEditor.timebasedQuery)
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/frontend/lib/js/timebased-query-editor/TimebasedQueryEditor.js
+++ b/frontend/lib/js/timebased-query-editor/TimebasedQueryEditor.js
@@ -98,7 +98,7 @@ const TimebasedQueryEditor = (props: PropsType) => {
 };
 
 const mapStateToProps = state => ({
-  query: state.panes.right.tabs.timebasedQueryEditor.timebasedQuery
+  query: state.timebasedQueryEditor.timebasedQuery
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/frontend/lib/js/timebased-query-editor/TimebasedQueryRunner.js
+++ b/frontend/lib/js/timebased-query-editor/TimebasedQueryRunner.js
@@ -10,27 +10,21 @@ const { startTimebasedQuery, stopTimebasedQuery } = actions;
 function isButtonEnabled(state, ownProps) {
   return !!(
     ownProps.datasetId !== null &&
-    !state.panes.right.tabs.timebasedQueryEditor.timebasedQueryRunner.startQuery
-      .loading &&
-    !state.panes.right.tabs.timebasedQueryEditor.timebasedQueryRunner.stopQuery
-      .loading &&
-    allConditionsFilled(
-      state.panes.right.tabs.timebasedQueryEditor.timebasedQuery
-    )
+    !state.timebasedQueryEditor.timebasedQueryRunner.startQuery.loading &&
+    !state.timebasedQueryEditor.timebasedQueryRunner.stopQuery.loading &&
+    allConditionsFilled(state.timebasedQueryEditor.timebasedQuery)
   );
 }
 
 const mapStateToProps = (state, ownProps) => ({
-  queryRunner: state.panes.right.tabs.timebasedQueryEditor.timebasedQueryRunner,
+  queryRunner: state.timebasedQueryEditor.timebasedQueryRunner,
   isButtonEnabled: isButtonEnabled(state, ownProps),
-  isQueryRunning: !!state.panes.right.tabs.timebasedQueryEditor
-    .timebasedQueryRunner.runningQuery,
+  isQueryRunning: !!state.timebasedQueryEditor.timebasedQueryRunner
+    .runningQuery,
   // Following ones only needed in dispatch functions
-  queryId:
-    state.panes.right.tabs.timebasedQueryEditor.timebasedQueryRunner
-      .runningQuery,
+  queryId: state.timebasedQueryEditor.timebasedQueryRunner.runningQuery,
   version: state.categoryTrees.version,
-  query: state.panes.right.tabs.timebasedQueryEditor.timebasedQuery
+  query: state.timebasedQueryEditor.timebasedQuery
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/frontend/lib/js/timebased-query-editor/index.js
+++ b/frontend/lib/js/timebased-query-editor/index.js
@@ -1,25 +1,22 @@
+import { combineReducers } from "redux";
+
+import type { TabType } from "../common/types/tabs";
 import { createQueryRunnerReducer } from "../query-runner";
 import { default as timebasedQueryReducer } from "./reducer";
 import TimebasedQueryEditorTab from "./TimebasedQueryEditorTab";
 
 const timebasedQueryRunnerReducer = createQueryRunnerReducer("timebased");
 
-const timebasedQueryEditorTabDescription = {
-  key: "timebasedQueryEditor",
-  label: "rightPane.timebasedQueryEditor"
-};
-
 export * as actions from "./actions";
 
-export default {
-  description: timebasedQueryEditorTabDescription,
-  reducer: (state = timebasedQueryEditorTabDescription, action) => ({
-    ...state,
-    timebasedQuery: timebasedQueryReducer(state.timebasedQuery, action),
-    timebasedQueryRunner: timebasedQueryRunnerReducer(
-      state.timebasedQueryRunner,
-      action
-    )
+const Tab: TabType = {
+  key: "timebasedQueryEditor",
+  label: "rightPane.timebasedQueryEditor",
+  reducer: combineReducers({
+    timebasedQuery: timebasedQueryReducer,
+    timebasedQueryRunner: timebasedQueryRunnerReducer
   }),
   component: TimebasedQueryEditorTab
 };
+
+export default Tab;


### PR DESCRIPTION
This gets us from `state.panes.right.tabs.queryEditor` to `state.queryEditor`, which is important for modifying the external form state very soon.