### PR TITLE
Add forms endpoint to get configured forms

### DIFF
--- a/frontend/lib/js/api/api.js
+++ b/frontend/lib/js/api/api.js
@@ -14,7 +14,8 @@ import type {
   GetStoredQueryResponseT,
   PostConceptResolveResponseT,
   PostFilterResolveResponseT,
-  PostFilterSuggestionsResponseT
+  PostFilterSuggestionsResponseT,
+  GetFormQueriesResponseT
 } from "./types";
 
 import fetchJson from "./fetchJson";
@@ -107,6 +108,12 @@ export function getFormQuery(
   queryId: QueryIdT
 ): Promise<GetQueryResponseT> {
   return fetchJson(apiUrl() + `/datasets/${datasetId}/form-queries/${queryId}`);
+}
+
+export function getForms(
+  datasetId: DatasetIdT
+): Promise<GetFormQueriesResponseT> {
+  return fetchJson(apiUrl() + `/datasets/${datasetId}/form-queries`);
 }
 
 export function getStoredQueries(

--- a/frontend/lib/js/api/form-types.js
+++ b/frontend/lib/js/api/form-types.js
@@ -1,0 +1,180 @@
+// @flow
+
+/* ------------------------------ */
+/* COMMON, FORMS, TABS */
+/* ------------------------------ */
+type TranslatableString = {
+  de: string,
+  en?: string
+};
+
+export type Forms = Form[];
+
+export type FormField = Field | Tabs;
+
+export type Form = {
+  type: string, // Sent to backend API
+  title: TranslatableString, // Displayed
+  headline: TranslatableString, // Displayed
+  fields: FormField[]
+};
+
+type Tabs = {
+  name: string, // Sent to backend API
+  type: "TABS",
+  tabs: Tab[],
+  defaultValue: string // corresponds to Tab.name
+};
+
+type Tab = {
+  name: string, // // Sent to backend API
+  title: TranslatableString,
+  fields: Field[]
+};
+
+/* ------------------------------ */
+/* VALIDATIONS */
+/* ------------------------------ */
+type NOT_EMPTY_VALIDATION = "NOT_EMPTY";
+type GREATER_THAN_ZERO_VALIDATION = "GREATER_THAN_ZERO";
+
+/* ------------------------------ */
+/* FIELDS AND THEIR VALIDATIONS */
+/* ------------------------------ */
+type Field =
+  | CheckboxField
+  | StringField
+  | NumberField
+  | SelectField
+  | DatasetSelectField
+  | MultiSelectField
+  | ResultGroupField
+  | MultiResultGroupField
+  | ConceptListField
+  | DateRangeField;
+
+type CommonField = {
+  name: string, // Sent to backend API
+  label: TranslatableString // Used to display
+};
+
+/* ------------------------------ */
+
+type CheckboxField = CommonField & {
+  type: "CHECKBOX",
+  defaultValue?: boolean // Default: False
+};
+
+/* ------------------------------ */
+
+type StringFieldValidation = NOT_EMPTY_VALIDATION;
+type StringField = CommonField & {
+  type: "STRING",
+  placeholder?: TranslatableString,
+  defaultValue?: string, // Default: ""
+  style?: {
+    fullWidth?: boolean // Default: False
+  },
+  pattern?: string, // Regex to validate, using double backslashes, e.g.: "^(?!-)\\\\d*$"
+  validations?: StringFieldValidation[]
+};
+
+/* ------------------------------ */
+
+type NumberFieldValidation =
+  | NOT_EMPTY_VALIDATION
+  | GREATER_THAN_ZERO_VALIDATION;
+type NumberField = CommonField & {
+  type: "NUMBER",
+  defaultValue?: number, // Default: null
+  placeholder?: TranslatableString,
+  pattern?: string, // Regex to validate, using double backslashes, e.g.: "^(?!-)\\\\d*$"
+  step?: string,
+  min?: number,
+  max?: number,
+  validations?: NumberFieldValidation[]
+};
+
+/* ------------------------------ */
+
+type SelectValue = string;
+type SelectOption = {
+  label: TranslatableString,
+  value: SelectValue
+};
+type SelectFieldValidation = NOT_EMPTY_VALIDATION;
+type SelectField = CommonField & {
+  type: "SELECT",
+  options: SelectOption[],
+  defaultValue?: SelectValue,
+  validations?: SelectFieldValidation[]
+};
+type DatasetSelectField = CommonField & {
+  type: "DATASET_SELECT",
+  validations?: SelectFieldValidation[]
+};
+
+/* ------------------------------ */
+
+type MultiSelectField = CommonField & {
+  type: "MULTI_SELECT",
+  options: SelectOption[],
+  defaultOption?: SelectValue,
+  validations?: SelectFieldValidation[]
+};
+
+/* ------------------------------ */
+
+type DateRangeFieldValidation = NOT_EMPTY_VALIDATION;
+type DateRangeField = CommonField & {
+  type: "DATE_RANGE",
+  validations?: DateRangeFieldValidation[]
+};
+
+/* ------------------------------ */
+
+type ResultGroupFieldValidation = NOT_EMPTY_VALIDATION;
+type ResultGroupField = CommonField & {
+  type: "RESULT_GROUP",
+  dropzoneLabel: TranslatableString,
+  validations?: ResultGroupFieldValidation[]
+};
+
+/* ------------------------------ */
+
+type MultiResultGroupField = CommonField & {
+  type: "MULTI_RESULT_GROUP",
+  dropzoneLabel: TranslatableString,
+  validations?: ResultGroupFieldValidation[]
+};
+
+/* ------------------------------ */
+
+type SelectName = string;
+export type ConnectorDefault = {
+  name: string,
+  selects: SelectName[]
+};
+export type ConceptListDefaults = {
+  selects?: SelectName[],
+  connectors?: ConnectorDefault[]
+};
+type ConceptListFieldValidation = NOT_EMPTY_VALIDATION;
+type ConceptListField = CommonField & {
+  type: "CONCEPT_LIST",
+  conceptDropzoneLabel?: TranslatableString,
+  conceptColumnDropzoneLabel?: TranslatableString,
+  rowPrefixField?: SelectField & { apiType: string }, // Used for PSM with "MATCHES"
+  isTwoDimensional?: boolean, // Default: False
+  isSingle?: boolean, // Default: False
+  defaults?: ConceptListDefaults,
+  validations?: ConceptListFieldValidation[],
+  // EITHER USE BLACKLISTING OR WHITELISTING OR NONE OF THE TWO:
+  blacklistedConceptIds?: string[], // Matching ("contains") the ID string, lowercased
+  whitelistedConceptIds?: string[], // Matching ("contains") the ID string, lowercased
+  // EITHER USE BLACKLISTING OR WHITELISTING OR NONE OF THE TWO:
+  blacklistedConnectors?: string[], // Matching ("contains") the name of the connector / table
+  whitelistedConnectors?: string[] // Matching ("contains") the name of the connector / table
+};
+
+/* ------------------------------ */

--- a/frontend/lib/js/api/types.js
+++ b/frontend/lib/js/api/types.js
@@ -4,6 +4,8 @@
 // - response type provided by the backend API
 // - partial types that the reponses are built from
 
+import type { Forms } from "./form-types";
+
 export type DatasetIdT = string;
 export type DatasetT = {
   id: DatasetIdT,
@@ -293,3 +295,5 @@ export type PostFilterSuggestionsResponseT = {
   optionValue: ?string,
   templateValues: string[] // unclear whether that's correct
 }[];
+
+export type GetFormQueriesResponseT = Forms;

--- a/frontend/lib/js/query-runner/QueryRunner.js
+++ b/frontend/lib/js/query-runner/QueryRunner.js
@@ -14,7 +14,7 @@ import QueryRunnerInfo from "./QueryRunnerInfo";
 import QueryRunnerButton from "./QueryRunnerButton";
 
 type PropsType = {
-  queryRunner: Object,
+  queryRunner?: Object,
   isQueryRunning: boolean,
   isButtonEnabled: boolean,
   buttonTooltipKey?: ?string,
@@ -59,7 +59,8 @@ const QueryRunner = (props: PropsType) => {
   const btnAction = isQueryRunning ? stopQuery : startQuery;
 
   const isStartStopLoading =
-    queryRunner.startQuery.loading || queryRunner.stopQuery.loading;
+    !!queryRunner &&
+    (queryRunner.startQuery.loading || queryRunner.stopQuery.loading);
 
   return (
     <Root>
@@ -85,12 +86,14 @@ const QueryRunner = (props: PropsType) => {
       <Right>
         <LoadingGroup>
           <QueryRunningSpinner isQueryRunning={isQueryRunning} />
-          <QueryRunnerInfo queryRunner={queryRunner} />
+          {!!queryRunner && <QueryRunnerInfo queryRunner={queryRunner} />}
         </LoadingGroup>
-        <QueryResults
-          resultCount={queryRunner.queryResult.resultCount}
-          resultUrl={queryRunner.queryResult.resultUrl}
-        />
+        {!!queryRunner && (
+          <QueryResults
+            resultCount={queryRunner.queryResult.resultCount}
+            resultUrl={queryRunner.queryResult.resultUrl}
+          />
+        )}
       </Right>
     </Root>
   );

--- a/frontend/lib/js/store.js
+++ b/frontend/lib/js/store.js
@@ -1,4 +1,5 @@
 // @flow
+
 import { applyMiddleware, compose, createStore, type Store } from "redux";
 
 import buildAppReducer from "./app/reducers";

--- a/frontend/lib/js/store.js
+++ b/frontend/lib/js/store.js
@@ -1,4 +1,5 @@
-import { applyMiddleware, compose, createStore } from "redux";
+// @flow
+import { applyMiddleware, compose, createStore, type Store } from "redux";
 
 import buildAppReducer from "./app/reducers";
 import { isProduction } from "./environment";
@@ -13,23 +14,30 @@ export function makeStore(
 
   let enhancer;
 
-  if (!isProduction())
+  if (!isProduction()) {
     enhancer = compose(
       middleware,
       // Use the Redux devtools extention, but only in development
       window.devToolsExtension ? window.devToolsExtension() : f => f
     );
-  else enhancer = compose(middleware);
+  } else {
+    enhancer = compose(middleware);
+  }
 
   const store = createStore(buildAppReducer(tabs), initialState, enhancer);
 
-  if (module.hot)
+  if (module.hot) {
     // Enable Webpack hot module replacement for reducers
     module.hot.accept("./app/reducers", () => {
       const nextRootReducer = buildAppReducer(tabs);
 
       store.replaceReducer(nextRootReducer);
     });
+  }
 
   return store;
+}
+
+export function updateReducers(store: Store, tabs: TabT[]) {
+  store.replaceReducer(buildAppReducer(tabs));
 }


### PR DESCRIPTION
This adds the endpoint to the other api endpoints, such that the user's bearer token will be used when forms are loaded. (Even though this endpoint won't be used from within conquery yet)

Exposes
- updateReducers (to replace the main reducer once the forms have been loaded)
- getForms - an endpoint to load the forms
- form config types to type the getForms response