### PR TITLE
fixes roleUI test

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/model/FEPermission.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/model/FEPermission.java
@@ -6,7 +6,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import java.util.TimeZone;
 
@@ -21,10 +20,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class FEPermission {
-	/**
-	 * The standard format, that Freemarker understands.
-	 */
-	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("MMM d, y, h:mm:ss a", Locale.US);
 	private static final ZoneId TIMEZONE = TimeZone.getDefault().toZoneId();
 
 	private final Set<String> domains;
@@ -54,7 +49,7 @@ public class FEPermission {
 			domains,
 			abilities,
 			targets,
-			LocalDateTime.ofInstant(cPermission.getCreationTime(), TIMEZONE).format(FORMATTER));
+			LocalDateTime.ofInstant(cPermission.getCreationTime(), TIMEZONE).format(DateTimeFormatter.ISO_DATE_TIME));
 	}
 	
 	public static List<FEPermission> from(Collection<WildcardPermission> cPermission) {

--- a/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/templates/permissionTable.html.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/templates/permissionTable.html.ftl
@@ -26,7 +26,7 @@
                             <#list permission.left.targets as target> ${target} </#list>
                         </#if>
                     </td>
-                    <td>${permission.left.creationTime?datetime}</td>
+                    <td>${permission.left.creationTime}</td>
                     <td><a href="#" onclick="handleDeletePermission('${permission.right}')"><i class="fas fa-trash-alt text-danger"></i></a></td>
                 </tr>
             </#list>

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/RoleUITest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/RoleUITest.java
@@ -31,7 +31,7 @@ import com.bakdata.conquery.util.support.StandaloneSupport;
  * tested against the created entities.
  *
  */
-public class MandatorUITest implements ProgrammaticIntegrationTest, IntegrationTest.Simple {
+public class RoleUITest implements ProgrammaticIntegrationTest, IntegrationTest.Simple {
 
 
 	private MasterMetaStorage storage;


### PR DESCRIPTION
Uses ISO date representation and prints it directly in the freemarker template without using its datetime function