### PR TITLE
also send query description in status from query-endpoint

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
@@ -148,7 +148,7 @@ public class QueryProcessor {
 	}
 
 	public ExecutionStatus getStatus(Dataset dataset, ManagedExecution<?> query, URLBuilder urlb, User user) {
-		return query.buildStatus(storage, urlb, user);
+		return query.buildStatus(storage, urlb, user, true, false);
 	}
 
 	public ExecutionStatus cancel(Dataset dataset, ManagedExecution<?> query, URLBuilder urlb) {

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
@@ -17,6 +17,7 @@ import com.bakdata.conquery.models.auth.permissions.DatasetPermission;
 import com.bakdata.conquery.models.auth.permissions.QueryPermission;
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.execution.ExecutionStatus;
+import com.bakdata.conquery.models.execution.ExecutionStatus.CreationFlag;
 import com.bakdata.conquery.models.execution.ManagedExecution;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
@@ -148,7 +149,7 @@ public class QueryProcessor {
 	}
 
 	public ExecutionStatus getStatus(Dataset dataset, ManagedExecution<?> query, URLBuilder urlb, User user) {
-		return query.buildStatus(storage, urlb, user, true, false);
+		return query.buildStatus(storage, urlb, user, CreationFlag.WITH_COLUMN_DESCIPTION);
 	}
 
 	public ExecutionStatus cancel(Dataset dataset, ManagedExecution<?> query, URLBuilder urlb) {

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesProcessor.java
@@ -52,7 +52,9 @@ public class StoredQueriesProcessor {
 						mq.buildStatus(
 							storage,
 							URLBuilder.fromRequest(req),
-							user));
+							user,
+							false,
+							false));
 				}
 				catch (Exception e) {
 					log.warn("Could not build status of " + mq, e);
@@ -70,7 +72,7 @@ public class StoredQueriesProcessor {
 		if (query == null) {
 			return null;
 		}
-		return query.buildStatusWithSource(storage, null, user);
+		return query.buildStatus(storage, null, user, true, true);
 	}
 
 	public void patchQuery(User user, ManagedExecutionId executionId, MetaDataPatch patch) throws JSONException {

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesProcessor.java
@@ -4,6 +4,7 @@ import static com.bakdata.conquery.models.auth.AuthorizationHelper.*;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -17,6 +18,7 @@ import com.bakdata.conquery.models.auth.permissions.QueryPermission;
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.exceptions.JSONException;
 import com.bakdata.conquery.models.execution.ExecutionStatus;
+import com.bakdata.conquery.models.execution.ExecutionStatus.CreationFlag;
 import com.bakdata.conquery.models.execution.ManagedExecution;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
 import com.bakdata.conquery.models.query.ManagedQuery;
@@ -52,9 +54,7 @@ public class StoredQueriesProcessor {
 						mq.buildStatus(
 							storage,
 							URLBuilder.fromRequest(req),
-							user,
-							false,
-							false));
+							user));
 				}
 				catch (Exception e) {
 					log.warn("Could not build status of " + mq, e);
@@ -72,7 +72,7 @@ public class StoredQueriesProcessor {
 		if (query == null) {
 			return null;
 		}
-		return query.buildStatus(storage, null, user, true, true);
+		return query.buildStatus(storage, null, user, EnumSet.of(CreationFlag.WITH_COLUMN_DESCIPTION, CreationFlag.WITH_SOURCE));
 	}
 
 	public void patchQuery(User user, ManagedExecutionId executionId, MetaDataPatch patch) throws JSONException {

--- a/backend/src/main/java/com/bakdata/conquery/models/config/CSVConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/CSVConfig.java
@@ -43,6 +43,7 @@ public class CSVConfig {
 		settings.setFormat(createCsvFormat());
 		settings.setHeaderExtractionEnabled(parseHeaders);
 		settings.setMaxColumns(maxColumns);
+		settings.setLineSeparatorDetectionEnabled(true);
 		return settings;
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java
@@ -51,4 +51,9 @@ public class ExecutionStatus {
 		 * Is set to the query description if the user can expand all included concepts.
 		 */
 		private QueryDescription query;
+		
+		public static enum CreationFlag{
+			WITH_COLUMN_DESCIPTION,
+			WITH_SOURCE;
+		}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java
@@ -10,7 +10,6 @@ import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
 import com.bakdata.conquery.models.query.ColumnDescriptor;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
@@ -22,39 +21,34 @@ import lombok.experimental.FieldNameConstants;
 @FieldNameConstants
 public class ExecutionStatus {
 
-	private String[] tags;
-	private String label;
-	private ZonedDateTime createdAt;
-	private ZonedDateTime lastUsed;
-	private UserId owner;
-	private String ownerName;
-	private boolean shared;
-	private boolean own;
-	private boolean system;
+		private String[] tags;
+		private String label;
+		private ZonedDateTime createdAt;
+		private ZonedDateTime lastUsed;
+		private UserId owner;
+		private String ownerName;
+		private boolean shared;
+		private boolean own;
+		private boolean system;
 
-	private ManagedExecutionId id;
-	private ExecutionState status;
-	private Long numberOfResults;
-	private Long requiredTime;
-	private URL resultUrl;
-
-	@Data
-	@NoArgsConstructor
-	@EqualsAndHashCode(callSuper = true)
-	public static class WithSingleQuery extends ExecutionStatus {
-		/**
-		 * Indicates if the concepts that are included in the query description can be accesed by the user.
-		 */
-		boolean canExpand;
-		/**
-		 * Is set to the query description if the user can expand all included concepts.
-		 */
-		private QueryDescription query;
+		private ManagedExecutionId id;
+		private ExecutionState status;
+		private Long numberOfResults;
+		private Long requiredTime;
+		private URL resultUrl;
 		
 		/**
 		 * Holds a description for each column, present in the result.
 		 */
 		private List<ColumnDescriptor> columnDescriptions;
 		
-	}
+		/**
+		 * Indicates if the concepts that are included in the query description can be accesed by the user.
+		 */
+		private boolean canExpand;
+		
+		/**
+		 * Is set to the query description if the user can expand all included concepts.
+		 */
+		private QueryDescription query;
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
@@ -19,7 +19,7 @@ import com.bakdata.conquery.io.jackson.InternalOnly;
 import com.bakdata.conquery.io.xodus.MasterMetaStorage;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.execution.ExecutionState;
-import com.bakdata.conquery.models.execution.ExecutionStatus.WithSingleQuery;
+import com.bakdata.conquery.models.execution.ExecutionStatus;
 import com.bakdata.conquery.models.execution.ManagedExecution;
 import com.bakdata.conquery.models.forms.managed.ManagedForm.FormSharedResult;
 import com.bakdata.conquery.models.identifiable.IdMap;
@@ -224,8 +224,8 @@ public class ManagedForm extends ManagedExecution<FormSharedResult> {
 	}
 	
 	@Override
-	protected void setAdditionalFieldsForStatusWithSource(@NonNull MasterMetaStorage storage, URLBuilder url, User user, WithSingleQuery status) {
-		super.setAdditionalFieldsForStatusWithSource(storage, url, user, status);
+	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MasterMetaStorage storage, URLBuilder url, User user, ExecutionStatus status) {
+		super.setAdditionalFieldsForStatusWithColumnDescription(storage, url, user, status);
 		// Set the ColumnDescription if the Form only consits of a single subquery
 		if(subQueries == null) {
 			// If subqueries was not set the Execution was not initialized
@@ -246,7 +246,6 @@ public class ManagedForm extends ManagedExecution<FormSharedResult> {
 			return;
 		}
 		status.setColumnDescriptions(subQuery.get(0).generateColumnDescriptions());
-		
 	}
 
 

--- a/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
@@ -22,7 +22,6 @@ import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.execution.ExecutionState;
 import com.bakdata.conquery.models.execution.ExecutionStatus;
-import com.bakdata.conquery.models.execution.ExecutionStatus.WithSingleQuery;
 import com.bakdata.conquery.models.execution.ManagedExecution;
 import com.bakdata.conquery.models.i18n.I18n;
 import com.bakdata.conquery.models.identifiable.ids.NamespacedId;
@@ -143,23 +142,21 @@ public class ManagedQuery extends ManagedExecution<ShardResult> {
 	}
 	
 	@Override
-	protected void setStatusBase(@NonNull MasterMetaStorage storage, URLBuilder url, @NonNull  User user, @NonNull ExecutionStatus status) {
-
-		super.setStatusBase(storage, url, user, status);
+	protected void setStatusBase(@NonNull MasterMetaStorage storage, URLBuilder url, @NonNull User user, @NonNull ExecutionStatus status, boolean withColumnDescription) {
+		super.setStatusBase(storage, url, user, status, withColumnDescription);
 		status.setNumberOfResults(lastResultCount);
+		if(!withColumnDescription) {
+			return;
+		}
 	}
 	
 	@Override
-	protected void setAdditionalFieldsForStatusWithSource(@NonNull MasterMetaStorage storage, URLBuilder url, User user, WithSingleQuery status) {
-		if(columnDescriptions == null) {
+	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MasterMetaStorage storage, URLBuilder url, User user, ExecutionStatus status) {
+		super.setAdditionalFieldsForStatusWithColumnDescription(storage, url, user, status);
+		if (columnDescriptions == null) {
 			columnDescriptions = generateColumnDescriptions();
 		}
-		// Set flag if user can expand the query and in that case also the query
-		super.setAdditionalFieldsForStatusWithSource(storage, url, user, status);
-		if(status.isCanExpand()) {
-			// If the user can expand the query (can use all included concepts), also set the column description
-			status.setColumnDescriptions(columnDescriptions);
-		}
+		status.setColumnDescriptions(columnDescriptions);
 	}
 
 	/**

--- a/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
@@ -142,12 +142,9 @@ public class ManagedQuery extends ManagedExecution<ShardResult> {
 	}
 	
 	@Override
-	protected void setStatusBase(@NonNull MasterMetaStorage storage, URLBuilder url, @NonNull User user, @NonNull ExecutionStatus status, boolean withColumnDescription) {
-		super.setStatusBase(storage, url, user, status, withColumnDescription);
+	protected void setStatusBase(@NonNull MasterMetaStorage storage, URLBuilder url, @NonNull User user, @NonNull ExecutionStatus status) {
+		super.setStatusBase(storage, url, user, status);
 		status.setNumberOfResults(lastResultCount);
-		if(!withColumnDescription) {
-			return;
-		}
 	}
 	
 	@Override

--- a/docs/REST API JSONs.md
+++ b/docs/REST API JSONs.md
@@ -669,7 +669,7 @@ Supported Fields:
 | [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/config/FrontendConfig.java#L24) | thousandSeparator | `String` | `"."` |  |  | 
 </p></details>
 
-### Type ExecutionStatus<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L18)</sup></sub></sup>
+### Type ExecutionStatus<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L17)</sup></sub></sup>
 
 
 <details><summary>Details</summary><p>
@@ -680,20 +680,23 @@ Supported Fields:
 
 |  | Field | Type | Default | Example | Description |
 | --- | --- | --- | --- | --- | --- |
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L27) | createdAt | `ZonedDateTime` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L35) | id | ID of `ManagedExecution` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L26) | label | `String` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L28) | lastUsed | `ZonedDateTime` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L37) | numberOfResults | `long` or `null` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L32) | own | `boolean` | `false` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L29) | owner | ID of `User` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L30) | ownerName | `String` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L38) | requiredTime | `long` or `null` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L39) | resultUrl | `URL` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L31) | shared | `boolean` | `false` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L36) | status | one of NEW, RUNNING, CANCELED, FAILED, DONE | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L33) | system | `boolean` | `false` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L25) | tags | list of `String` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L45-L47) | canExpand | `boolean` | `false` |  | Indicates if the concepts that are included in the query description can be accesed by the user. | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L40-L42) | columnDescriptions | list of `ColumnDescriptor` | `null` |  | Holds a description for each column, present in the result. | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L26) | createdAt | `ZonedDateTime` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L34) | id | ID of `ManagedExecution` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L25) | label | `String` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L27) | lastUsed | `ZonedDateTime` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L36) | numberOfResults | `long` or `null` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L31) | own | `boolean` | `false` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L28) | owner | ID of `User` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L29) | ownerName | `String` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L50-L52) | query | [QueryDescription](#Base-QueryDescription) | `null` |  | Is set to the query description if the user can expand all included concepts. | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L37) | requiredTime | `long` or `null` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L38) | resultUrl | `URL` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L30) | shared | `boolean` | `false` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L35) | status | one of NEW, RUNNING, CANCELED, FAILED, DONE | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L32) | system | `boolean` | `false` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L24) | tags | list of `String` | `null` |  |  | 
 </p></details>
 
 ### Type FERoot<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/api/description/FERoot.java#L10-L12)</sup></sub></sup>


### PR DESCRIPTION
The column description is now also send on requests like:
```
POST /api/datasets/adb_bosch/queries
GET /api/datasets/adb_bosch/queries/<QueryId>
```