### PR TITLE
Add a FormConceptCopyModal to select concepts to copy in detail

### DIFF
--- a/frontend/lib/js/button/PrimaryButton.js
+++ b/frontend/lib/js/button/PrimaryButton.js
@@ -12,12 +12,6 @@ export default styled(BasicButton)`
   border: none;
 
   &:hover {
-    background-color: ${({ theme }) => `rgba(${theme.col.blueGrayDark}, 0.8)`};
-    border-color: ${({ theme }) => `rgba(${theme.col.blueGrayDark}, 0.8)`};
-  }
-
-  &:disabled {
-    background-color: ${({ theme }) => theme.col.blueGrayDark};
-    border-color: ${({ theme }) => theme.col.blueGrayDark};
+    opacity: 0.9;
   }
 `;

--- a/frontend/lib/js/external-forms/FormsQueryRunner.js
+++ b/frontend/lib/js/external-forms/FormsQueryRunner.js
@@ -11,8 +11,7 @@ import {
   selectFormConfig,
   selectQueryRunner,
   selectRunningQuery,
-  selectActiveForm,
-  selectActiveFormValues
+  selectActiveForm
 } from "./stateSelectors";
 
 import { QueryRunner } from "../query-runner";
@@ -20,10 +19,9 @@ import { QueryRunner } from "../query-runner";
 const { startExternalFormsQuery, stopExternalFormsQuery } = actions;
 
 const isActiveFormValid = state => {
-  const form = selectActiveFormValues(state);
   const activeForm = selectActiveForm(state);
 
-  if (!form || !activeForm) return false;
+  if (!activeForm) return false;
 
   return (
     !isPristine(activeForm, selectReduxFormState)(state) &&

--- a/frontend/lib/js/external-forms/form-components/DropzoneList.js
+++ b/frontend/lib/js/external-forms/form-components/DropzoneList.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from "react";
+import * as React from "react";
 import styled from "@emotion/styled";
 
 import IconButton from "../../button/IconButton";
@@ -27,7 +27,7 @@ const StyledIconButton = styled(IconButton)`
 
 type PropsType = {
   className?: string,
-  label?: string,
+  label?: React.ReactNode,
   dropzoneText: string,
   items: any,
   acceptedDropTypes: string[],

--- a/frontend/lib/js/external-forms/form-concept-group/FormConceptCopyModal.js
+++ b/frontend/lib/js/external-forms/form-concept-group/FormConceptCopyModal.js
@@ -1,0 +1,174 @@
+// @flow
+
+import React from "react";
+import { useSelector } from "react-redux";
+import styled from "@emotion/styled";
+import T from "i18n-react";
+
+import { Modal } from "../../modal";
+import BasicButton from "../../button/BasicButton";
+import PrimaryButton from "../../button/PrimaryButton";
+import {
+  selectActiveFormValues,
+  useVisibleConceptListFields
+} from "../stateSelectors";
+import { InputSelect, InputCheckbox } from "../../form-components";
+import { getLocale } from "../../localization";
+
+const Buttons = styled("div")`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  margin-top: 20px;
+`;
+
+const Options = styled("div")`
+  padding: 8px 0 0 28px;
+  overflow-y: auto;
+  max-height: 345px;
+`;
+
+const SelectAllCheckbox = styled(InputCheckbox)`
+  margin: 10px 0 0 8px;
+`;
+
+const SxInputCheckbox = styled(InputCheckbox)`
+  margin: 5px 0;
+`;
+
+type PropsT = {
+  targetFieldname: string,
+  onAccept: (selectedNodes: Object[]) => void,
+  onClose: () => void
+};
+
+const FormConceptCopyModal = ({
+  targetFieldname,
+  onAccept,
+  onClose
+}: PropsT) => {
+  const locale = getLocale();
+  const formValues = useSelector(state => selectActiveFormValues(state));
+  const visibleConceptListFields = useVisibleConceptListFields();
+
+  const conceptListFieldOptions = visibleConceptListFields
+    .filter(field => field.name !== targetFieldname)
+    .map(field => ({
+      label: field.label[locale],
+      value: field.name
+    }));
+
+  // Since the modal is only rendered when there exists more than one concept list field
+  // we can assume that `conceptListFieldOptions` still has length >= 1
+  const [selectedOption, setSelectedOption] = React.useState<string>(
+    conceptListFieldOptions[0].value
+  );
+
+  const [valuesChecked, setValuesChecked] = React.useState<{
+    [key: number]: boolean
+  }>({});
+
+  React.useEffect(() => {
+    const values = formValues[selectedOption];
+    const initiallyChecked = values.reduce((checkedValues, value, i) => {
+      checkedValues[i] = false;
+      return checkedValues;
+    }, {});
+
+    setValuesChecked(initiallyChecked);
+  }, [selectedOption]);
+
+  const allConceptsSelected = Object.keys(valuesChecked).every(
+    key => valuesChecked[key]
+  );
+
+  function idxHasConcepts(idx: number) {
+    const values = formValues[selectedOption];
+    const concepts = values[idx].concepts.filter(cpt => !!cpt);
+
+    return concepts.length > 0;
+  }
+
+  function getLabelFromIdx(idx: number) {
+    const values = formValues[selectedOption];
+    const concepts = values[idx].concepts.filter(cpt => !!cpt);
+
+    if (concepts.length === 0) return "-";
+
+    return (
+      concepts[0].label +
+      (concepts.length > 1 ? ` + ${concepts.length - 1}` : "")
+    );
+  }
+
+  function onToggleAllConcepts(checked: boolean) {
+    const allChecked = Object.keys(valuesChecked).reduce((all, key) => {
+      all[key] = allConceptsSelected ? false : true;
+
+      return all;
+    }, {});
+
+    setValuesChecked(allChecked);
+  }
+
+  function onToggleConcept(idx: number, checked: boolean) {
+    const nextValues = {
+      ...valuesChecked,
+      [idx]: checked
+    };
+
+    setValuesChecked(nextValues);
+  }
+
+  function onSubmit() {
+    const selectedValues = Object.keys(valuesChecked)
+      .filter(key => valuesChecked[key])
+      .map(key => formValues[selectedOption][key]);
+
+    onAccept(selectedValues);
+    onClose();
+  }
+
+  return (
+    <Modal
+      onClose={onClose}
+      closeIcon
+      headline={T.translate("externalForms.copyModal.headline")}
+    >
+      <InputSelect
+        label={T.translate("externalForms.copyModal.selectLabel")}
+        options={conceptListFieldOptions}
+        input={{ onChange: setSelectedOption, value: selectedOption }}
+      />
+      <SelectAllCheckbox
+        label={T.translate("externalForms.copyModal.selectAll")}
+        input={{ value: allConceptsSelected, onChange: onToggleAllConcepts }}
+      />
+      <Options>
+        {Object.keys(valuesChecked).map((idx, i) =>
+          idxHasConcepts ? (
+            <SxInputCheckbox
+              key={idx}
+              label={getLabelFromIdx(idx)}
+              input={{
+                value: valuesChecked[idx],
+                onChange: (checked: boolean) => onToggleConcept(idx, checked)
+              }}
+            />
+          ) : null
+        )}
+      </Options>
+      <Buttons>
+        <BasicButton onClick={onClose}>
+          {T.translate("common.cancel")}
+        </BasicButton>
+        <PrimaryButton onClick={onSubmit}>
+          {T.translate("externalForms.copyModal.accept")}
+        </PrimaryButton>
+      </Buttons>
+    </Modal>
+  );
+};
+
+export default FormConceptCopyModal;

--- a/frontend/lib/js/external-forms/form-concept-group/FormConceptCopyModal.js
+++ b/frontend/lib/js/external-forms/form-concept-group/FormConceptCopyModal.js
@@ -83,6 +83,10 @@ const FormConceptCopyModal = ({
     key => valuesChecked[key]
   );
 
+  const isAcceptDisabled = Object.keys(valuesChecked).every(
+    key => !valuesChecked[key]
+  );
+
   function idxHasConcepts(idx: number) {
     const values = formValues[selectedOption];
     const concepts = values[idx].concepts.filter(cpt => !!cpt);
@@ -163,7 +167,7 @@ const FormConceptCopyModal = ({
         <BasicButton onClick={onClose}>
           {T.translate("common.cancel")}
         </BasicButton>
-        <PrimaryButton onClick={onSubmit}>
+        <PrimaryButton onClick={onSubmit} disabled={isAcceptDisabled}>
           {T.translate("externalForms.copyModal.accept")}
         </PrimaryButton>
       </Buttons>

--- a/frontend/lib/js/external-forms/form-concept-group/FormConceptGroup.js
+++ b/frontend/lib/js/external-forms/form-concept-group/FormConceptGroup.js
@@ -487,6 +487,21 @@ const FormConceptGroup = (props: PropsType) => {
     onCloseModal();
   };
 
+  const onAcceptCopyModal = valuesToCopy => {
+    // Deeply copy all values + concepts
+    const nextValue = valuesToCopy.reduce((currentValue, value) => {
+      const newVal = addValue(currentValue, newValue);
+
+      return value.concepts.reduce(
+        (curVal, concept) =>
+          addConcept(newVal, curVal.length, copyConcept(concept)),
+        currentValue
+      );
+    }, props.input.value);
+
+    return props.input.onChange(nextValue);
+  };
+
   return (
     <div>
       <DropzoneList
@@ -634,19 +649,7 @@ const FormConceptGroup = (props: PropsType) => {
       {isCopyModalOpen && (
         <FormConceptCopyModal
           targetFieldname={props.fieldName}
-          onAccept={valuesToCopy => {
-            const nextValue = valuesToCopy.reduce((currentValue, value) => {
-              const newVal = addValue(currentValue, newValue);
-
-              return value.concepts.reduce(
-                (curVal, concept) =>
-                  addConcept(newVal, curVal.length, copyConcept(concept)),
-                currentValue
-              );
-            }, props.input.value);
-
-            return props.input.onChange(nextValue);
-          }}
+          onAccept={onAcceptCopyModal}
           onClose={() => setIsCopyModalOpen(false)}
         />
       )}

--- a/frontend/lib/js/external-forms/form-concept-group/FormConceptGroup.js
+++ b/frontend/lib/js/external-forms/form-concept-group/FormConceptGroup.js
@@ -79,13 +79,12 @@ const onToggleIncludeSubnodes = (
   includeSubnodes,
   newValue
 ) => {
-  const feature = value[valueIdx];
-  const concepts = feature.concepts;
-  const formConcept = concepts[conceptIdx];
-  const concept = getConceptById(formConcept.ids);
+  const element = value[valueIdx];
+  const concept = element.concepts[conceptIdx];
+  const conceptData = getConceptById(concept.ids);
 
   const childIds = [];
-  const elements = concept.children.map(childId => {
+  const elements = conceptData.children.map(childId => {
     const child = getConceptById(childId);
 
     childIds.push(childId);
@@ -97,9 +96,9 @@ const onToggleIncludeSubnodes = (
           ids: [childId],
           label: child.label,
           description: child.description,
-          tables: formConcept.tables,
-          selects: formConcept.selects,
-          tree: formConcept.tree
+          tables: concept.tables,
+          selects: concept.selects,
+          tree: concept.tree
         }
       ]
     };
@@ -107,15 +106,20 @@ const onToggleIncludeSubnodes = (
 
   const nextValue = includeSubnodes
     ? [...value, ...elements]
-    : value.filter(f =>
-        f.concepts.some(c => {
-          return childIds.every(childId => !includes(c.ids, childId));
+    : value.filter(val =>
+        val.concepts.some(cpt => {
+          return childIds.every(childId => !includes(cpt.ids, childId));
         })
       );
 
-  return setConceptProperties(nextValue, valueIdx, conceptIdx, {
-    includeSubnodes
-  });
+  return setConceptProperties(
+    nextValue,
+    nextValue.indexOf(element),
+    conceptIdx,
+    {
+      includeSubnodes
+    }
+  );
 };
 
 const createQueryNodeFromConceptListUploadResult = (

--- a/frontend/lib/js/external-forms/form/Field.js
+++ b/frontend/lib/js/external-forms/form/Field.js
@@ -189,6 +189,7 @@ const Field = ({ field, ...commonProps }: PropsType) => {
           name={field.name}
           component={ConceptGroup}
           props={{
+            fieldName: field.name,
             label: field.label[locale],
             conceptDropzoneText: field.conceptDropzoneLabel
               ? field.conceptDropzoneLabel[locale]

--- a/frontend/lib/js/external-forms/stateSelectors.js
+++ b/frontend/lib/js/external-forms/stateSelectors.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { initTables } from "./transformers";
+import { useSelector } from "react-redux";
 
 const selectFormField = (state, formName, fieldName) => {
   if (
@@ -64,7 +65,7 @@ export const selectActiveFormValues = (state: Object) => {
   const reduxForm = selectReduxForm(state);
   const activeForm = selectActiveForm(state);
 
-  return reduxForm ? reduxForm[activeForm] : {};
+  return reduxForm && activeForm ? reduxForm[activeForm].values : {};
 };
 
 export const selectAvailableForms = (state: Object) =>
@@ -90,4 +91,49 @@ export const selectRunningQuery = (state: Object) => {
   const queryRunner = selectQueryRunner(state);
 
   return queryRunner ? queryRunner.runningQuery : null;
+};
+
+function getVisibleConceptListFields(config, values) {
+  const topLevelFields = config.fields.filter(
+    field => field.type === "CONCEPT_LIST"
+  );
+  const tabFields = config.fields.filter(field => field.type === "TABS");
+
+  const fieldsWithinVisibleTabs = tabFields.reduce((fields, tabField) => {
+    const activeTabName = values[tabField.name];
+    const activeTab = tabField.tabs.find(tab => tab.name === activeTabName);
+
+    const activeTabConceltListFields = activeTab
+      ? getVisibleConceptListFields(activeTab)
+      : [];
+
+    return [...fields, ...activeTabConceltListFields];
+  }, []);
+
+  return [...topLevelFields, ...fieldsWithinVisibleTabs];
+}
+
+export const useVisibleConceptListFields = () => {
+  const config = useSelector(state => selectFormConfig(state));
+  const values = useSelector(state => selectActiveFormValues(state));
+
+  if (!config) return false;
+
+  return getVisibleConceptListFields(config, values);
+};
+
+export const useAllowExtendedCopying = (targetFieldname: string) => {
+  const values = useSelector(state => selectActiveFormValues(state));
+  const otherConceptListFields = useVisibleConceptListFields().filter(
+    field => field.name !== targetFieldname
+  );
+
+  // Need to have min 2 fields to copy from one to another
+  if (otherConceptListFields.length < 1) return false;
+
+  const fieldHasFilledConcept = field =>
+    !!values[field.name] &&
+    values[field.name].some(value => value.concepts.some(concept => !!concept));
+
+  return otherConceptListFields.some(fieldHasFilledConcept);
 };

--- a/frontend/lib/localization/de.yml
+++ b/frontend/lib/localization/de.yml
@@ -206,6 +206,11 @@ externalForms:
   default:
     conceptDropzoneLabel: "Füge ein Konzept oder eine Konzeptliste hinzu"
     conceptColumnDropzoneLabel: "Füge ein Konzept oder eine Konzeptliste hinzu"
+  copyModal:
+    headline: "Kopieren von Konzepten aus anderem Feld"
+    selectLabel: "Kopieren aus Quelle"
+    selectAll: "Alle auswählen"
+    accept: "Kopieren"
   common:
     relativeToIndex: "Relativ zum Indexdatum"
     timespan: "Zeitraum"
@@ -231,6 +236,7 @@ externalForms:
     edit: "Bearbeiten"
     concept:
       expand: "Untergeordnete Attribute einbeziehen / wieder ausschließen."
+      copyFrom: "Kopieren von ..."
     clear: "Formular leeren"
 
 uploadQueryResultsModal:

--- a/frontend/lib/localization/en.yml
+++ b/frontend/lib/localization/en.yml
@@ -206,6 +206,11 @@ externalForms:
   default:
     conceptDropzoneLabel: "Add a concept or a concept list"
     conceptColumnDropzoneLabel: "Add a concept or a concept list"
+  copyModal:
+    headline: "Copy concepts form another field"
+    selectLabel: "Copy from source"
+    selectAll: "Select all"
+    accept: "Copy"
   common:
     relativeToIndex: "Relative to index date"
     timespan: "Time span"
@@ -231,6 +236,7 @@ externalForms:
     edit: "Edit"
     concept:
       expand: "Include / exclude sub-attributes"
+      copyFrom: "Copy from ..."
     clear: "Clear form"
 
 uploadQueryResultsModal:


### PR DESCRIPTION
Looks like this:
<img width="952" alt="Bildschirmfoto 2020-03-16 um 15 41 58" src="https://user-images.githubusercontent.com/1403093/76772256-e2757c00-67a0-11ea-9697-f2a5013c4f38.png">

And is almost done.

TODO:
- [ ] Make sure there is no conflict with expand-unexpand subnodes after a successful copying
- [ ] Refactor this a bit to make the logic less complicated (e.g. no nested reduce)