### PR TITLE
Use excludeTimestamps and description on expand

### DIFF
--- a/frontend/app/api/stored-queries/25.json
+++ b/frontend/app/api/stored-queries/25.json
@@ -7,115 +7,106 @@
   "version": 0,
   "tags": ["Fun"],
   "query": {
-    "queryId": "0f104f67-949c-49aa-9023-66722caa1a5d",
-    "shared": false,
-
-    "creationTime": "2019-03-12T17:26:00.621428",
-    "dataset": "demo",
-    "label": "myquery",
-    "lastResultCount": 1899,
-    "owner": "user.SUPERUSER$40SUPERUSER",
-    "query": {
-      "type": "CONCEPT_QUERY",
-      "root": {
-        "type": "AND",
-        "children": [
-          {
-            "type": "NEGATION",
+    "type": "CONCEPT_QUERY",
+    "root": {
+      "type": "AND",
+      "children": [
+        {
+          "type": "NEGATION",
+          "child": {
+            "type": "DATE_RESTRICTION",
+            "dateRange": {
+              "min": "1969-12-01",
+              "max": "2012-01-31"
+            },
             "child": {
-              "type": "DATE_RESTRICTION",
-              "dateRange": {
-                "min": "1969-12-01",
-                "max": "2012-01-31"
-              },
-              "child": {
-                "type": "OR",
-                "children": [
-                  {
-                    "query": "25602",
-                    "type": "SAVED_QUERY"
-                  },
-                  {
-                    "ids": ["action_movies"],
-                    "type": "CONCEPT",
-                    "selects": ["123456789"],
-                    "tables": [
-                      {
-                        "id": "feature_films",
-                        "selects": ["12345678"],
-                        "filters": [
-                          {
-                            "filter": "budget",
-                            "value": {
-                              "min": 10000000,
-                              "max": 150000000
-                            }
+              "type": "OR",
+              "children": [
+                {
+                  "query": "25602",
+                  "type": "SAVED_QUERY"
+                },
+                {
+                  "ids": ["action_movies"],
+                  "type": "CONCEPT",
+                  "excludeFromTimeAggregation": true,
+                  "selects": ["123456789"],
+                  "tables": [
+                    {
+                      "id": "feature_films",
+                      "selects": ["12345678"],
+                      "filters": [
+                        {
+                          "filter": "budget",
+                          "value": {
+                            "min": 10000000,
+                            "max": 150000000
                           }
-                        ]
-                      },
-                      {
-                        "id": "tv_series"
-                      }
-                    ]
-                  },
-                  {
-                    "ids": ["horror_movies"],
-                    "type": "CONCEPT",
-                    "tables": [
-                      {
-                        "id": "feature_films",
-                        "filters": [
-                          {
-                            "filter": "studio",
-                            "value": "universal"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
+                        }
+                      ]
+                    },
+                    {
+                      "id": "tv_series"
+                    }
+                  ]
+                },
+                {
+                  "ids": ["horror_movies"],
+                  "type": "CONCEPT",
+                  "tables": [
+                    {
+                      "id": "feature_films",
+                      "filters": [
+                        {
+                          "filter": "studio",
+                          "value": "universal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             }
-          },
-          {
-            "type": "OR",
-            "children": [
-              {
-                "ids": ["best_actor_award"],
-                "type": "CONCEPT",
-                "tables": [
-                  {
-                    "id": "awards",
-                    "filters": [
-                      {
-                        "filter": "award_type",
-                        "type": "MULTI_SELECT",
-                        "value": ["won"]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "ids": ["best_actress_award"],
-                "type": "CONCEPT",
-                "tables": [
-                  {
-                    "id": "awards",
-                    "filters": [
-                      {
-                        "filter": "award_type",
-                        "type": "MULTI_SELECT",
-                        "value": ["won"]
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
           }
-        ]
-      }
+        },
+        {
+          "type": "OR",
+          "children": [
+            {
+              "ids": ["best_actor_award"],
+              "type": "CONCEPT",
+              "tables": [
+                {
+                  "id": "awards",
+                  "filters": [
+                    {
+                      "filter": "award_type",
+                      "type": "MULTI_SELECT",
+                      "value": ["won"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "ids": ["best_actress_award"],
+              "type": "CONCEPT",
+              "tables": [
+                {
+                  "id": "awards",
+                  "filters": [
+                    {
+                      "filter": "award_type",
+                      "type": "MULTI_SELECT",
+                      "value": ["won"]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/frontend/lib/js/standard-query-editor/reducer.js
+++ b/frontend/lib/js/standard-query-editor/reducer.js
@@ -553,12 +553,16 @@ const expandNode = (rootConcepts, node) => {
 
       const { tables, selects } = mergeFromSavedConcept(lookupResult, node);
       const label = node.label || lookupResult.concepts[0].label;
+      const description =
+        node.description || lookupResult.concepts[0].description;
 
       return {
         ...node,
         label,
+        description,
         tables,
         selects,
+        excludeTimestamps: node.excludeFromTimeAggregation,
         tree: lookupResult.root
       };
   }


### PR DESCRIPTION
This fixes expanding queries, when they include concepts that have timestamps excluded. Also draws the description from the lookup-node