### PR TITLE
Add an insert all button and options display

### DIFF
--- a/frontend/lib/js/form-components/InputMultiSelect.js
+++ b/frontend/lib/js/form-components/InputMultiSelect.js
@@ -10,6 +10,7 @@ import Mustache from "mustache";
 
 import type { SelectOptionsT } from "../api/types";
 import { isEmpty } from "../common/helpers";
+import TransparentButton from "../button/TransparentButton";
 import InfoTooltip from "../tooltip/InfoTooltip";
 
 import InputMultiSelectDropzone from "./InputMultiSelectDropzone";
@@ -38,23 +39,46 @@ const SxReactSelect = styled(ReactSelect)`
   width: 100%;
 `;
 
+const SxMarkdown = styled(Markdown)`
+  p {
+    margin: 0;
+  }
+`;
+
+const Row = styled("div")`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 10px;
+  border-bottom: 1px solid #ccc;
+`;
+
+const InfoText = styled("p")`
+  margin: 0;
+  color: ${({ theme }) => theme.col.gray};
+  font-size: ${({ theme }) => theme.font.xs};
+  margin-right: 10px;
+`;
+
+// Arbitrary number that has been set in the backend as well
+// TODO: Unlimited here + paginated backend vs
 const OPTIONS_LIMIT = 50;
+
+const MultiValueLabel = params => {
+  const label = params.data.optionLabel || params.data.label || params.data;
+  const valueLabel = params.data.templateValues
+    ? Mustache.render(label, params.data.templateValues)
+    : label;
+
+  return (
+    <components.MultiValueLabel {...params}>
+      <span>{valueLabel}</span>
+    </components.MultiValueLabel>
+  );
+};
 
 const InputMultiSelect = (props: PropsType) => {
   const allowDropFile = props.allowDropFile && !!props.onDropFile;
-
-  const MultiValueLabel = params => {
-    const label = params.data.optionLabel || params.data.label || params.data;
-    const valueLabel = params.data.templateValues
-      ? Mustache.render(label, params.data.templateValues)
-      : label;
-
-    return (
-      <components.MultiValueLabel {...params}>
-        <span>{valueLabel}</span>
-      </components.MultiValueLabel>
-    );
-  };
 
   const hasTooManyValues =
     props.input.value && props.input.value.length > OPTIONS_LIMIT;
@@ -71,6 +95,27 @@ const InputMultiSelect = (props: PropsType) => {
       optionLabel: option.label
     }));
 
+  const MenuList = ({ children, ...ownProps }) => {
+    return (
+      <div>
+        <Row>
+          <InfoText>
+            {props.options.length || 0}{" "}
+            {T.translate("inputMultiSelect.options")}
+          </InfoText>
+          <TransparentButton
+            tiny
+            disabled={props.options.length === 0}
+            onClick={() => ownProps.setValue(props.options)}
+          >
+            {T.translate("inputMultiSelect.insertAll")}
+          </TransparentButton>
+        </Row>
+        <components.MenuList {...ownProps}>{children}</components.MenuList>
+      </div>
+    );
+  };
+
   const Select = (
     <SxReactSelect
       creatable
@@ -80,7 +125,7 @@ const InputMultiSelect = (props: PropsType) => {
       createOptionPosition="first"
       name="form-field"
       options={options}
-      components={{ MultiValueLabel }}
+      components={{ MultiValueLabel, MenuList }}
       value={props.input.value}
       isDisabled={props.disabled}
       isLoading={!!props.isLoading}
@@ -102,7 +147,7 @@ const InputMultiSelect = (props: PropsType) => {
       }
       formatOptionLabel={({ label, optionValue, templateValues, highlight }) =>
         optionValue && templateValues ? (
-          <Markdown source={Mustache.render(optionValue, templateValues)} />
+          <SxMarkdown source={Mustache.render(optionValue, templateValues)} />
         ) : (
           label
         )

--- a/frontend/lib/localization/de.yml
+++ b/frontend/lib/localization/de.yml
@@ -149,6 +149,8 @@ inputDateRange:
 
 inputMultiSelect:
   openFileDialog: "Datei auswählen"
+  insertAll: "Alle einfügen"
+  options: "Werte"
 
 previousQueries:
   loading: "Lade Anfragen"

--- a/frontend/lib/localization/en.yml
+++ b/frontend/lib/localization/en.yml
@@ -149,6 +149,8 @@ inputDateRange:
 
 inputMultiSelect:
   openFileDialog: "Select file"
+  insertAll: "Insert all"
+  options: "options"
 
 previousQueries:
   loading: "Loading queries"


### PR DESCRIPTION
This adds
- options count display
- insert all button

to `InputMultiSelect`

The amount of auto-complete options returned by the backend is limited to 50. We'll need to think about pagination here together, before I can do more on the frontend side.