### PR TITLE
Feature/validate query dates

### DIFF
--- a/frontend/lib/js/model/query.js
+++ b/frontend/lib/js/model/query.js
@@ -1,6 +1,9 @@
 // @flow
 
-import type { ConceptQueryNodeType } from "../standard-query-editor/types";
+import type {
+  ConceptQueryNodeType,
+  StandardQueryType
+} from "../standard-query-editor/types";
 import { TIMEBASED_OPERATOR_TYPES } from "../common/constants/timebasedQueryOperatorTypes";
 
 function isTimebasedQuery(node) {
@@ -24,4 +27,22 @@ export function isQueryExpandable(node: ConceptQueryNodeType) {
   if (!node.isPreviousQuery || !node.query) return false;
 
   return !isTimebasedQuery(node) && !isExternalQuery(node);
+}
+
+// Validation
+
+export function validateQueryLength(query: StandardQueryType) {
+  return query.length > 0;
+}
+
+function elementHasValidDates(element) {
+  return !element.excludeTimestamps;
+}
+
+function groupHasValidDates(group) {
+  return !group.exclude && group.elements.some(elementHasValidDates);
+}
+
+export function validateQueryDates(query: StandardQueryType) {
+  return !query || query.length === 0 || query.some(groupHasValidDates);
 }

--- a/frontend/lib/js/query-runner/QueryRunner.js
+++ b/frontend/lib/js/query-runner/QueryRunner.js
@@ -3,8 +3,10 @@
 import React from "react";
 import styled from "@emotion/styled";
 import Hotkeys from "react-hot-keys";
+import T from "i18n-react";
 
 import Preview from "../preview/Preview";
+import WithTooltip from "../tooltip/WithTooltip";
 
 import QueryResults from "./QueryResults";
 import QueryRunningSpinner from "./QueryRunningSpinner";
@@ -15,6 +17,7 @@ type PropsType = {
   queryRunner: Object,
   isQueryRunning: boolean,
   isButtonEnabled: boolean,
+  buttonTooltipKey?: ?string,
   startQuery: Function,
   stopQuery: Function
 };
@@ -47,6 +50,7 @@ const QueryRunner = (props: PropsType) => {
     queryRunner,
     startQuery,
     stopQuery,
+    buttonTooltipKey,
     isQueryRunning,
     isButtonEnabled
   } = props;
@@ -66,12 +70,16 @@ const QueryRunner = (props: PropsType) => {
       />
       <Preview />
       <Left>
-        <QueryRunnerButton
-          onClick={btnAction}
-          isStartStopLoading={isStartStopLoading}
-          isQueryRunning={isQueryRunning}
-          disabled={!isButtonEnabled}
-        />
+        <WithTooltip
+          text={buttonTooltipKey ? T.translate(buttonTooltipKey) : null}
+        >
+          <QueryRunnerButton
+            onClick={btnAction}
+            isStartStopLoading={isStartStopLoading}
+            isQueryRunning={isQueryRunning}
+            disabled={!isButtonEnabled}
+          />
+        </WithTooltip>
       </Left>
       <Right>
         <LoadingGroup>

--- a/frontend/lib/js/standard-query-editor/StandardQueryRunner.js
+++ b/frontend/lib/js/standard-query-editor/StandardQueryRunner.js
@@ -8,25 +8,53 @@ import actions from "../app/actions";
 
 const { startStandardQuery, stopStandardQuery } = actions;
 
-function isButtonEnabled(state, ownProps) {
-  return !!// Return true or false even if all are undefined / null
-  (
-    ownProps.datasetId !== null &&
-    !state.queryEditor.queryRunner.startQuery.loading &&
-    !state.queryEditor.queryRunner.stopQuery.loading &&
-    state.queryEditor.query.length > 0
-  );
+function validateQueryStartStop(queryRunner) {
+  return !queryRunner.startQuery.loading && !queryRunner.stopQuery.loading;
 }
 
-const mapStateToProps = (state, ownProps) => ({
-  queryRunner: state.queryEditor.queryRunner,
-  isButtonEnabled: isButtonEnabled(state, ownProps),
-  isQueryRunning: !!state.queryEditor.queryRunner.runningQuery,
-  // Following ones only needed in dispatch functions
-  queryId: state.queryEditor.queryRunner.runningQuery,
-  version: state.conceptTrees.version,
-  query: state.queryEditor.query
-});
+function validateDataset(datasetId) {
+  return datasetId !== null;
+}
+
+function validateQueryLength(query) {
+  return query.length > 0;
+}
+
+function validateQueryDates(query) {
+  return true;
+}
+
+function getButtonTooltipKey(hasQueryValidDates) {
+  if (!hasQueryValidDates) {
+    return "tooltip";
+  }
+
+  return null;
+}
+
+const mapStateToProps = (state, ownProps) => {
+  const { query, queryRunner } = state.queryEditor;
+
+  const isDatasetValid = validateDataset(ownProps.datasetId);
+  const hasQueryValidDates = validateQueryDates(query);
+  const isQueryValid = validateQueryLength(query) && hasQueryValidDates;
+  const isQueryNotStartedOrStopped = validateQueryStartStop(queryRunner);
+
+  const isButtonEnabled =
+    isDatasetValid && isQueryValid && isQueryNotStartedOrStopped;
+
+  const buttonTooltipKey = getButtonTooltipKey(hasQueryValidDates);
+
+  return {
+    buttonTooltipKey,
+    isButtonEnabled,
+    query,
+    queryRunner,
+    isQueryRunning: !!queryRunner.runningQuery,
+    queryId: queryRunner.runningQuery,
+    version: state.conceptTrees.version
+  };
+};
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   startQuery: (datasetId, query, version) =>

--- a/frontend/lib/js/standard-query-editor/StandardQueryRunner.js
+++ b/frontend/lib/js/standard-query-editor/StandardQueryRunner.js
@@ -4,6 +4,9 @@ import { connect } from "react-redux";
 import type { Dispatch } from "redux-thunk";
 
 import { QueryRunner } from "../query-runner";
+
+import { validateQueryLength, validateQueryDates } from "../model/query";
+
 import actions from "../app/actions";
 
 const { startStandardQuery, stopStandardQuery } = actions;
@@ -16,18 +19,12 @@ function validateDataset(datasetId) {
   return datasetId !== null;
 }
 
-function validateQueryLength(query) {
-  return query.length > 0;
-}
-
-function validateQueryDates(query) {
-  return true;
-}
-
 function getButtonTooltipKey(hasQueryValidDates) {
   if (!hasQueryValidDates) {
-    return "tooltip";
+    return "queryRunner.errorDates";
   }
+
+  // Potentially add further validation and more detailed messages
 
   return null;
 }

--- a/frontend/lib/js/tooltip/WithTooltip.js
+++ b/frontend/lib/js/tooltip/WithTooltip.js
@@ -1,7 +1,6 @@
 // @flow
 
 import * as React from "react";
-import styled from "@emotion/styled";
 import { Tooltip } from "react-tippy";
 import "react-tippy/dist/tippy.css";
 
@@ -9,10 +8,12 @@ type PropsType = {
   className?: string,
   children: React.Node,
   place?: string,
-  text?: string
+  text?: ?string
 };
 
 const WithTooltip = ({ className, children, place, text }: PropsType) => {
+  if (!text) return children;
+
   return (
     <Tooltip
       className={className}

--- a/frontend/lib/localization/de.yml
+++ b/frontend/lib/localization/de.yml
@@ -25,6 +25,7 @@ conceptTreeList:
   showingMismatches: "Zeige vollständig"
 
 queryRunner:
+  errorDates: "Invalider Datumsbereich"
   start: "Anfrage starten"
   stop: "Anfrage stoppen"
   stopSuccess: "Anfrage erfolgreich gestoppt."

--- a/frontend/lib/localization/en.yml
+++ b/frontend/lib/localization/en.yml
@@ -25,6 +25,7 @@ conceptTreeList:
   showingMismatches: "Showing full trees"
 
 queryRunner:
+  errorDates: "Invalid date range"
   start: "Start Query"
   stop: "Stop Query"
   stopSuccess: "Query was successfully stopped."


### PR DESCRIPTION
This allows to only start queries in the frontend, when they contain at least one column with valid dates.

One column has valid dates if 
- it's not excluded
- at least one concept does NOT have excluded timestamps.