### PR TITLE
Slims status generation

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesProcessor.java
@@ -1,6 +1,8 @@
 package com.bakdata.conquery.apiv1;
 
-import static com.bakdata.conquery.models.auth.AuthorizationHelper.*;
+import static com.bakdata.conquery.models.auth.AuthorizationHelper.addPermission;
+import static com.bakdata.conquery.models.auth.AuthorizationHelper.authorize;
+import static com.bakdata.conquery.models.auth.AuthorizationHelper.removePermission;
 
 import java.util.Collection;
 import java.util.List;
@@ -163,7 +165,7 @@ public class StoredQueriesProcessor {
 		if (query == null) {
 			return null;
 		}
-		return query.buildStatus(storage, user);
+		return query.buildStatusWithSource(storage, null, user);
 	}
 
 	public void shareQuery(User user, ManagedQuery query, Collection<GroupId> groupIds, Boolean shared) throws JSONException {

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java
@@ -6,18 +6,15 @@ import com.bakdata.conquery.apiv1.QueryDescription;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
 import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 
-@Getter
-@Setter
 @NoArgsConstructor
 @ToString
 @AllArgsConstructor
-@Builder
+@Data
 public class ExecutionStatus {
 
 	private String[] tags;
@@ -29,12 +26,18 @@ public class ExecutionStatus {
 	private boolean shared;
 	private boolean own;
 	private boolean system;
-	private QueryDescription query;
 
 	private ManagedExecutionId id;
 	private ExecutionState status;
-	private String message;
 	private Long numberOfResults;
 	private Long requiredTime;
 	private String resultUrl;
+
+	@Data
+	@NoArgsConstructor
+	@EqualsAndHashCode(callSuper = true)
+	public static class WithQuery extends ExecutionStatus {
+		private QueryDescription query;
+		
+	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
@@ -163,26 +163,36 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 		}
 	}
 
+	protected ExecutionStatus buildStatusBase(@NonNull MasterMetaStorage storage, URLBuilder url, @NonNull  User user, @NonNull ExecutionStatus status) {
+		status.setLabel(label == null ? queryId.toString() : label);
+		status.setId(getId());
+		status.setTags(tags);
+		status.setShared(shared);
+		status.setOwn(getOwner().equals(user.getId()));
+		status.setCreatedAt(getCreationTime().atZone(ZoneId.systemDefault()));
+		status.setRequiredTime((startTime != null && finishTime != null) ? ChronoUnit.MILLIS.between(startTime, finishTime) : null);
+		status.setStatus(state);
+		status.setOwner(Optional.ofNullable(owner).orElse(null));
+		status.setOwnerName(Optional.ofNullable(owner).map(owner -> storage.getUser(owner)).map(User::getLabel).orElse(null));
+		status.setResultUrl(
+			isReadyToDownload(url, user)
+				? url.set(ResourceConstants.DATASET, dataset.getName()).set(ResourceConstants.QUERY, getId().toString())
+					.to(ResultCSVResource.GET_CSV_PATH).get()
+				: null);
+		return status;
+	}
+
 	public ExecutionStatus buildStatus(@NonNull MasterMetaStorage storage, URLBuilder url, User user) {
-		return ExecutionStatus.builder()
-							  .label(label == null ? queryId.toString() : label)
-							  .id(getId())
-							  .query(getSubmitted())
-							  .tags(tags)
-							  .shared(shared)
-							  .own(getOwner().equals(user.getId()))
-							  .createdAt(getCreationTime().atZone(ZoneId.systemDefault()))
-							  .requiredTime((startTime != null && finishTime != null) ? ChronoUnit.MILLIS.between(startTime, finishTime) : null).status(state)
-							  .owner(Optional.ofNullable(owner).orElse(null))
-							  .ownerName(
-									  Optional.ofNullable(owner).map(owner -> storage.getUser(owner)).map(User::getLabel)
-											  .orElse(null))
-							  .resultUrl(
-									  isReadyToDownload(url, user)
-									  ? url.set(ResourceConstants.DATASET, dataset.getName()).set(ResourceConstants.QUERY, getId().toString())
-										   .to(ResultCSVResource.GET_CSV_PATH).get()
-									  : null)
-							  .build();
+		ExecutionStatus status = new ExecutionStatus();
+		return buildStatusBase(storage, url, user, status);
+		
+		
+	}
+	
+	public ExecutionStatus buildStatusWithSource(@NonNull MasterMetaStorage storage, URLBuilder url, User user) {
+		ExecutionStatus.WithQuery status = new ExecutionStatus.WithQuery();
+		status.setQuery(getSubmitted());
+		return buildStatusBase(storage, url, user, status);
 	}
 
 	public boolean isReadyToDownload(URLBuilder url, User user) {
@@ -196,10 +206,6 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 		return url != null && state != ExecutionState.NEW && isPermittedDownload;
 	}
 
-	public ExecutionStatus buildStatus(@NonNull MasterMetaStorage storage, User user) {
-		return buildStatus(storage, null, user);
-	}
-
 	public abstract Collection<ManagedQuery> toResultQuery();
 	
 	/**
@@ -210,6 +216,9 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 	public abstract Set<NamespacedId> getUsedNamespacedIds();
 
 
+	/**
+	 * Creates a mapping from subexecutions. Their id is mapped to their {@link QueryPlan}.
+	 */
 	public abstract Map<ManagedExecutionId,QueryPlan> createQueryPlans(QueryPlanContext context);
 
 	public abstract void addResult(@NonNull MasterMetaStorage storage, R result);

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
@@ -163,7 +163,7 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 		}
 	}
 
-	protected ExecutionStatus buildStatusBase(@NonNull MasterMetaStorage storage, URLBuilder url, @NonNull  User user, @NonNull ExecutionStatus status) {
+	protected void setStatusBase(@NonNull MasterMetaStorage storage, URLBuilder url, @NonNull  User user, @NonNull ExecutionStatus status) {
 		status.setLabel(label == null ? queryId.toString() : label);
 		status.setId(getId());
 		status.setTags(tags);
@@ -179,12 +179,12 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 				? url.set(ResourceConstants.DATASET, dataset.getName()).set(ResourceConstants.QUERY, getId().toString())
 					.to(ResultCSVResource.GET_CSV_PATH).get()
 				: null);
-		return status;
 	}
 
 	public ExecutionStatus buildStatus(@NonNull MasterMetaStorage storage, URLBuilder url, User user) {
 		ExecutionStatus status = new ExecutionStatus();
-		return buildStatusBase(storage, url, user, status);
+		setStatusBase(storage, url, user, status);
+		return status;
 		
 		
 	}
@@ -192,7 +192,8 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 	public ExecutionStatus buildStatusWithSource(@NonNull MasterMetaStorage storage, URLBuilder url, User user) {
 		ExecutionStatus.WithQuery status = new ExecutionStatus.WithQuery();
 		status.setQuery(getSubmitted());
-		return buildStatusBase(storage, url, user, status);
+		setStatusBase(storage, url, user, status);
+		return status;
 	}
 
 	public boolean isReadyToDownload(URLBuilder url, User user) {

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
@@ -10,14 +10,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import com.bakdata.conquery.apiv1.QueryDescription;
-import com.bakdata.conquery.apiv1.URLBuilder;
 import com.bakdata.conquery.apiv1.forms.Form;
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.io.jackson.InternalOnly;
 import com.bakdata.conquery.io.xodus.MasterMetaStorage;
-import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.execution.ExecutionState;
-import com.bakdata.conquery.models.execution.ExecutionStatus;
 import com.bakdata.conquery.models.execution.ManagedExecution;
 import com.bakdata.conquery.models.forms.managed.ManagedForm.FormSharedResult;
 import com.bakdata.conquery.models.identifiable.IdMap;
@@ -94,14 +91,6 @@ public class ManagedForm extends ManagedExecution<FormSharedResult> {
 		super.start();
 	}
 	
-	@Override
-	public ExecutionStatus buildStatus(@NonNull MasterMetaStorage storage, URLBuilder url, User user) {
-		ExecutionStatus status = super.buildStatus(storage, url, user);
-		// Send null here, because no usable value can be reported to the user for a form
-		status.setNumberOfResults(null);
-		return status;
-	}
-
 	@Override
 	public Collection<ManagedQuery> toResultQuery() {
 		if(subQueries.size() == 1) {

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
@@ -31,6 +31,7 @@ import com.bakdata.conquery.models.worker.Namespaces;
 import com.bakdata.conquery.util.QueryUtils.NamespacedIdCollector;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -163,6 +164,7 @@ public class ManagedForm extends ManagedExecution<FormSharedResult> {
 	
 	@Data
 	@CPSType(id = "FORM_SHARD_RESULT", base = ShardResult.class)
+	@EqualsAndHashCode(callSuper = true)
 	public static class FormSharedResult extends ShardResult {
 		private ManagedExecutionId subqueryId;
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
@@ -120,10 +120,9 @@ public class ManagedQuery extends ManagedExecution<ShardResult> {
 	}
 	
 	@Override
-	protected ExecutionStatus buildStatusBase(@NonNull MasterMetaStorage storage, URLBuilder url, @NonNull  User user, @NonNull ExecutionStatus status) {
-		super.buildStatusBase(storage, url, user, status);
+	protected void setStatusBase(@NonNull MasterMetaStorage storage, URLBuilder url, @NonNull  User user, @NonNull ExecutionStatus status) {
+		super.setStatusBase(storage, url, user, status);
 		status.setNumberOfResults(lastResultCount);
-		return status;
 	}
 	
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
@@ -120,8 +120,8 @@ public class ManagedQuery extends ManagedExecution<ShardResult> {
 	}
 	
 	@Override
-	public ExecutionStatus buildStatus(@NonNull MasterMetaStorage storage, URLBuilder url, User user) {
-		ExecutionStatus status = super.buildStatus(storage, url, user);
+	protected ExecutionStatus buildStatusBase(@NonNull MasterMetaStorage storage, URLBuilder url, @NonNull  User user, @NonNull ExecutionStatus status) {
+		super.buildStatusBase(storage, url, user, status);
 		status.setNumberOfResults(lastResultCount);
 		return status;
 	}

--- a/docs/REST API JSONs.md
+++ b/docs/REST API JSONs.md
@@ -654,7 +654,7 @@ Supported Fields:
 | [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/config/FrontendConfig.java#L24) | thousandSeparator | `String` | `"."` |  |  | 
 </p></details>
 
-### Type ExecutionStatus<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L15)</sup></sub></sup>
+### Type ExecutionStatus<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L14)</sup></sub></sup>
 
 
 <details><summary>Details</summary><p>
@@ -665,22 +665,20 @@ Supported Fields:
 
 |  | Field | Type | Default | Example | Description |
 | --- | --- | --- | --- | --- | --- |
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L25) | createdAt | `ZonedDateTime` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L34) | id | ID of `ManagedExecution` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L24) | label | `String` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L26) | lastUsed | `ZonedDateTime` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L36) | message | `String` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L37) | numberOfResults | `long` or `null` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L30) | own | `boolean` | `false` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L27) | owner | ID of `User` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L28) | ownerName | `String` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L32) | query | [QueryDescription](#Base-QueryDescription) | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L38) | requiredTime | `long` or `null` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L39) | resultUrl | `String` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L29) | shared | `boolean` | `false` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L35) | status | one of NEW, RUNNING, CANCELED, FAILED, DONE | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L31) | system | `boolean` | `false` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L23) | tags | list of `String` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L22) | createdAt | `ZonedDateTime` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L30) | id | ID of `ManagedExecution` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L21) | label | `String` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L23) | lastUsed | `ZonedDateTime` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L32) | numberOfResults | `long` or `null` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L27) | own | `boolean` | `false` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L24) | owner | ID of `User` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L25) | ownerName | `String` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L33) | requiredTime | `long` or `null` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L34) | resultUrl | `String` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L26) | shared | `boolean` | `false` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L31) | status | one of NEW, RUNNING, CANCELED, FAILED, DONE | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L28) | system | `boolean` | `false` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L20) | tags | list of `String` | `null` |  |  | 
 </p></details>
 
 ### Type FERoot<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/api/description/FERoot.java#L10-L12)</sup></sub></sup>


### PR DESCRIPTION
Before the complete query source was send, when all stored queries were requested.
This could lead to enormous Responses.

Now only general status information is send, when all queries are requested.
The complete query source is only send, when a  specific query is requested.