### PR TITLE
Don't display done too early

### DIFF
--- a/frontend/lib/js/query-runner/QueryRunner.js
+++ b/frontend/lib/js/query-runner/QueryRunner.js
@@ -91,6 +91,7 @@ const QueryRunner = (props: PropsType) => {
         {!!queryRunner &&
           !!queryRunner.queryResult &&
           !queryRunner.queryResult.error &&
+          !queryRunner.queryResult.loading &&
           !isQueryRunning && (
             <QueryResults
               datasetId={queryRunner.queryResult.datasetId}

--- a/frontend/lib/localization/de.yml
+++ b/frontend/lib/localization/de.yml
@@ -31,7 +31,7 @@ queryRunner:
   stopSuccess: "Anfrage gestoppt."
   stopError: "Anfrage stoppen fehlgeschlagen."
   startSuccess: "Anfrage gestartet."
-  endSuccess: "Anfrage erfolgreich gestartet" # TODO This is a hotfix
+  endSuccess: "Anfrage erfolgreich"
   startError: "Anfrage starten fehlgeschlagen."
   resultError: "Anfrageergebnis konnte nicht geladen werden."
   resultCount: "Ergebnisse"


### PR DESCRIPTION
Reverts the hotfix and prevents displaying the `endSuccess` too early