### PR TITLE
quick fix grabbing FAILED status for function call

### DIFF
--- a/frontend/src/js/query-runner/reducer.ts
+++ b/frontend/src/js/query-runner/reducer.ts
@@ -150,7 +150,8 @@ export default function createQueryRunnerReducer(type: string) {
         };
       case QUERY_RESULT_ERROR:
         const error = getQueryError(
-          action.payload.data,
+          // TODO Clean up. This is just a quick fix to prevent the frontend to fail if the backend sends the status of a failed query
+          {status: action.payload.status}, 
           action.payload.message
         );
 


### PR DESCRIPTION
The call of `query-runner/reducer.ts/getQueryError` ended in  accessing an undefined  by calling
```js
if (data.status === "CANCELED") { ...
```

This forms `data` to have a member `status`