### PR TITLE
Feature/restrict entity upload

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/apiv1/ApiV1.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/ApiV1.java
@@ -1,7 +1,5 @@
 package com.bakdata.conquery.apiv1;
 
-import org.glassfish.hk2.utilities.binding.AbstractBinder;
-
 import com.bakdata.conquery.commands.MasterCommand;
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.io.jersey.IdParamConverter;
@@ -11,14 +9,13 @@ import com.bakdata.conquery.models.auth.TokenExtractorFilter;
 import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.worker.Namespaces;
 import com.bakdata.conquery.resources.ResourcesProvider;
-import com.bakdata.conquery.resources.admin.rest.AdminProcessor;
 import com.bakdata.conquery.resources.api.APIResource;
 import com.bakdata.conquery.resources.api.ConceptResource;
 import com.bakdata.conquery.resources.api.ConceptsProcessor;
 import com.bakdata.conquery.resources.api.DatasetResource;
 import com.bakdata.conquery.resources.api.FilterResource;
-
 import io.dropwizard.jersey.setup.JerseyEnvironment;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
 
 @CPSType(base = ResourcesProvider.class, id = "ApiV1")
 public class ApiV1 implements ResourcesProvider {
@@ -28,6 +25,16 @@ public class ApiV1 implements ResourcesProvider {
 		Namespaces namespaces = master.getNamespaces();
 		JerseyEnvironment environment = master.getEnvironment().jersey();
 
+		//inject required services
+		environment.register(new AbstractBinder() {
+			@Override
+			protected void configure() {
+				bind(new ConceptsProcessor(master.getNamespaces())).to(ConceptsProcessor.class);
+				bind(new QueryProcessor(namespaces, master.getStorage())).to(QueryProcessor.class);
+				bind(new MeProcessor(namespaces.getMetaStorage())).to(MeProcessor.class);
+			}
+		});
+		
 		environment.register(new TokenExtractorFilter(ConqueryConfig.getInstance().getAuthentication().getTokenExtractor()));
 		/*
 		 * register CORS-Preflight filter inbetween token extraction and authentication
@@ -35,31 +42,13 @@ public class ApiV1 implements ResourcesProvider {
 		 */
 		environment.register(new CORSPreflightRequestFilter());
 		environment.register(master.getAuthDynamicFeature());
-		environment.register(new QueryResource(namespaces, master.getStorage()));
+		environment.register(QueryResource.class);
 		environment.register(new ResultCSVResource(namespaces, master.getConfig()));
 		environment.register(new StoredQueriesResource(namespaces));
 		environment.register(IdParamConverter.Provider.INSTANCE);
 		environment.register(CORSResponseFilter.class);
 		environment.register(new ConfigResource(master.getConfig()));
 		
-		//inject required services
-		environment.register(new AbstractBinder() {
-			@Override
-			protected void configure() {
-				bind(new ConceptsProcessor(master.getNamespaces())).to(ConceptsProcessor.class);
-				bind(
-					new AdminProcessor(
-						master.getConfig(),
-						master.getStorage(),
-						master.getNamespaces(),
-						master.getJobManager(),
-						master.getMaintenanceService(),
-						master.getValidator()
-					)
-				).to(AdminProcessor.class);
-				bind(new MeProcessor(namespaces.getMetaStorage())).to(MeProcessor.class);
-			}
-		});
 		environment.register(APIResource.class);
 		environment.register(ConceptResource.class);
 		environment.register(DatasetResource.class);

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
@@ -4,6 +4,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 
 import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.NamespaceStorage;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.auth.permissions.Ability;
 import com.bakdata.conquery.models.auth.permissions.AbilitySets;
@@ -13,6 +14,7 @@ import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.exceptions.JSONException;
 import com.bakdata.conquery.models.execution.ExecutionStatus;
 import com.bakdata.conquery.models.execution.ManagedExecution;
+import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
 import com.bakdata.conquery.models.query.IQuery;
 import com.bakdata.conquery.models.query.ManagedQuery;
@@ -128,5 +130,21 @@ public class QueryProcessor {
 	public ExecutionStatus cancel(Dataset dataset, ManagedExecution query, URLBuilder urlb) {
 
 		return null;
+	}
+	
+	public Namespace getNamespace(DatasetId dataset) {
+		return namespaces.get(dataset);
+	}
+	
+	public Dataset getDataset(DatasetId id) {
+		return namespaces.get(id).getStorage().getDataset();
+	}
+
+	public NamespaceStorage getStorage(DatasetId id) {
+		return namespaces.get(id).getStorage();
+	}
+
+	public ManagedQuery getManagedQuery(ManagedExecutionId queryId) {
+		return namespaces.get(queryId.getDataset()).getQueryManager().getQuery(queryId);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesProcessor.java
@@ -53,6 +53,7 @@ public class StoredQueriesProcessor {
 			// to exclude subtypes from somewhere else
 			.filter(q -> (q instanceof ManagedQuery) && ((ManagedQuery) q).getQuery().getClass().equals(ConceptQuery.class))
 			.filter(q -> q.getDataset().equals(dataset.getId()))
+			.filter(q -> user.isPermitted(QueryPermission.onInstance(Ability.READ, q.getId())))
 			.flatMap(mq -> {
 				try {
 					return Stream.of(

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesResource.java
@@ -22,7 +22,6 @@ import javax.ws.rs.core.Response.Status;
 import com.bakdata.conquery.io.xodus.MasterMetaStorage;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.auth.permissions.Ability;
-import com.bakdata.conquery.models.auth.permissions.QueryPermission;
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.exceptions.JSONException;
 import com.bakdata.conquery.models.execution.ExecutionStatus;
@@ -56,7 +55,6 @@ public class StoredQueriesResource {
 		authorize(user, datasetId, Ability.READ);
 
 		return processor.getAllQueries(dsUtil.getDataset(datasetId), req, user)
-			.filter(status -> user.isPermitted(QueryPermission.onInstance(Ability.READ.asSet(), status.getId())))
 			.collect(Collectors.toList());
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/identifiable/mapping/IdMappingAccessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/identifiable/mapping/IdMappingAccessor.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.bakdata.conquery.io.xodus.NamespaceStorage;
-import org.apache.commons.lang3.ArrayUtils;
 
 public interface IdMappingAccessor {
 
@@ -42,13 +41,20 @@ public interface IdMappingAccessor {
 		Arrays.fill(applicationMapping, -1);
 		for (int indexInHeader = 0; indexInHeader < csvHeader.length; indexInHeader++) {
 			String csvHeaderField = csvHeader[indexInHeader];
-			int indexInCsvHeader = ArrayUtils.indexOf(getHeader(), csvHeaderField);
+			int indexInCsvHeader = findIndexfromMappingHeader(csvHeaderField);
 			if (indexInCsvHeader != -1) {
 				applicationMapping[indexInHeader] = indexInCsvHeader;
 			}
 		}
 		return new IdAccessorImpl(this, applicationMapping, storage);
 	}
+	
+	/**
+	 * Returns the index of the header in the setted mapping that maps best to the provided header in the CSV.
+	 * @param csvHeaderField The header field in the CSV that is machted to the predefined required headers.
+	 * @return The index of the predefined header that matched best.
+	 */
+	int findIndexfromMappingHeader(String csvHeaderField);
 
 	/**
 	 * Extracts the Id information from a CSV line using this accessor

--- a/backend/src/main/java/com/bakdata/conquery/models/identifiable/mapping/NoIdMapping.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/identifiable/mapping/NoIdMapping.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.io.xodus.NamespaceStorage;
-
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ArrayUtils;
 
 @CPSType(base = IdMappingConfig.class, id = "NO_ID_MAPPING")
 public class NoIdMapping extends IdMappingConfig {
@@ -52,6 +52,11 @@ public class NoIdMapping extends IdMappingConfig {
 		@Override
 		public CsvEntityId getFallbackCsvId(String[] reorderedCsvLine) {
 			return new CsvEntityId(reorderedCsvLine[0]);
+		}
+
+		@Override
+		public int findIndexfromMappingHeader(String csvHeaderField) {
+			return ArrayUtils.indexOf(getHeader(), csvHeaderField);
 		}
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/identifiable/mapping/SimpleIdMapping.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/identifiable/mapping/SimpleIdMapping.java
@@ -1,6 +1,7 @@
 package com.bakdata.conquery.models.identifiable.mapping;
 
 import com.bakdata.conquery.io.cps.CPSType;
+import org.apache.commons.lang3.ArrayUtils;
 
 @CPSType(base= IdMappingConfig.class, id="SIMPLE")
 public class SimpleIdMapping extends IdMappingConfig {
@@ -11,6 +12,11 @@ public class SimpleIdMapping extends IdMappingConfig {
 			@Override
 			public CsvEntityId getFallbackCsvId(String[] reorderedCsvLine) {
 				return new CsvEntityId(reorderedCsvLine[0]);
+			}
+
+			@Override
+			public int findIndexfromMappingHeader(String csvHeaderField) {
+				return ArrayUtils.indexOf(getHeader(), csvHeaderField);
 			}
 		}};
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/query/IQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/IQuery.java
@@ -7,12 +7,11 @@ import com.bakdata.conquery.io.cps.CPSBase;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
 import com.bakdata.conquery.models.query.queryplan.QueryPlan;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
-import com.bakdata.conquery.models.query.visitor.QueryVisitor;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonTypeInfo(use=JsonTypeInfo.Id.CUSTOM, property="type")
 @CPSBase
-public interface IQuery {
+public interface IQuery extends Visitable{
 
 	IQuery resolve(QueryResolveContext context);
 	QueryPlan createQueryPlan(QueryPlanContext context);
@@ -33,5 +32,4 @@ public interface IQuery {
 	
 	void collectResultInfos(ResultInfoCollector collector);
 
-	void visit(QueryVisitor visitor);
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/query/IQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/IQuery.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonTypeInfo(use=JsonTypeInfo.Id.CUSTOM, property="type")
 @CPSBase
-public interface IQuery extends Visitable{
+public interface IQuery extends Visitable {
 
 	IQuery resolve(QueryResolveContext context);
 	QueryPlan createQueryPlan(QueryPlanContext context);

--- a/backend/src/main/java/com/bakdata/conquery/models/query/Visitable.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/Visitable.java
@@ -1,0 +1,35 @@
+package com.bakdata.conquery.models.query;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.bakdata.conquery.models.query.concept.CQElement;
+import com.bakdata.conquery.models.query.concept.specific.CQExternal;
+import com.bakdata.conquery.models.query.visitor.QueryVisitor;
+
+public interface Visitable {
+
+	void visit(QueryVisitor visitor);
+	
+	
+	/**
+	 * Checks if the query requires to resolve external ids.
+	 * @return True if a {@link CQExternal} is found.
+	 */
+	public static boolean usesExternalIds(Visitable query) {
+		
+		final List<CQExternal> elements = new ArrayList<>();
+		
+		query.visit(new QueryVisitor() {
+			
+			@Override
+			public void visit(CQElement element) {
+				if (element instanceof CQExternal) {					
+					elements.add((CQExternal)element);
+				}
+			}
+		});
+		
+		return elements.size() > 0;
+	}
+}

--- a/backend/src/main/java/com/bakdata/conquery/models/query/Visitable.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/Visitable.java
@@ -1,35 +1,11 @@
 package com.bakdata.conquery.models.query;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.function.Consumer;
 
 import com.bakdata.conquery.models.query.concept.CQElement;
-import com.bakdata.conquery.models.query.concept.specific.CQExternal;
-import com.bakdata.conquery.models.query.visitor.QueryVisitor;
 
 public interface Visitable {
 
-	void visit(QueryVisitor visitor);
+	void visit(Consumer<CQElement> visitor);
 	
-	
-	/**
-	 * Checks if the query requires to resolve external ids.
-	 * @return True if a {@link CQExternal} is found.
-	 */
-	static boolean usesExternalIds(Visitable query) {
-		
-		final List<CQExternal> elements = new ArrayList<>();
-		
-		query.visit(new QueryVisitor() {
-			
-			@Override
-			public void visit(CQElement element) {
-				if (element instanceof CQExternal) {	
-					elements.add((CQExternal)element);
-				}
-			}
-		});
-		
-		return elements.size() > 0;
-	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/query/Visitable.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/Visitable.java
@@ -16,7 +16,7 @@ public interface Visitable {
 	 * Checks if the query requires to resolve external ids.
 	 * @return True if a {@link CQExternal} is found.
 	 */
-	public static boolean usesExternalIds(Visitable query) {
+	static boolean usesExternalIds(Visitable query) {
 		
 		final List<CQExternal> elements = new ArrayList<>();
 		
@@ -24,7 +24,7 @@ public interface Visitable {
 			
 			@Override
 			public void visit(CQElement element) {
-				if (element instanceof CQExternal) {					
+				if (element instanceof CQExternal) {	
 					elements.add((CQExternal)element);
 				}
 			}

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/ArrayConceptQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/ArrayConceptQuery.java
@@ -3,6 +3,7 @@ package com.bakdata.conquery.models.query.concept;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import com.bakdata.conquery.ConqueryConstants;
 import com.bakdata.conquery.io.cps.CPSType;
@@ -12,8 +13,6 @@ import com.bakdata.conquery.models.query.QueryPlanContext;
 import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.queryplan.ArrayConceptQueryPlan;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
-import com.bakdata.conquery.models.query.visitor.QueryVisitor;
-
 import lombok.Getter;
 import lombok.Setter;
 
@@ -59,7 +58,7 @@ public class ArrayConceptQuery implements IQuery {
 	}
 
 	@Override
-	public void visit(QueryVisitor visitor) {
+	public void visit(Consumer<CQElement> visitor) {
 		childQueries.forEach(q -> q.visit(visitor));
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/CQElement.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/CQElement.java
@@ -2,6 +2,7 @@ package com.bakdata.conquery.models.query.concept;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import com.bakdata.conquery.io.cps.CPSBase;
 import com.bakdata.conquery.models.identifiable.ids.NamespacedId;
@@ -12,7 +13,6 @@ import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.queryplan.ConceptQueryPlan;
 import com.bakdata.conquery.models.query.queryplan.QPNode;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
-import com.bakdata.conquery.models.query.visitor.QueryVisitor;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonTypeInfo(use=JsonTypeInfo.Id.CUSTOM, property="type")
@@ -50,7 +50,7 @@ public interface CQElement {
 	
 	void collectResultInfos(ResultInfoCollector collector);
 
-	default void visit(QueryVisitor visitor) {
-		visitor.visit(this);
+	default void visit(Consumer<CQElement> visitor) {
+		visitor.accept(this);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/CQElement.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/CQElement.java
@@ -50,5 +50,7 @@ public interface CQElement {
 	
 	void collectResultInfos(ResultInfoCollector collector);
 
-	void visit(QueryVisitor visitor);
+	default void visit(QueryVisitor visitor) {
+		visitor.visit(this);
+	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/ConceptQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/ConceptQuery.java
@@ -1,6 +1,7 @@
 package com.bakdata.conquery.models.query.concept;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -13,7 +14,6 @@ import com.bakdata.conquery.models.query.QueryPlanContext;
 import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.queryplan.ConceptQueryPlan;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
-import com.bakdata.conquery.models.query.visitor.QueryVisitor;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -54,7 +54,7 @@ public class ConceptQuery implements IQuery {
 	}
 
 	@Override
-	public void visit(QueryVisitor visitor) {
+	public void visit(Consumer<CQElement> visitor) {
 		root.visit(visitor);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQAnd.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQAnd.java
@@ -6,8 +6,6 @@ import java.util.Set;
 
 import javax.validation.Valid;
 
-import org.hibernate.validator.constraints.NotEmpty;
-
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.models.identifiable.ids.NamespacedId;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
@@ -19,9 +17,9 @@ import com.bakdata.conquery.models.query.queryplan.QPNode;
 import com.bakdata.conquery.models.query.queryplan.specific.AndNode;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
 import com.bakdata.conquery.models.query.visitor.QueryVisitor;
-
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.validator.constraints.NotEmpty;
 
 @CPSType(id="AND", base=CQElement.class)
 public class CQAnd implements CQElement {
@@ -66,6 +64,7 @@ public class CQAnd implements CQElement {
 	
 	@Override
 	public void visit(QueryVisitor visitor) {
+		CQElement.super.visit(visitor);
 		for(CQElement c:children) {
 			c.visit(visitor);
 		}

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQAnd.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQAnd.java
@@ -3,6 +3,7 @@ package com.bakdata.conquery.models.query.concept.specific;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import javax.validation.Valid;
 
@@ -16,7 +17,6 @@ import com.bakdata.conquery.models.query.queryplan.ConceptQueryPlan;
 import com.bakdata.conquery.models.query.queryplan.QPNode;
 import com.bakdata.conquery.models.query.queryplan.specific.AndNode;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
-import com.bakdata.conquery.models.query.visitor.QueryVisitor;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.validator.constraints.NotEmpty;
@@ -63,7 +63,7 @@ public class CQAnd implements CQElement {
 	}
 	
 	@Override
-	public void visit(QueryVisitor visitor) {
+	public void visit(Consumer<CQElement> visitor) {
 		CQElement.super.visit(visitor);
 		for(CQElement c:children) {
 			c.visit(visitor);

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQConcept.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQConcept.java
@@ -33,7 +33,6 @@ import com.bakdata.conquery.models.query.queryplan.specific.SpecialDateUnionAggr
 import com.bakdata.conquery.models.query.queryplan.specific.ValidityDateNode;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
 import com.bakdata.conquery.models.query.resultinfo.SelectResultInfo;
-import com.bakdata.conquery.models.query.visitor.QueryVisitor;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Getter;
@@ -193,10 +192,5 @@ public class CQConcept implements CQElement {
 		selects.forEach(select -> namespacedIds.add(select.getId()));
 		tables.forEach(table -> namespacedIds.add(table.getId()));
 		
-	}
-	
-	@Override
-	public void visit(QueryVisitor visitor) {
-		visitor.visitConcept(this);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQDateRestriction.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQDateRestriction.java
@@ -5,6 +5,7 @@ import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Queue;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -23,7 +24,6 @@ import com.bakdata.conquery.models.query.queryplan.specific.DateRestrictingNode;
 import com.bakdata.conquery.models.query.queryplan.specific.NegatingNode;
 import com.bakdata.conquery.models.query.queryplan.specific.ValidityDateNode;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
-import com.bakdata.conquery.models.query.visitor.QueryVisitor;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -84,7 +84,7 @@ public class CQDateRestriction implements CQElement {
 	}
 	
 	@Override
-	public void visit(QueryVisitor visitor) {
+	public void visit(Consumer<CQElement> visitor) {
 		CQElement.super.visit(visitor);
 		child.visit(visitor);
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQDateRestriction.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQDateRestriction.java
@@ -86,6 +86,6 @@ public class CQDateRestriction implements CQElement {
 	@Override
 	public void visit(QueryVisitor visitor) {
 		CQElement.super.visit(visitor);
-		child.visit(visitor);		
+		child.visit(visitor);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQDateRestriction.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQDateRestriction.java
@@ -1,5 +1,14 @@
 package com.bakdata.conquery.models.query.concept.specific;
 
+import java.time.LocalDate;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Queue;
+import java.util.Set;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.models.common.CDateSet;
 import com.bakdata.conquery.models.common.Range;
@@ -17,14 +26,6 @@ import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
 import com.bakdata.conquery.models.query.visitor.QueryVisitor;
 import lombok.Getter;
 import lombok.Setter;
-
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import java.time.LocalDate;
-import java.util.ArrayDeque;
-import java.util.Collections;
-import java.util.Queue;
-import java.util.Set;
 
 @CPSType(id = "DATE_RESTRICTION", base = CQElement.class)
 @Setter
@@ -84,6 +85,7 @@ public class CQDateRestriction implements CQElement {
 	
 	@Override
 	public void visit(QueryVisitor visitor) {
+		CQElement.super.visit(visitor);
 		child.visit(visitor);		
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQExternal.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQExternal.java
@@ -8,8 +8,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.hibernate.validator.constraints.NotEmpty;
-
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.models.common.CDateSet;
 import com.bakdata.conquery.models.common.daterange.CDateRange;
@@ -28,16 +26,15 @@ import com.bakdata.conquery.models.query.concept.CQElement;
 import com.bakdata.conquery.models.query.queryplan.ConceptQueryPlan;
 import com.bakdata.conquery.models.query.queryplan.QPNode;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
-import com.bakdata.conquery.models.query.visitor.QueryVisitor;
 import com.bakdata.conquery.models.types.parser.specific.DateRangeParser;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.common.collect.MoreCollectors;
-
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.validator.constraints.NotEmpty;
 
 @Slf4j
 @CPSType(id = "EXTERNAL", base = CQElement.class)
@@ -57,8 +54,6 @@ public class CQExternal implements CQElement {
 		throw new IllegalStateException("CQExternal needs to be resolved before creating a plan");
 	}
 	
-	@Override
-	public void visit(QueryVisitor visitor) {}
 
 	@Override
 	public CQElement resolve(QueryResolveContext context) {

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQExternal.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQExternal.java
@@ -176,7 +176,7 @@ public class CQExternal implements CQElement {
 
 	@RequiredArgsConstructor
 	@Getter
-	public static enum FormatColumn {
+	public enum FormatColumn {
 		ID(true, null),
 		EVENT_DATE(false, DateFormat.EVENT_DATE),
 		START_DATE(false, DateFormat.START_END_DATE),

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQExternalResolved.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQExternalResolved.java
@@ -1,5 +1,9 @@
 package com.bakdata.conquery.models.query.concept.specific;
 
+import java.util.Map;
+
+import javax.validation.constraints.NotNull;
+
 import com.bakdata.conquery.ConqueryConstants;
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.models.common.CDateSet;
@@ -12,15 +16,11 @@ import com.bakdata.conquery.models.query.queryplan.QPNode;
 import com.bakdata.conquery.models.query.queryplan.specific.ExternalNode;
 import com.bakdata.conquery.models.query.queryplan.specific.SpecialDateUnionAggregatorNode;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
-import com.bakdata.conquery.models.query.visitor.QueryVisitor;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
-
-import javax.validation.constraints.NotNull;
-import java.util.Map;
 
 @CPSType(id="EXTERNAL_RESOLVED", base=CQElement.class)
 @Getter @Setter
@@ -31,9 +31,6 @@ public class CQExternalResolved implements CQElement {
 	@Getter @NotNull @NonNull
 	private Map<Integer, CDateSet> values;
 	
-	@Override
-	public void visit(QueryVisitor visitor) {}
-
 	@Override
 	public QPNode createQueryPlan(QueryPlanContext context, ConceptQueryPlan plan) {
 		DatasetId dataset = context.getDataset();

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQNegation.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQNegation.java
@@ -15,7 +15,6 @@ import com.bakdata.conquery.models.query.queryplan.QPNode;
 import com.bakdata.conquery.models.query.queryplan.specific.NegatingNode;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
 import com.bakdata.conquery.models.query.visitor.QueryVisitor;
-
 import lombok.Getter;
 import lombok.Setter;
 
@@ -50,6 +49,7 @@ public class CQNegation implements CQElement {
 	
 	@Override
 	public void visit(QueryVisitor visitor) {
+		CQElement.super.visit(visitor);
 		child.visit(visitor);		
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQNegation.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQNegation.java
@@ -1,6 +1,7 @@
 package com.bakdata.conquery.models.query.concept.specific;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -14,7 +15,6 @@ import com.bakdata.conquery.models.query.queryplan.ConceptQueryPlan;
 import com.bakdata.conquery.models.query.queryplan.QPNode;
 import com.bakdata.conquery.models.query.queryplan.specific.NegatingNode;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
-import com.bakdata.conquery.models.query.visitor.QueryVisitor;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -48,7 +48,7 @@ public class CQNegation implements CQElement {
 	}
 	
 	@Override
-	public void visit(QueryVisitor visitor) {
+	public void visit(Consumer<CQElement> visitor) {
 		CQElement.super.visit(visitor);
 		child.visit(visitor);
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQNegation.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQNegation.java
@@ -50,6 +50,6 @@ public class CQNegation implements CQElement {
 	@Override
 	public void visit(QueryVisitor visitor) {
 		CQElement.super.visit(visitor);
-		child.visit(visitor);		
+		child.visit(visitor);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQOr.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQOr.java
@@ -7,8 +7,6 @@ import java.util.Set;
 
 import javax.validation.Valid;
 
-import org.hibernate.validator.constraints.NotEmpty;
-
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.models.identifiable.ids.NamespacedId;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
@@ -20,11 +18,11 @@ import com.bakdata.conquery.models.query.queryplan.QPNode;
 import com.bakdata.conquery.models.query.queryplan.specific.OrNode;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
 import com.bakdata.conquery.models.query.visitor.QueryVisitor;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.validator.constraints.NotEmpty;
 
 @NoArgsConstructor @AllArgsConstructor
 @CPSType(id="OR", base=CQElement.class)
@@ -71,6 +69,7 @@ public class CQOr implements CQElement {
 	
 	@Override
 	public void visit(QueryVisitor visitor) {
+		CQElement.super.visit(visitor);
 		for(CQElement c:children) {
 			c.visit(visitor);
 		}

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQOr.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQOr.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import javax.validation.Valid;
 
@@ -17,7 +18,6 @@ import com.bakdata.conquery.models.query.queryplan.ConceptQueryPlan;
 import com.bakdata.conquery.models.query.queryplan.QPNode;
 import com.bakdata.conquery.models.query.queryplan.specific.OrNode;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
-import com.bakdata.conquery.models.query.visitor.QueryVisitor;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -68,7 +68,7 @@ public class CQOr implements CQElement {
 	}
 	
 	@Override
-	public void visit(QueryVisitor visitor) {
+	public void visit(Consumer<CQElement> visitor) {
 		CQElement.super.visit(visitor);
 		for(CQElement c:children) {
 			c.visit(visitor);

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQReusedQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQReusedQuery.java
@@ -2,6 +2,7 @@ package com.bakdata.conquery.models.query.concept.specific;
 
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -19,7 +20,6 @@ import com.bakdata.conquery.models.query.concept.ConceptQuery;
 import com.bakdata.conquery.models.query.queryplan.ConceptQueryPlan;
 import com.bakdata.conquery.models.query.queryplan.QPNode;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
-import com.bakdata.conquery.models.query.visitor.QueryVisitor;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -56,7 +56,7 @@ public class CQReusedQuery implements CQElement {
 	}
 	
 	@Override
-	public void visit(QueryVisitor visitor) {
+	public void visit(Consumer<CQElement> visitor) {
 		CQElement.super.visit(visitor);
 		if(resolvedQuery != null) {
 			resolvedQuery.visit(visitor);

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQReusedQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQReusedQuery.java
@@ -1,5 +1,11 @@
 package com.bakdata.conquery.models.query.concept.specific;
 
+import java.util.Objects;
+import java.util.Set;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.io.jackson.InternalOnly;
 import com.bakdata.conquery.models.identifiable.ids.NamespacedId;
@@ -18,11 +24,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import java.util.Objects;
-import java.util.Set;
 
 @CPSType(id="SAVED_QUERY", base=CQElement.class)
 @RequiredArgsConstructor @AllArgsConstructor(onConstructor_=@JsonCreator)
@@ -56,6 +57,7 @@ public class CQReusedQuery implements CQElement {
 	
 	@Override
 	public void visit(QueryVisitor visitor) {
+		CQElement.super.visit(visitor);
 		if(resolvedQuery != null) {
 			resolvedQuery.visit(visitor);
 		}

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/temporal/CQAbstractTemporalQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/temporal/CQAbstractTemporalQuery.java
@@ -1,9 +1,10 @@
 package com.bakdata.conquery.models.query.concept.specific.temporal;
 
+import java.util.function.Consumer;
+
 import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.concept.CQElement;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
-import com.bakdata.conquery.models.query.visitor.QueryVisitor;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -28,7 +29,7 @@ public abstract class CQAbstractTemporalQuery implements CQElement {
 	public abstract CQAbstractTemporalQuery resolve(QueryResolveContext context);
 	
 	@Override
-	public void visit(QueryVisitor visitor) {
+	public void visit(Consumer<CQElement> visitor) {
 		CQElement.super.visit(visitor);
 		index.getChild().visit(visitor);
 		preceding.getChild().visit(visitor);

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/temporal/CQAbstractTemporalQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/temporal/CQAbstractTemporalQuery.java
@@ -4,7 +4,6 @@ import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.concept.CQElement;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
 import com.bakdata.conquery.models.query.visitor.QueryVisitor;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -30,6 +29,7 @@ public abstract class CQAbstractTemporalQuery implements CQElement {
 	
 	@Override
 	public void visit(QueryVisitor visitor) {
+		CQElement.super.visit(visitor);
 		index.getChild().visit(visitor);
 		preceding.getChild().visit(visitor);
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/query/visitor/QueryVisitor.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/visitor/QueryVisitor.java
@@ -1,8 +1,11 @@
 package com.bakdata.conquery.models.query.visitor;
 
-import com.bakdata.conquery.models.query.concept.specific.CQConcept;
+import com.bakdata.conquery.models.query.concept.CQElement;
 
+/**
+ * Visits the elements of which a query consist.
+ */
 public interface QueryVisitor {
-
-	public default void visitConcept(CQConcept concept) {}
+	
+	void visit(CQElement element);
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/query/visitor/QueryVisitor.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/visitor/QueryVisitor.java
@@ -2,10 +2,14 @@ package com.bakdata.conquery.models.query.visitor;
 
 import java.util.function.Consumer;
 
+import com.bakdata.conquery.apiv1.QueryProcessor;
 import com.bakdata.conquery.models.query.concept.CQElement;
+import com.bakdata.conquery.util.QueryUtils;
 
 /**
  * Visits the elements of which a query consist.
+ * For example in {@link QueryProcessor} to check if the query consists only of a single reusing node.
+ * Reference implementations can be found in {@link QueryUtils}.
  */
 @FunctionalInterface
 public interface QueryVisitor extends Consumer<CQElement>{

--- a/backend/src/main/java/com/bakdata/conquery/models/query/visitor/QueryVisitor.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/visitor/QueryVisitor.java
@@ -1,11 +1,12 @@
 package com.bakdata.conquery.models.query.visitor;
 
+import java.util.function.Consumer;
+
 import com.bakdata.conquery.models.query.concept.CQElement;
 
 /**
  * Visits the elements of which a query consist.
  */
-public interface QueryVisitor {
-	
-	void visit(CQElement element);
+@FunctionalInterface
+public interface QueryVisitor extends Consumer<CQElement>{
 }

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/TablesUIResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/TablesUIResource.java
@@ -1,26 +1,35 @@
 package com.bakdata.conquery.resources.admin.ui;
 
+import static com.bakdata.conquery.resources.ResourceConstants.DATASET_NAME;
 import static com.bakdata.conquery.resources.ResourceConstants.IMPORT_ID;
+import static com.bakdata.conquery.resources.ResourceConstants.TABLE_NAME;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.annotation.PostConstruct;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response.Status;
 
 import com.bakdata.conquery.io.jersey.ExtraMimeTypes;
 import com.bakdata.conquery.models.datasets.Import;
+import com.bakdata.conquery.models.datasets.Table;
+import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.identifiable.ids.specific.ImportId;
+import com.bakdata.conquery.models.identifiable.ids.specific.TableId;
 import com.bakdata.conquery.models.types.MajorTypeId;
 import com.bakdata.conquery.models.types.specific.AStringType;
+import com.bakdata.conquery.models.worker.Namespace;
 import com.bakdata.conquery.resources.admin.ui.model.TableStatistics;
 import com.bakdata.conquery.resources.admin.ui.model.UIView;
-import com.bakdata.conquery.resources.hierarchies.HTables;
+import com.bakdata.conquery.resources.hierarchies.HAdmin;
 import io.dropwizard.views.View;
 import lombok.Getter;
 import lombok.Setter;
@@ -28,9 +37,29 @@ import lombok.extern.slf4j.Slf4j;
 
 @Produces(MediaType.TEXT_HTML)
 @Consumes({ExtraMimeTypes.JSON_STRING, ExtraMimeTypes.SMILE_STRING})
-
+@Path("datasets/{" + DATASET_NAME + "}/tables/{" + TABLE_NAME + "}")
 @Getter @Setter @Slf4j
-public class TablesUIResource extends HTables {
+public class TablesUIResource extends HAdmin {
+	
+	@PathParam(DATASET_NAME)
+	protected DatasetId datasetId;
+	protected Namespace namespace;
+	@PathParam(TABLE_NAME)
+	protected TableId tableId;
+	protected Table table;
+	
+	@PostConstruct
+	@Override
+	public void init() {
+		super.init();
+		this.namespace = processor.getNamespaces().get(datasetId);
+		this.table = namespace
+			.getStorage()
+			.getDataset()
+			.getTables()
+			.getOptional(tableId)
+			.orElseThrow(() -> new WebApplicationException("Could not find table "+tableId, Status.NOT_FOUND));
+	}
 	
 	@GET
 	public View getTableView() {

--- a/backend/src/main/java/com/bakdata/conquery/resources/hierarchies/HAuthorized.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/hierarchies/HAuthorized.java
@@ -1,7 +1,5 @@
 package com.bakdata.conquery.resources.hierarchies;
 
-import static com.bakdata.conquery.models.auth.AuthorizationHelper.authorize;
-
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.WebApplicationException;
@@ -9,8 +7,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response.Status;
 
 import com.bakdata.conquery.models.auth.entities.User;
-import com.bakdata.conquery.models.auth.permissions.AdminPermission;
-
 import io.dropwizard.auth.Auth;
 import lombok.Getter;
 import lombok.Setter;

--- a/backend/src/main/java/com/bakdata/conquery/resources/hierarchies/HConcepts.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/hierarchies/HConcepts.java
@@ -12,7 +12,6 @@ import javax.ws.rs.core.Response.Status;
 import com.bakdata.conquery.models.concepts.Concept;
 import com.bakdata.conquery.models.identifiable.ids.specific.ConceptId;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
-
 import lombok.Getter;
 import lombok.Setter;
 
@@ -30,7 +29,6 @@ public abstract class HConcepts extends HDatasets {
 	@Override
 	public void init() {
 		super.init();
-		this.namespace = processor.getNamespaces().get(datasetId);
 		this.concept = namespace.getStorage().getConcept(conceptId);
 		if(this.concept == null) {
 			throw new WebApplicationException("Could not find concept "+conceptId, Status.NOT_FOUND);

--- a/backend/src/main/java/com/bakdata/conquery/resources/hierarchies/HDatasets.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/hierarchies/HDatasets.java
@@ -33,7 +33,7 @@ public abstract class HDatasets extends HAuthorized {
 	public void init() {
 		super.init();
 		authorize(user, datasetId, Ability.READ);
-		this.namespace = processor.getNamespace(datasetId);
+		this.namespace = processor.getNamespaces().get(datasetId);
 		if(namespace == null) {
 			throw new WebApplicationException("Could not find dataset "+datasetId, Status.NOT_FOUND);
 		}

--- a/backend/src/main/java/com/bakdata/conquery/resources/hierarchies/HDatasets.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/hierarchies/HDatasets.java
@@ -10,12 +10,11 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 
+import com.bakdata.conquery.apiv1.QueryProcessor;
 import com.bakdata.conquery.models.auth.permissions.Ability;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.worker.Namespace;
-import com.bakdata.conquery.resources.admin.rest.AdminProcessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import lombok.Setter;
 
 @Setter
@@ -23,7 +22,7 @@ import lombok.Setter;
 public abstract class HDatasets extends HAuthorized {
 	
 	@Inject
-	protected AdminProcessor processor;
+	protected QueryProcessor processor;
 	@PathParam(DATASET_NAME)
 	protected DatasetId datasetId;
 	protected Namespace namespace;
@@ -34,7 +33,7 @@ public abstract class HDatasets extends HAuthorized {
 	public void init() {
 		super.init();
 		authorize(user, datasetId, Ability.READ);
-		this.namespace = processor.getNamespaces().get(datasetId);
+		this.namespace = processor.getNamespace(datasetId);
 		if(namespace == null) {
 			throw new WebApplicationException("Could not find dataset "+datasetId, Status.NOT_FOUND);
 		}

--- a/backend/src/main/java/com/bakdata/conquery/util/QueryUtils.java
+++ b/backend/src/main/java/com/bakdata/conquery/util/QueryUtils.java
@@ -1,0 +1,63 @@
+package com.bakdata.conquery.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
+import com.bakdata.conquery.models.query.concept.CQElement;
+import com.bakdata.conquery.models.query.concept.specific.CQAnd;
+import com.bakdata.conquery.models.query.concept.specific.CQExternal;
+import com.bakdata.conquery.models.query.concept.specific.CQOr;
+import com.bakdata.conquery.models.query.concept.specific.CQReusedQuery;
+import com.bakdata.conquery.models.query.visitor.QueryVisitor;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class QueryUtils {
+	
+	/**
+	 * Checks if the query requires to resolve external ids.
+	 * @return True if a {@link CQExternal} is found.
+	 */
+	public static class ExternalIdChecker implements QueryVisitor{
+		private final List<CQExternal> elements = new ArrayList<>();
+		
+		@Override
+		public void accept(CQElement element) {
+			if (element instanceof CQExternal) {	
+				elements.add((CQExternal)element);
+			}
+		}
+		
+		public boolean resolvesExternalIds() {
+			return elements.size() > 0;
+		}
+	}
+	
+	/**
+	 * Find first and only directly ReusedQuery in the queries tree, and return its Id. ie.: arbirtary CQAnd/CQOr with only them or then a ReusedQuery.
+	 *
+	 * @return Null if not only a single {@link CQReusedQuery} was found beside {@link CQAnd} / {@link CQOr}.
+	 */
+	public static class SingleReusedChecker implements QueryVisitor{
+		final List<CQReusedQuery> reusedElements = new ArrayList<>();
+		private boolean containsOthersElements = false;
+		
+		@Override
+		public void accept(CQElement element) {
+			if (element instanceof CQReusedQuery) {	
+				reusedElements.add((CQReusedQuery)element);
+			}
+			else if(element instanceof CQAnd || element instanceof CQOr) {
+				// Ignore these elements
+			}
+			else {
+				containsOthersElements = true;
+			}
+		}
+		
+		public ManagedExecutionId getOnlyReused(){
+			return (reusedElements.size() == 1 && !containsOthersElements)? reusedElements.get(0).getQuery() : null;
+		}
+	}
+}

--- a/backend/src/test/java/com/bakdata/conquery/integration/ConqueryIntegrationTests.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/ConqueryIntegrationTests.java
@@ -4,16 +4,15 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Stream;
 
+import com.bakdata.conquery.TestTags;
 import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestFactory;
 
-import com.bakdata.conquery.TestTags;
-
 public class ConqueryIntegrationTests extends IntegrationTests {
 
 	public ConqueryIntegrationTests() {
-		super("tests/");
+		super("tests/","com.bakdata.conquery.integration");
 	}
 	
 	@Override

--- a/backend/src/test/java/com/bakdata/conquery/integration/IntegrationTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/IntegrationTest.java
@@ -11,7 +11,7 @@ public interface IntegrationTest {
 
 	void execute(String name, TestConquery testConquery) throws Exception;
 
-	static abstract class Simple implements IntegrationTest {
+	abstract class Simple implements IntegrationTest {
 		public abstract void execute(StandaloneSupport conquery) throws Exception;
 		
 		@Override
@@ -24,7 +24,7 @@ public interface IntegrationTest {
 	
 	@Slf4j
 	@RequiredArgsConstructor
-	static final class Wrapper implements Executable {
+	final class Wrapper implements Executable {
 		private final String name;
 		private final TestConquery testConquery;
 		private final IntegrationTest test;

--- a/backend/src/test/java/com/bakdata/conquery/integration/IntegrationTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/IntegrationTest.java
@@ -1,5 +1,6 @@
 package com.bakdata.conquery.integration;
 
+import com.bakdata.conquery.util.io.ConqueryMDC;
 import com.bakdata.conquery.util.support.StandaloneSupport;
 import com.bakdata.conquery.util.support.TestConquery;
 import lombok.RequiredArgsConstructor;
@@ -30,14 +31,17 @@ public interface IntegrationTest {
 		
 		@Override
 		public void execute() throws Throwable {
+			ConqueryMDC.setLocation(name);
 			log.info("STARTING integration test {}", name);
 			try {
 				test.execute(name, testConquery);
 			}
 			catch(Exception e) {
+				ConqueryMDC.setLocation(name);
 				log.info("FAILED integration test "+name, e);
 				throw e;
 			}
+			ConqueryMDC.setLocation(name);
 			log.info("SUCCESS integration test {}", name);
 		}
 	}

--- a/backend/src/test/java/com/bakdata/conquery/integration/IntegrationTests.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/IntegrationTests.java
@@ -14,10 +14,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.DynamicNode;
-import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.extension.RegisterExtension;
-
 import com.bakdata.conquery.TestTags;
 import com.bakdata.conquery.integration.json.JsonIntegrationTest;
 import com.bakdata.conquery.integration.tests.ProgrammaticIntegrationTest;
@@ -25,16 +21,19 @@ import com.bakdata.conquery.io.cps.CPSTypeIdResolver;
 import com.bakdata.conquery.io.jackson.Jackson;
 import com.bakdata.conquery.util.support.TestConquery;
 import com.fasterxml.jackson.databind.JsonNode;
-
 import io.github.classgraph.Resource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 @Slf4j @RequiredArgsConstructor
 public class IntegrationTests {
 
 	
 	private final String defaultTestRoot;
+	private final String defaultTestRootPackage;
 	
 	@RegisterExtension
 	public static final TestConquery CONQUERY = new TestConquery();
@@ -72,6 +71,7 @@ public class IntegrationTests {
 		List<Class<?>> programmatic = CPSTypeIdResolver
 			.SCAN_RESULT
 			.getClassesImplementing(ProgrammaticIntegrationTest.class.getName())
+			.filter(info -> info.getPackageName().startsWith(defaultTestRootPackage))
 			.loadClasses();
 
 		return programmatic


### PR DESCRIPTION
Restrict entity upload based on a permission check that scans incomming queries for parts that required an resolving of external Ids