### PR TITLE
Simplify list rendering in preview

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,8 +60,6 @@
     "react-select": "^3.0.4",
     "react-split-pane": "^0.1.91",
     "react-tippy": "^1.2.3",
-    "react-virtualized-auto-sizer": "^1.0.2",
-    "react-window": "^1.8.5",
     "redux": "^4.0.5",
     "redux-form": "^8.2.4",
     "redux-multi": "^0.1.12",

--- a/frontend/src/localization/de.json
+++ b/frontend/src/localization/de.json
@@ -325,7 +325,7 @@
   "preview": {
     "preview": "Vorschau",
     "headline": "Ergebnisvorschau",
-    "explanation": "Stellt die CSV-Datei der Ergebnisse dar",
+    "explanation": "Stellt die ersten {count} Zeilen der Ergebnisse dar",
     "total": "Zeilen",
     "min": "Min Datum",
     "max": "Max Datum",

--- a/frontend/src/localization/en.json
+++ b/frontend/src/localization/en.json
@@ -325,7 +325,7 @@
   "preview": {
     "preview": "Preview",
     "headline": "Results preview",
-    "explanation": "Visualizes the CSV file for the results",
+    "explanation": "Visualizes the first {count} lines from the results",
     "total": "Total rows",
     "min": "Min date",
     "max": "Max date",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7953,11 +7953,6 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
-"memoize-one@>=3.1.1 <6":
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.0.5.tgz#8cd3809555723a07684afafcd6f756072ac75d7e"
-  integrity sha512-ey6EpYv0tEaIbM/nTDOpHciXUvd+ackQrJgEzBwemhZZIWZjcyodqEcrmqDy2BKRTM3a65kKBV4WtLXJDt26SQ==
-
 memoize-one@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.1.0.tgz#a2387c58c03fff27ca390c31b764a79addf3f906"
@@ -10619,19 +10614,6 @@ react-transition-group@^2.2.1:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
-
-react-virtualized-auto-sizer@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.2.tgz#a61dd4f756458bbf63bd895a92379f9b70f803bd"
-  integrity sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg==
-
-react-window@^1.8.5:
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.5.tgz#a56b39307e79979721021f5d06a67742ecca52d1"
-  integrity sha512-HeTwlNa37AFa8MDZFZOKcNEkuF2YflA0hpGPiTT9vR7OawEt+GZbfM6wqkBahD3D3pUjIabQYzsnY/BSJbgq6Q==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    memoize-one ">=3.1.1 <6"
 
 react@16.8.6:
   version "16.8.6"


### PR DESCRIPTION
Don't use react-window with a virtualized list anymore.
Now the header isn't sticky anymore, but that's the price we'll have to
pay until we consider this more important