### PR TITLE
Feature/fix remove user from groups on delete

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/models/auth/entities/Group.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/entities/Group.java
@@ -51,7 +51,6 @@ public class Group extends PermissionOwner<GroupId> implements RoleOwner {
 	@Override
 	protected void updateStorage(MasterMetaStorage storage) throws JSONException {
 		storage.updateGroup(this);
-
 	}
 
 	@Override
@@ -60,20 +59,16 @@ public class Group extends PermissionOwner<GroupId> implements RoleOwner {
 	}
 
 	public void addMember(MasterMetaStorage storage, User user) throws JSONException {
-		synchronized (members) {
-			if(members.add(user)) {
-				log.trace("Added user {} to group {}", user.getId(), getId());
-				updateStorage(storage);
-			}
+		if(members.add(user)) {
+			log.trace("Added user {} to group {}", user.getId(), getId());
+			updateStorage(storage);
 		}
 	}
 
 	public void removeMember(MasterMetaStorage storage, User user) throws JSONException {
-		synchronized (members) {
-			if(members.remove(user)) {
-				log.trace("Removed user {} from group {}", user.getId(), getId());				
-				updateStorage(storage);
-			}
+		if(members.remove(user)) {
+			log.trace("Removed user {} from group {}", user.getId(), getId());				
+			updateStorage(storage);
 		}
 	}
 
@@ -86,20 +81,16 @@ public class Group extends PermissionOwner<GroupId> implements RoleOwner {
 	}
 
 	public void addRole(MasterMetaStorage storage, Role role) throws JSONException {
-		synchronized (roles) {
-			if (roles.add(role)) {
-				log.trace("Added role {} to group {}", role.getId(), getId());
-				updateStorage(storage);
-			}
+		if (roles.add(role)) {
+			log.trace("Added role {} to group {}", role.getId(), getId());
+			updateStorage(storage);
 		}
 	}
 
 	public void removeRole(MasterMetaStorage storage, Role role) throws JSONException {
-		synchronized (roles) {
-			if (roles.remove(role)) {
-				log.trace("Removed role {} from group {}", role.getId(), getId());
-				updateStorage(storage);
-			}
+		if (roles.remove(role)) {
+			log.trace("Removed role {} from group {}", role.getId(), getId());
+			updateStorage(storage);
 		}
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/entities/Group.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/entities/Group.java
@@ -6,16 +6,15 @@ import java.util.Set;
 
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
-
 import com.bakdata.conquery.io.jackson.serializer.MetaIdRefCollection;
 import com.bakdata.conquery.io.xodus.MasterMetaStorage;
 import com.bakdata.conquery.models.exceptions.JSONException;
 import com.bakdata.conquery.models.identifiable.ids.specific.GroupId;
-
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.validator.constraints.NotEmpty;
 
 /**
  * A group consists of users and permissions. The permissions held by the group
@@ -23,6 +22,7 @@ import lombok.Setter;
  * query it is currently shared with all groups a user is in.
  *
  */
+@Slf4j
 public class Group extends PermissionOwner<GroupId> implements RoleOwner {
 
 	@Getter
@@ -60,13 +60,21 @@ public class Group extends PermissionOwner<GroupId> implements RoleOwner {
 	}
 
 	public void addMember(MasterMetaStorage storage, User user) throws JSONException {
-		members.add(user);
-		updateStorage(storage);
+		synchronized (members) {
+			if(members.add(user)) {
+				log.trace("Added user {} to group {}", user.getId(), getId());
+				updateStorage(storage);
+			}
+		}
 	}
 
 	public void removeMember(MasterMetaStorage storage, User user) throws JSONException {
-		members.remove(user);
-		updateStorage(storage);
+		synchronized (members) {
+			if(members.remove(user)) {
+				log.trace("Removed user {} from group {}", user.getId(), getId());				
+				updateStorage(storage);
+			}
+		}
 	}
 
 	public boolean containsMember(User user) {
@@ -79,8 +87,8 @@ public class Group extends PermissionOwner<GroupId> implements RoleOwner {
 
 	public void addRole(MasterMetaStorage storage, Role role) throws JSONException {
 		synchronized (roles) {
-			if (!roles.contains(role)) {
-				roles.add(role);
+			if (roles.add(role)) {
+				log.trace("Added role {} to group {}", role.getId(), getId());
 				updateStorage(storage);
 			}
 		}
@@ -88,8 +96,8 @@ public class Group extends PermissionOwner<GroupId> implements RoleOwner {
 
 	public void removeRole(MasterMetaStorage storage, Role role) throws JSONException {
 		synchronized (roles) {
-			if (roles.contains(role)) {
-				roles.remove(role);
+			if (roles.remove(role)) {
+				log.trace("Removed role {} from group {}", role.getId(), getId());
 				updateStorage(storage);
 			}
 		}

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/entities/Role.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/entities/Role.java
@@ -2,16 +2,14 @@ package com.bakdata.conquery.models.auth.entities;
 
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
-
 import com.bakdata.conquery.io.xodus.MasterMetaStorage;
 import com.bakdata.conquery.models.exceptions.JSONException;
 import com.bakdata.conquery.models.identifiable.ids.specific.RoleId;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+import org.hibernate.validator.constraints.NotEmpty;
 
 @AllArgsConstructor
 public class Role extends PermissionOwner<RoleId> {
@@ -28,7 +26,7 @@ public class Role extends PermissionOwner<RoleId> {
 	}
 	
 	@Override
-	protected synchronized void updateStorage(MasterMetaStorage storage) throws JSONException {
+	protected void updateStorage(MasterMetaStorage storage) throws JSONException {
 		storage.updateRole(this);
 		
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/entities/User.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/entities/User.java
@@ -81,21 +81,17 @@ public class User extends FilteredUser<UserId> implements Principal, RoleOwner {
 	}
 
 	public void addRole(MasterMetaStorage storage, Role role) throws JSONException {
-		synchronized (roles) {
-			if(roles.add(role)) {
-				log.trace("Added role {} to user {}", role.getId(), getId());
-				updateStorage(storage);
-			}
+		if(roles.add(role)) {
+			log.trace("Added role {} to user {}", role.getId(), getId());
+			updateStorage(storage);
 		}
 	}
 	
 	@Override
 	public void removeRole(MasterMetaStorage storage, Role role) throws JSONException {
-		synchronized (roles) {
-			if(roles.remove(role)) {
-				log.trace("Removed role {} from user {}", role.getId(), getId());				
-				updateStorage(storage);
-			}
+		if(roles.remove(role)) {
+			log.trace("Removed role {} from user {}", role.getId(), getId());				
+			updateStorage(storage);
 		}
 	}
 
@@ -104,7 +100,7 @@ public class User extends FilteredUser<UserId> implements Principal, RoleOwner {
 	}
 	
 	@Override
-	protected synchronized void updateStorage(MasterMetaStorage storage) throws JSONException {
+	protected void updateStorage(MasterMetaStorage storage) throws JSONException {
 		storage.updateUser(this);
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/entities/User.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/entities/User.java
@@ -9,21 +9,21 @@ import java.util.Set;
 
 import javax.validation.constraints.NotNull;
 
-import org.apache.shiro.SecurityUtils;
-import org.apache.shiro.authz.AuthorizationException;
-import org.apache.shiro.authz.Permission;
-import org.apache.shiro.subject.PrincipalCollection;
-
 import com.bakdata.conquery.io.jackson.serializer.MetaIdRefCollection;
 import com.bakdata.conquery.io.xodus.MasterMetaStorage;
 import com.bakdata.conquery.models.auth.util.SinglePrincipalCollection;
 import com.bakdata.conquery.models.exceptions.JSONException;
 import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
-
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.authz.AuthorizationException;
+import org.apache.shiro.authz.Permission;
+import org.apache.shiro.subject.PrincipalCollection;
 
+@Slf4j
 public class User extends FilteredUser<UserId> implements Principal, RoleOwner {
 
 	@MetaIdRefCollection
@@ -82,17 +82,18 @@ public class User extends FilteredUser<UserId> implements Principal, RoleOwner {
 
 	public void addRole(MasterMetaStorage storage, Role role) throws JSONException {
 		synchronized (roles) {
-			if(!roles.contains(role)) {
-				roles.add(role);
+			if(roles.add(role)) {
+				log.trace("Added role {} to user {}", role.getId(), getId());
 				updateStorage(storage);
 			}
 		}
 	}
 	
+	@Override
 	public void removeRole(MasterMetaStorage storage, Role role) throws JSONException {
 		synchronized (roles) {
-			if(roles.contains(role)) {
-				roles.remove(role);
+			if(roles.remove(role)) {
+				log.trace("Removed role {} from user {}", role.getId(), getId());				
 				updateStorage(storage);
 			}
 		}

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
@@ -1,9 +1,5 @@
 package com.bakdata.conquery.resources.admin.rest;
 
-import javax.validation.Validator;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response.Status;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -425,7 +421,7 @@ public class AdminProcessor {
 		log.trace("Removed user {} from group {}", userId.getPermissionOwner(storage), groupId.getPermissionOwner(getStorage()));
 	}
 
-	public void removeGroup(GroupId groupId) {
+	public void deleteGroup(GroupId groupId) {
 		synchronized (storage) {
 			storage.removeGroup(groupId);
 		}

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/GroupResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/GroupResource.java
@@ -37,7 +37,7 @@ public class GroupResource extends HGroups {
 	@Path("{" + GROUP_ID + "}")
 	@DELETE
 	public Response deleteGroup(@PathParam(GROUP_ID) GroupId groupId) throws JSONException {
-		processor.removeGroup(groupId);
+		processor.deleteGroup(groupId);
 		return Response.ok().build();
 	}
 


### PR DESCRIPTION
when a user was deleted it reference was not removed from groups it was a member of.
this causes that the group object could not be loaded at restart.

this PR fixes that and improves the restart test