### PR TITLE
csv column names can be configured in the config via script

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/apiv1/ResultCSVResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/ResultCSVResource.java
@@ -44,10 +44,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ResultCSVResource {
 
+	private static final PrintSettings PRINT_SETTINGS = new PrintSettings(ConqueryConfig.getInstance().getCsv().getColumnNamerScript());
 	public static final URLBuilderPath GET_CSV_PATH = new URLBuilderPath(ResultCSVResource.class, "getAsCSV");
 	private final Namespaces namespaces;
 	private final ConqueryConfig config;
-	private PrintSettings printSettings = null;
 
 	@GET
 	@Path("{" + QUERY + "}.csv")
@@ -56,13 +56,9 @@ public class ResultCSVResource {
 		authorize(user, datasetId, Ability.READ);
 		authorize(user, queryId, Ability.READ);
 		
-		if (printSettings == null) {			
-			printSettings = new PrintSettings(config.getCsv().getColumnNamerScript());
-		}
-		
 		try {
 			ManagedExecution exec = namespaces.getMetaStorage().getExecution(queryId);
-			Stream<String> csv = new QueryToCSVRenderer().toCSV(printSettings, exec.toResultQuery());
+			Stream<String> csv = new QueryToCSVRenderer().toCSV(PRINT_SETTINGS, exec.toResultQuery());
 
 			log.info("Querying results for {}", queryId);
 			StreamingOutput out = new StreamingOutput() {

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/ResultCSVResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/ResultCSVResource.java
@@ -47,7 +47,7 @@ public class ResultCSVResource {
 	public static final URLBuilderPath GET_CSV_PATH = new URLBuilderPath(ResultCSVResource.class, "getAsCSV");
 	private final Namespaces namespaces;
 	private final ConqueryConfig config;
-		
+	private PrintSettings printSettings = null;
 
 	@GET
 	@Path("{" + QUERY + "}.csv")
@@ -56,7 +56,9 @@ public class ResultCSVResource {
 		authorize(user, datasetId, Ability.READ);
 		authorize(user, queryId, Ability.READ);
 		
-		PrintSettings printSettings = new PrintSettings(config.getCsv().getColumnNamerScript());
+		if (printSettings == null) {			
+			printSettings = new PrintSettings(config.getCsv().getColumnNamerScript());
+		}
 		
 		try {
 			ManagedExecution exec = namespaces.getMetaStorage().getExecution(queryId);

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/ResultCSVResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/ResultCSVResource.java
@@ -45,9 +45,9 @@ import lombok.extern.slf4j.Slf4j;
 public class ResultCSVResource {
 
 	public static final URLBuilderPath GET_CSV_PATH = new URLBuilderPath(ResultCSVResource.class, "getAsCSV");
-	private static final PrintSettings PRINT_SETTINGS = new PrintSettings(true);
 	private final Namespaces namespaces;
 	private final ConqueryConfig config;
+		
 
 	@GET
 	@Path("{" + QUERY + "}.csv")
@@ -55,10 +55,12 @@ public class ResultCSVResource {
 	public Response getAsCSV(@Auth User user, @PathParam(DATASET) DatasetId datasetId, @PathParam(QUERY) ManagedExecutionId queryId) {
 		authorize(user, datasetId, Ability.READ);
 		authorize(user, queryId, Ability.READ);
-
+		
+		PrintSettings printSettings = new PrintSettings(config.getCsv().getColumnNamerScript());
+		
 		try {
 			ManagedExecution exec = namespaces.getMetaStorage().getExecution(queryId);
-			Stream<String> csv = new QueryToCSVRenderer().toCSV(PRINT_SETTINGS, exec.toResultQuery());
+			Stream<String> csv = new QueryToCSVRenderer().toCSV(printSettings, exec.toResultQuery());
 
 			log.info("Querying results for {}", queryId);
 			StreamingOutput out = new StreamingOutput() {

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/ResultCSVResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/ResultCSVResource.java
@@ -44,7 +44,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ResultCSVResource {
 
-	private static final PrintSettings PRINT_SETTINGS = new PrintSettings(ConqueryConfig.getInstance().getCsv().getColumnNamerScript());
+	private static final PrintSettings PRINT_SETTINGS = new PrintSettings(true, ConqueryConfig.getInstance().getCsv().getColumnNamerScript());
 	public static final URLBuilderPath GET_CSV_PATH = new URLBuilderPath(ResultCSVResource.class, "getAsCSV");
 	private final Namespaces namespaces;
 	private final ConqueryConfig config;

--- a/backend/src/main/java/com/bakdata/conquery/models/config/CSVConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/CSVConfig.java
@@ -32,6 +32,7 @@ public class CSVConfig {
 	 * Script used to generate the CSV column names from CQConcept and Select information.
 	 * The script has an instance of SelectResultInfo named columnInfo available to construct the name.
 	 */
+	@ValidColumnNamer
 	private String columnNamerScript = "java.lang.String.format(\"%s %s\",columnInfo.getCqConcept().getLabel(),columnInfo.getSelect().getLabel())";
 	
 	public CsvParserSettings createCsvParserSettings() {

--- a/backend/src/main/java/com/bakdata/conquery/models/config/CSVConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/CSVConfig.java
@@ -32,7 +32,7 @@ public class CSVConfig {
 	 * Script used to generate the CSV column names from CQConcept and Select information.
 	 * The script has an instance of SelectResultInfo named columnInfo available to construct the name.
 	 */
-	private String columnNamerScript = null;
+	private String columnNamerScript = "java.lang.String.format(\"%s %s\",columnInfo.getCqConcept().getLabel(),columnInfo.getSelect().getLabel())";
 	
 	public CsvParserSettings createCsvParserSettings() {
 		CsvParserSettings settings = new CsvParserSettings();

--- a/backend/src/main/java/com/bakdata/conquery/models/config/CSVConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/CSVConfig.java
@@ -28,6 +28,11 @@ public class CSVConfig {
 	@NotNull
 	private Charset encoding = StandardCharsets.UTF_8;
 	private boolean skipHeader = true;
+	/**
+	 * Script used to generate the CSV column names from CQConcept and Select information.
+	 * The script has an instance of SelectResultInfo named columnInfo available to construct the name.
+	 */
+	private String columnNamerScript = null;
 	
 	public CsvParserSettings createCsvParserSettings() {
 		CsvParserSettings settings = new CsvParserSettings();

--- a/backend/src/main/java/com/bakdata/conquery/models/config/ColumnNamerValidator.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/ColumnNamerValidator.java
@@ -48,8 +48,7 @@ public class ColumnNamerValidator implements ConstraintValidator<ValidColumnName
 
 	@Override
 	public void initialize(ValidColumnNamer constraintAnnotation) {
-		
-		
+		// Nothing to initialize
 	}
 
 	@Override
@@ -92,7 +91,7 @@ public class ColumnNamerValidator implements ConstraintValidator<ValidColumnName
 		}
 		
 		
-		log.info("Configured column namer script is okay.");
+		log.info(String.format("Configured column namer script is okay: %s", scriptString));
 		
 		return true;
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/config/ColumnNamerValidator.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/ColumnNamerValidator.java
@@ -83,7 +83,7 @@ public class ColumnNamerValidator implements ConstraintValidator<ValidColumnName
 		
 		// Check if script handles a simple SelectResultInfo
 		try {
-			script.run();			
+			script.run();
 		}
 		catch (Exception e) {
 			context.buildConstraintViolationWithTemplate(String.format("Column Namer Script failed execution: %s",e)).addConstraintViolation();

--- a/backend/src/main/java/com/bakdata/conquery/models/config/ColumnNamerValidator.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/ColumnNamerValidator.java
@@ -1,0 +1,91 @@
+package com.bakdata.conquery.models.config;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import org.codehaus.groovy.control.CompilationFailedException;
+import org.codehaus.groovy.control.CompilerConfiguration;
+
+import com.bakdata.conquery.models.concepts.select.Select;
+import com.bakdata.conquery.models.query.PrintSettings;
+import com.bakdata.conquery.models.query.concept.specific.CQConcept;
+import com.bakdata.conquery.models.query.queryplan.aggregators.Aggregator;
+import com.bakdata.conquery.models.query.resultinfo.SelectResultInfo;
+
+import groovy.lang.GroovyShell;
+import groovy.lang.Script;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This validator checks a common use case for the column name creation. It may be extended.
+ * For now the parsing, compilation and a column name creation based on the labels is checked.
+ *
+ */
+@Slf4j
+public class ColumnNamerValidator implements ConstraintValidator<ValidColumnNamer, String> {
+	private static final String SELECT_NAME = "selectName";
+	private static final String CONCEPT_NAME = "conceptName";
+	
+	private static final CQConcept CQ_CONCEPT = new CQConcept();
+	private static final Select SELECT = new Select() {
+		@Override
+		public Aggregator<?> createAggregator() {
+			return null;
+		}
+	};
+	
+	static {
+		CQ_CONCEPT.setLabel(CONCEPT_NAME);
+		SELECT.setName(SELECT_NAME);
+	}
+	
+	private final GroovyShell groovyShell = new GroovyShell(new CompilerConfiguration());
+	
+
+	@Override
+	public void initialize(ValidColumnNamer constraintAnnotation) {
+		
+		
+	}
+
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		context.disableDefaultConstraintViolation();
+		String scriptString = value;
+
+		log.info("Checking configured column namer script");
+		
+		
+		/*
+		 * Instantiate a column info. Be aware that this instance is not fully resolved (e.g. json backreferences are not set),
+		 * so the validator might fail if the script intents to use these.
+		 * Regarding this aspect, the validator has to be extend.
+		 */
+		SelectResultInfo columnInfo = new SelectResultInfo(SELECT, CQ_CONCEPT);
+		
+		groovyShell.setProperty(PrintSettings.GROOVY_VARIABLE, columnInfo);
+
+		// Check if script can be parsed
+		Script script;
+		try {
+			script  = groovyShell.parse(scriptString);
+		}
+		catch (CompilationFailedException e) {
+			context.buildConstraintViolationWithTemplate(String.format("Column Namer Script could not be parsed/compiled: %s", e)).addConstraintViolation();
+			return false;
+		}
+		
+		
+		// Check if script handles a simple SelectResultInfo
+		try {
+			script.run();			
+		}
+		catch (Exception e) {
+			context.buildConstraintViolationWithTemplate(String.format("Column Namer Script failed execution: %s",e)).addConstraintViolation();
+			return false;
+		}
+		
+		return true;
+	}
+
+}

--- a/backend/src/main/java/com/bakdata/conquery/models/config/ValidColumnNamer.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/ValidColumnNamer.java
@@ -1,0 +1,24 @@
+package com.bakdata.conquery.models.config;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+
+
+@Retention(RUNTIME)
+@Target({ FIELD, PARAMETER })
+@Constraint(validatedBy = ColumnNamerValidator.class)
+public @interface ValidColumnNamer {
+	String message() default "ColumnNamerScript Validation Error";
+
+	Class<?>[] groups() default { };
+	
+	Class<? extends Payload>[] payload() default { };
+}

--- a/backend/src/main/java/com/bakdata/conquery/models/config/ValidColumnNamer.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/ValidColumnNamer.java
@@ -11,7 +11,10 @@ import javax.validation.Constraint;
 import javax.validation.Payload;
 
 
-
+/*
+ * Annotation to mark a String for validation as a column name generator.
+ * The validation includes parsing and an exemplary execution of the script.
+ */
 @Retention(RUNTIME)
 @Target({ FIELD, PARAMETER })
 @Constraint(validatedBy = ColumnNamerValidator.class)

--- a/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
@@ -27,7 +27,7 @@ public class PrintSettings implements SelectNameExtractor {
 	
 
 	/**
-	 * Generates the name for a query result column. 
+	 * Generates the name for a query result column.
 	 * The name is either determined by a configured script or by a standard procedure
 	 */
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 
 import org.codehaus.groovy.control.CompilerConfiguration;
 
+import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.query.resultinfo.SelectNameExtractor;
 import com.bakdata.conquery.models.query.resultinfo.SelectResultInfo;
 import com.google.common.base.Strings;
@@ -11,17 +12,20 @@ import com.google.common.base.Strings;
 import groovy.lang.GroovyShell;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
-@Getter @AllArgsConstructor @NoArgsConstructor @ToString
+@Getter @RequiredArgsConstructor @AllArgsConstructor @ToString
 public class PrintSettings implements SelectNameExtractor {
 	public static final String GROOVY_VARIABLE = "columnInfo";
 	/**
 	 * Non static shell because thread safety is not given.
 	 */
 	private final GroovyShell groovyShell = new GroovyShell(new CompilerConfiguration());
+
+	private final boolean prettyPrint;
 	private String columnNamerScript = null;
+	
 
 	/**
 	 * Generates the name for a query result column. 
@@ -29,7 +33,7 @@ public class PrintSettings implements SelectNameExtractor {
 	 */
 	@Override
 	public String columnName(SelectResultInfo columnInfo) {
-		if(isPrettyPrint()) {
+		if(prettyPrint && !Strings.isNullOrEmpty(columnNamerScript)) {
 			// Use the provided script
 			groovyShell.setProperty(GROOVY_VARIABLE, columnInfo);
 			Object result = groovyShell.evaluate(columnNamerScript);
@@ -37,15 +41,7 @@ public class PrintSettings implements SelectNameExtractor {
 		}
 		else {
 			// Use the standard procedure
-			return Objects.toString(columnInfo.getSelect().getId().toStringWithoutDataset());
+			return String.format("%s %s",columnInfo.getCqConcept().getLabel(),columnInfo.getSelect().getLabel());
 		}
-	}
-	
-	/**
-	 * Determines if column names and values in the columns have a special formating.
-	 * @return True if pretty print should be used.
-	 */
-	public boolean isPrettyPrint() {
-		return !Strings.isNullOrEmpty(columnNamerScript);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
@@ -26,7 +26,7 @@ public class PrintSettings implements SelectNameExtractor {
 
 	private final boolean prettyPrint;
 	/**
-	 * Assuming the Script has already been validated (from loading the config)
+	 * Assuming the Script has already been validated (from loading the config).
 	 */
 	private String columnNamerScript = null;
 	
@@ -41,7 +41,7 @@ public class PrintSettings implements SelectNameExtractor {
 			// Use the provided script
 			groovyShell.setProperty(GROOVY_VARIABLE, columnInfo);
 			Object result = groovyShell.evaluate(columnNamerScript);
-			if(result != null) {				
+			if(result != null) {
 				return Objects.toString(result);
 			}
 			log.info("The column namer script returned null: {}\nFalling back to standard format",columnNamerScript);

--- a/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
@@ -1,23 +1,36 @@
 package com.bakdata.conquery.models.query;
 
+import java.util.Objects;
+
+import org.codehaus.groovy.control.CompilerConfiguration;
+
 import com.bakdata.conquery.models.query.resultinfo.SelectNameExtractor;
 import com.bakdata.conquery.models.query.resultinfo.SelectResultInfo;
 
+import groovy.lang.GroovyShell;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-@Getter @AllArgsConstructor @ToString
+@Getter @AllArgsConstructor @NoArgsConstructor @ToString
 public class PrintSettings implements SelectNameExtractor {
-	private boolean prettyPrint = true;
+	private final GroovyShell groovyShell = new GroovyShell(new CompilerConfiguration());
+	private String columnNamerScript = null;
 
 	@Override
 	public String columnName(SelectResultInfo info) {
-		if(prettyPrint) {
-			return info.getSelect().getLabel();
+		if(columnNamerScript != null) {
+			groovyShell.setProperty("columnInfo", info);
+			Object result = groovyShell.evaluate(columnNamerScript);
+			return Objects.toString(result);
 		}
 		else {
 			return info.getSelect().getId().toStringWithoutDataset();
 		}
+	}
+	
+	public boolean isPrettyPrint() {
+		return columnNamerScript != null;
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
@@ -16,7 +16,10 @@ import lombok.ToString;
 
 @Getter @AllArgsConstructor @NoArgsConstructor @ToString
 public class PrintSettings implements SelectNameExtractor {
-	private static final String GROOVY_VARIABLE = "columnInfo";
+	public static final String GROOVY_VARIABLE = "columnInfo";
+	/**
+	 * Non static shell because thread safety is not given.
+	 */
 	private final GroovyShell groovyShell = new GroovyShell(new CompilerConfiguration());
 	private String columnNamerScript = null;
 

--- a/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
@@ -4,7 +4,6 @@ import java.util.Objects;
 
 import org.codehaus.groovy.control.CompilerConfiguration;
 
-import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.query.resultinfo.SelectNameExtractor;
 import com.bakdata.conquery.models.query.resultinfo.SelectResultInfo;
 import com.google.common.base.Strings;
@@ -33,7 +32,7 @@ public class PrintSettings implements SelectNameExtractor {
 	 */
 	@Override
 	public String columnName(SelectResultInfo columnInfo) {
-		if(prettyPrint && !Strings.isNullOrEmpty(columnNamerScript)) {
+		if(!Strings.isNullOrEmpty(columnNamerScript)) {
 			// Use the provided script
 			groovyShell.setProperty(GROOVY_VARIABLE, columnInfo);
 			Object result = groovyShell.evaluate(columnNamerScript);

--- a/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
@@ -20,13 +20,13 @@ public class PrintSettings implements SelectNameExtractor {
 
 	@Override
 	public String columnName(SelectResultInfo info) {
-		if(columnNamerScript != null) {
+		if(columnNamerScript != null || !columnNamerScript.isEmpty()) {
 			groovyShell.setProperty("columnInfo", info);
 			Object result = groovyShell.evaluate(columnNamerScript);
 			return Objects.toString(result);
 		}
 		else {
-			return info.getSelect().getId().toStringWithoutDataset();
+			return String.format("%s %s",info.getCqConcept().getLabel(),info.getSelect().getLabel());
 		}
 	}
 	

--- a/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
@@ -13,7 +13,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Getter @RequiredArgsConstructor @AllArgsConstructor @ToString
 public class PrintSettings implements SelectNameExtractor {
 	public static final String GROOVY_VARIABLE = "columnInfo";
@@ -23,6 +25,9 @@ public class PrintSettings implements SelectNameExtractor {
 	private final GroovyShell groovyShell = new GroovyShell(new CompilerConfiguration());
 
 	private final boolean prettyPrint;
+	/**
+	 * Assuming the Script has already been validated (from loading the config)
+	 */
 	private String columnNamerScript = null;
 	
 
@@ -36,11 +41,14 @@ public class PrintSettings implements SelectNameExtractor {
 			// Use the provided script
 			groovyShell.setProperty(GROOVY_VARIABLE, columnInfo);
 			Object result = groovyShell.evaluate(columnNamerScript);
-			return Objects.toString(result);
+			if(result != null) {				
+				return Objects.toString(result);
+			}
+			log.info("The column namer script returned null: {}\nFalling back to standard format",columnNamerScript);
 		}
-		else {
-			// Use the standard procedure
-			return String.format("%s %s",columnInfo.getCqConcept().getLabel(),columnInfo.getSelect().getLabel());
-		}
+		
+		// Use the standard procedure
+		return String.format("%s %s",columnInfo.getCqConcept().getLabel(),columnInfo.getSelect().getLabel());
+		
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/query/QueryToCSVRenderer.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/QueryToCSVRenderer.java
@@ -31,7 +31,7 @@ public class QueryToCSVRenderer {
 	private static final CsvWriterSettings CSV_SETTINGS =  ConqueryConfig.getInstance().getCsv().createCsvWriterSettings();
 	private static final IdMappingConfig ID_MAPPING = ConqueryConfig.getInstance().getIdMapping();
 	private static final Collection<String> HEADER = Arrays.asList(ID_MAPPING.getPrintIdFields());
-	private static final PrintSettings PRINT_SETTINGS = new PrintSettings(ConqueryConfig.getInstance().getCsv().getColumnNamerScript());
+	private static final PrintSettings PRINT_SETTINGS = new PrintSettings(true, ConqueryConfig.getInstance().getCsv().getColumnNamerScript());
 	
 	public Stream<String> toCSV(ManagedQuery query) {
 		return toCSV(PRINT_SETTINGS, query);

--- a/backend/src/main/java/com/bakdata/conquery/models/query/QueryToCSVRenderer.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/QueryToCSVRenderer.java
@@ -31,9 +31,10 @@ public class QueryToCSVRenderer {
 	private static final CsvWriterSettings CSV_SETTINGS =  ConqueryConfig.getInstance().getCsv().createCsvWriterSettings();
 	private static final IdMappingConfig ID_MAPPING = ConqueryConfig.getInstance().getIdMapping();
 	private static final Collection<String> HEADER = Arrays.asList(ID_MAPPING.getPrintIdFields());
+	private static final PrintSettings PRINT_SETTINGS = new PrintSettings(ConqueryConfig.getInstance().getCsv().getColumnNamerScript());
 	
 	public Stream<String> toCSV(ManagedQuery query) {
-		return toCSV(new PrintSettings(ConqueryConfig.getInstance().getCsv().getColumnNamerScript()), query);
+		return toCSV(PRINT_SETTINGS, query);
 	}
 	
 	public Stream<String> toCSV(PrintSettings cfg, ManagedQuery query) {

--- a/backend/src/main/java/com/bakdata/conquery/models/query/QueryToCSVRenderer.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/QueryToCSVRenderer.java
@@ -33,7 +33,7 @@ public class QueryToCSVRenderer {
 	private static final Collection<String> HEADER = Arrays.asList(ID_MAPPING.getPrintIdFields());
 	
 	public Stream<String> toCSV(ManagedQuery query) {
-		return toCSV(new PrintSettings(true), query);
+		return toCSV(new PrintSettings(ConqueryConfig.getInstance().getCsv().getColumnNamerScript()), query);
 	}
 	
 	public Stream<String> toCSV(PrintSettings cfg, ManagedQuery query) {

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/AbstractQueryEngineTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/AbstractQueryEngineTest.java
@@ -36,7 +36,7 @@ public abstract class AbstractQueryEngineTest extends ConqueryTestSpec {
 	protected abstract ResourceFile getExpectedCsv();
 
 	@JsonIgnore
-	private static final PrintSettings PRINT_SETTINGS = new PrintSettings(false);
+	private static final PrintSettings PRINT_SETTINGS = new PrintSettings();
 
 	@Override
 	public void executeTest(StandaloneSupport standaloneSupport) throws IOException, JSONException {

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/AbstractQueryEngineTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/AbstractQueryEngineTest.java
@@ -36,7 +36,7 @@ public abstract class AbstractQueryEngineTest extends ConqueryTestSpec {
 	protected abstract ResourceFile getExpectedCsv();
 
 	@JsonIgnore
-	private static final PrintSettings PRINT_SETTINGS = new PrintSettings(false);
+	private static final PrintSettings PRINT_SETTINGS = new PrintSettings(false,"columnInfo.getSelect().getId().toStringWithoutDataset()");
 
 	@Override
 	public void executeTest(StandaloneSupport standaloneSupport) throws IOException, JSONException {

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/AbstractQueryEngineTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/AbstractQueryEngineTest.java
@@ -36,7 +36,7 @@ public abstract class AbstractQueryEngineTest extends ConqueryTestSpec {
 	protected abstract ResourceFile getExpectedCsv();
 
 	@JsonIgnore
-	private static final PrintSettings PRINT_SETTINGS = new PrintSettings();
+	private static final PrintSettings PRINT_SETTINGS = new PrintSettings(false);
 
 	@Override
 	public void executeTest(StandaloneSupport standaloneSupport) throws IOException, JSONException {

--- a/backend/src/test/java/com/bakdata/conquery/models/externalservice/ResultTypeTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/models/externalservice/ResultTypeTest.java
@@ -24,8 +24,8 @@ import com.google.common.collect.ImmutableMap;
 public class ResultTypeTest {
 
 	private static final String COLUMN_NAMER = "columnInfo.getSelect().getId().toStringWithoutDataset()";
-	private static final PrintSettings PRETTY = new PrintSettings(COLUMN_NAMER);
-	private static final PrintSettings PLAIN = new PrintSettings();
+	private static final PrintSettings PRETTY = new PrintSettings(true);
+	private static final PrintSettings PLAIN = new PrintSettings(false);
 	
 	public static Stream<Arguments> testData() {
 		//init global default config

--- a/backend/src/test/java/com/bakdata/conquery/models/externalservice/ResultTypeTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/models/externalservice/ResultTypeTest.java
@@ -23,8 +23,9 @@ import com.google.common.collect.ImmutableMap;
 @Execution(ExecutionMode.SAME_THREAD)
 public class ResultTypeTest {
 
-	private static final PrintSettings PRETTY = new PrintSettings(true);
-	private static final PrintSettings PLAIN = new PrintSettings(false);
+	private static final String COLUMN_NAMER = "columnInfo.getSelect().getId().toStringWithoutDataset()";
+	private static final PrintSettings PRETTY = new PrintSettings(COLUMN_NAMER);
+	private static final PrintSettings PLAIN = new PrintSettings();
 	
 	public static Stream<Arguments> testData() {
 		//init global default config

--- a/backend/src/test/java/com/bakdata/conquery/models/types/ColumnNamerTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/models/types/ColumnNamerTest.java
@@ -1,0 +1,59 @@
+package com.bakdata.conquery.models.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.bakdata.conquery.models.config.ValidColumnNamer;
+
+public class ColumnNamerTest {
+	
+	private static Validator validator;
+
+	@BeforeAll
+	public static void setUpValidator() {
+		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+		validator = factory.getValidator();
+	}
+	
+	// TEST null script
+
+	private static class NullScript{
+		@ValidColumnNamer
+		private String SCRIPT_NULL = null;
+	}
+    
+    @Test
+    void scriptIsNull () {
+    	assertThat(validator.validate(new NullScript())).isNotEmpty();
+    }
+    
+    // TEST empty script
+
+	private static class EmptyScript{
+		@ValidColumnNamer
+		private String SCRIPT_NULL = "";
+	}
+    
+    @Test
+    void scriptIsEmpty () {
+    	assertThat(validator.validate(new EmptyScript())).isNotEmpty();
+    }
+    
+    // TEST valid script
+
+	private static class ValidScript{
+		@ValidColumnNamer
+		private String SCRIPT_NULL = "java.lang.String.format(\"%s %s\",columnInfo.getCqConcept().getLabel(),columnInfo.getSelect().getLabel())";
+	}
+    
+    @Test
+    void scriptIsValid () {
+    	assertThat(validator.validate(new ValidScript())).isEmpty();
+    }
+}


### PR DESCRIPTION
The output of the CSV column names can be now optionally configured via a groovy script in the config:
There for add:
```
{
	"csv": {
		"delimeter": ";",
		"columnNamerScript": "java.lang.String.format(\"%s %s\",columnInfo.getCqConcept().getLabel(),columnInfo.getSelect().getLabel())"
	},
```
where `columnNamerScript` represents the script that is taken to generate the column name.
The object `columnInfo` is of the type SelectResultInfo.
The here presented script represents the standard column output, when `columnNamerScript` is not defined. 