### PR TITLE
#blm

### DIFF
--- a/autodoc/src/main/java/com/bakdata/conquery/AutoDoc.java
+++ b/autodoc/src/main/java/com/bakdata/conquery/AutoDoc.java
@@ -25,8 +25,8 @@ public class AutoDoc {
 	public AutoDoc() {
 		scan = new ClassGraph()
 			.enableAllInfo()
-			//blacklist some packages that contain large libraries
-			.blacklistPackages(
+			//reject some packages that contain large libraries
+			.rejectPackages(
 				"groovy",
 				"org.codehaus.groovy",
 				"org.apache",

--- a/backend/src/main/java/com/bakdata/conquery/Conquery.java
+++ b/backend/src/main/java/com/bakdata/conquery/Conquery.java
@@ -7,7 +7,7 @@ import javax.validation.Validator;
 
 import ch.qos.logback.classic.Level;
 import com.bakdata.conquery.commands.CollectEntitiesCommand;
-import com.bakdata.conquery.commands.MasterCommand;
+import com.bakdata.conquery.commands.ManagerNode;
 import com.bakdata.conquery.commands.PreprocessorCommand;
 import com.bakdata.conquery.commands.SlaveCommand;
 import com.bakdata.conquery.commands.StandaloneCommand;
@@ -33,7 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 public class Conquery extends Application<ConqueryConfig> {
 
 	private final String name;
-	private MasterCommand master;
+	private ManagerNode manager;
 
 	public Conquery() {
 		this("Conquery");
@@ -100,8 +100,8 @@ public class Conquery extends Application<ConqueryConfig> {
 
 	@Override
 	public void run(ConqueryConfig configuration, Environment environment) throws Exception {
-		master = new MasterCommand();
-		master.run(configuration, environment);
+		manager = new ManagerNode();
+		manager.run(configuration, environment);
 	}
 
 	public static void main(String... args) throws Exception {

--- a/backend/src/main/java/com/bakdata/conquery/Conquery.java
+++ b/backend/src/main/java/com/bakdata/conquery/Conquery.java
@@ -9,7 +9,7 @@ import ch.qos.logback.classic.Level;
 import com.bakdata.conquery.commands.CollectEntitiesCommand;
 import com.bakdata.conquery.commands.ManagerNode;
 import com.bakdata.conquery.commands.PreprocessorCommand;
-import com.bakdata.conquery.commands.SlaveCommand;
+import com.bakdata.conquery.commands.ShardNode;
 import com.bakdata.conquery.commands.StandaloneCommand;
 import com.bakdata.conquery.io.jackson.Jackson;
 import com.bakdata.conquery.io.jackson.MutableInjectableValues;
@@ -50,7 +50,7 @@ public class Conquery extends Application<ConqueryConfig> {
 		// main config file is json
 		bootstrap.setConfigurationFactoryFactory(JsonConfigurationFactory::new);
 
-		bootstrap.addCommand(new SlaveCommand());
+		bootstrap.addCommand(new ShardNode());
 		bootstrap.addCommand(new PreprocessorCommand());
 		bootstrap.addCommand(new CollectEntitiesCommand());
 		bootstrap.addCommand(new StandaloneCommand(this));

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/ApiV1.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/ApiV1.java
@@ -8,9 +8,8 @@ import com.bakdata.conquery.io.jersey.IdParamConverter;
 import com.bakdata.conquery.io.jetty.CORSPreflightRequestFilter;
 import com.bakdata.conquery.io.jetty.CORSResponseFilter;
 import com.bakdata.conquery.metrics.ActiveUsersFilter;
-import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.forms.frontendconfiguration.FormConfigProcessor;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.resources.ResourcesProvider;
 import com.bakdata.conquery.resources.api.APIResource;
 import com.bakdata.conquery.resources.api.ConceptResource;
@@ -31,16 +30,16 @@ public class ApiV1 implements ResourcesProvider {
 
 	@Override
 	public void registerResources(ManagerNode manager) {
-		Namespaces namespaces = manager.getNamespaces();
+		DatasetRegistry datasets = manager.getDatasetRegistry();
 		JerseyEnvironment environment = manager.getEnvironment().jersey();
 
 		//inject required services
 		environment.register(new AbstractBinder() {
 			@Override
 			protected void configure() {
-				bind(new ConceptsProcessor(manager.getNamespaces())).to(ConceptsProcessor.class);
+				bind(new ConceptsProcessor(manager.getDatasetRegistry())).to(ConceptsProcessor.class);
 				bind(new MeProcessor(manager.getStorage())).to(MeProcessor.class);
-				bind(new QueryProcessor(namespaces, manager.getStorage())).to(QueryProcessor.class);
+				bind(new QueryProcessor(datasets, manager.getStorage())).to(QueryProcessor.class);
 				bind(new FormConfigProcessor(manager.getValidator(),manager.getStorage())).to(FormConfigProcessor.class);
 			}
 		});
@@ -59,8 +58,8 @@ public class ApiV1 implements ResourcesProvider {
 		 */
 		environment.register(manager.getAuthController().getAuthenticationFilter());
 		environment.register(QueryResource.class);
-		environment.register(new ResultCSVResource(namespaces, manager.getConfig()));
-		environment.register(new StoredQueriesResource(namespaces));
+		environment.register(new ResultCSVResource(datasets, manager.getConfig()));
+		environment.register(new StoredQueriesResource(datasets));
 		environment.register(IdParamConverter.Provider.INSTANCE);
 		environment.register(CORSResponseFilter.class);
 		environment.register(new ConfigResource(manager.getConfig()));

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/ApiV1.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/ApiV1.java
@@ -41,6 +41,7 @@ public class ApiV1 implements ResourcesProvider {
 				bind(new MeProcessor(manager.getStorage())).to(MeProcessor.class);
 				bind(new QueryProcessor(datasets, manager.getStorage())).to(QueryProcessor.class);
 				bind(new FormConfigProcessor(manager.getValidator(),manager.getStorage())).to(FormConfigProcessor.class);
+				bind(new StoredQueriesProcessor(manager.getDatasetRegistry())).to(StoredQueriesProcessor.class);
 			}
 		});
 
@@ -59,7 +60,7 @@ public class ApiV1 implements ResourcesProvider {
 		environment.register(manager.getAuthController().getAuthenticationFilter());
 		environment.register(QueryResource.class);
 		environment.register(new ResultCSVResource(datasets, manager.getConfig()));
-		environment.register(new StoredQueriesResource(datasets));
+		environment.register(StoredQueriesResource.class);
 		environment.register(IdParamConverter.Provider.INSTANCE);
 		environment.register(CORSResponseFilter.class);
 		environment.register(new ConfigResource(manager.getConfig()));

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/FilterSearch.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/FilterSearch.java
@@ -12,7 +12,7 @@ import com.bakdata.conquery.models.concepts.filters.specific.AbstractSelectFilte
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.jobs.JobManager;
 import com.bakdata.conquery.models.jobs.SimpleJob;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.util.search.QuickSearch;
 import com.github.powerlibraries.io.In;
 import com.univocity.parsers.common.IterableResult;
@@ -86,9 +86,9 @@ public class FilterSearch {
 	/**
 	 * Scan all SelectFilters and submit {@link SimpleJob}s to create interactive searches for them.
 	 */
-	public static void updateSearch(Namespaces namespaces, Collection<Dataset> datasets, JobManager jobManager) {
-		datasets.stream()
-				.flatMap(ds -> namespaces.get(ds.getId()).getStorage().getAllConcepts().stream())
+	public static void updateSearch(DatasetRegistry datasets, Collection<Dataset> datasetsToUpdate, JobManager jobManager) {
+		datasetsToUpdate.stream()
+				.flatMap(ds -> datasets.get(ds.getId()).getStorage().getAllConcepts().stream())
 				.flatMap(c -> c.getConnectors().stream())
 				.flatMap(co -> co.collectAllFilters().stream())
 				.filter(f -> f instanceof AbstractSelectFilter && ((AbstractSelectFilter<?>) f).getTemplate() != null)

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/FormConfigPatch.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/FormConfigPatch.java
@@ -2,7 +2,7 @@ package com.bakdata.conquery.apiv1;
 
 import java.util.function.Consumer;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.auth.permissions.Ability;
 import com.bakdata.conquery.models.forms.configs.FormConfig;
@@ -24,12 +24,12 @@ import lombok.experimental.SuperBuilder;
 public class FormConfigPatch extends MetaDataPatch {
 	private JsonNode values;
 	
-	public void applyTo(FormConfig instance, MasterMetaStorage storage, User user, PermissionCreator<FormConfigId> permissionCreator){
+	public void applyTo(FormConfig instance, MetaStorage storage, User user, PermissionCreator<FormConfigId> permissionCreator){
 		chain(QueryUtils.getNoOpEntryPoint(), storage, user, instance, permissionCreator)
 			.accept(this);		
 	}
 	
-	protected Consumer<FormConfigPatch> chain(Consumer<FormConfigPatch> patchConsumerChain, MasterMetaStorage storage, User user, FormConfig instance, PermissionCreator<FormConfigId> permissionCreator) {
+	protected Consumer<FormConfigPatch> chain(Consumer<FormConfigPatch> patchConsumerChain, MetaStorage storage, User user, FormConfig instance, PermissionCreator<FormConfigId> permissionCreator) {
 		patchConsumerChain = super.buildChain(patchConsumerChain, storage, user, instance, permissionCreator);
 		if(getValues() != null && user.isPermitted(permissionCreator.apply(Ability.MODIFY.asSet(), instance.getId()))) {
 			patchConsumerChain = patchConsumerChain.andThen(instance.valueSetter());

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/MeProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/MeProcessor.java
@@ -3,7 +3,7 @@ package com.bakdata.conquery.apiv1;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.AuthorizationHelper;
 import com.bakdata.conquery.models.auth.entities.Group;
 import com.bakdata.conquery.models.auth.entities.User;
@@ -23,7 +23,7 @@ import lombok.NonNull;
 @AllArgsConstructor
 public class MeProcessor {
 
-	private final MasterMetaStorage storage;
+	private final MetaStorage storage;
 	
 	/**
 	 * Generates a summary of a user. It contains its name, the groups it belongs to and its permissions on a dataset.

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/MetaDataPatch.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/MetaDataPatch.java
@@ -5,7 +5,7 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.Group;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.auth.permissions.Ability;
@@ -45,7 +45,7 @@ public class MetaDataPatch implements Taggable, Labelable, ShareInformation {
 	 * @param permissionCreator	A function that produces a {@link Permission} that targets the given instance (e.g QueryPermission, FormConfigPermission).
 	 * @param <INST>	Type of the instance that is patched
 	 */
-	public <T extends MetaDataPatch, ID extends IId<?>, INST extends Taggable & Shareable & Labelable & Identifiable<? extends ID>> void applyTo(INST instance, MasterMetaStorage storage, User user, PermissionCreator<ID> permissionCreator){
+	public <T extends MetaDataPatch, ID extends IId<?>, INST extends Taggable & Shareable & Labelable & Identifiable<? extends ID>> void applyTo(INST instance, MetaStorage storage, User user, PermissionCreator<ID> permissionCreator){
 		buildChain(
 			QueryUtils.getNoOpEntryPoint(),
 			storage,
@@ -55,7 +55,7 @@ public class MetaDataPatch implements Taggable, Labelable, ShareInformation {
 			.accept(this);
 	}
 	
-	protected <T extends MetaDataPatch, ID extends IId<?>, INST extends Taggable & Shareable & Labelable & Identifiable<? extends ID>> Consumer<T> buildChain(Consumer<T> patchConsumerChain,MasterMetaStorage storage, User user, INST instance, PermissionCreator<ID> permissionCreator){
+	protected <T extends MetaDataPatch, ID extends IId<?>, INST extends Taggable & Shareable & Labelable & Identifiable<? extends ID>> Consumer<T> buildChain(Consumer<T> patchConsumerChain,MetaStorage storage, User user, INST instance, PermissionCreator<ID> permissionCreator){
 		if(getTags() != null && user.isPermitted(permissionCreator.apply(Ability.TAG.asSet(), instance.getId()))) {
 			patchConsumerChain = patchConsumerChain.andThen(instance.tagger());
 		}

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/QueryDescription.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/QueryDescription.java
@@ -18,7 +18,7 @@ import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.Visitable;
 import com.bakdata.conquery.models.query.concept.specific.CQExternal;
 import com.bakdata.conquery.models.query.visitor.QueryVisitor;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.util.QueryUtils;
 import com.bakdata.conquery.util.QueryUtils.ExternalIdChecker;
 import com.bakdata.conquery.util.QueryUtils.NamespacedIdCollector;
@@ -35,16 +35,16 @@ public interface QueryDescription extends Visitable {
 	 * Transforms the submitted query to an {@link ManagedExecution}.
 	 * In this step some external dependencies are resolve (such as {@link CQExternal}).
 	 * However steps that require add or manipulates queries programmatically based on the submitted query
-	 * should be done in an extra init procedure (see {@link ManagedForm#initExecutable(Namespaces)}.
+	 * should be done in an extra init procedure (see {@link ManagedForm#initExecutable(DatasetRegistry)}.
 	 * These steps are executed right before the execution of the query and not necessary in this creation phase.
 	 * 
 	 * @param storage Needed by {@link ManagedExecution} for the self update upon completion.
-	 * @param namespaces
+	 * @param datasets
 	 * @param userId
 	 * @param submittedDataset
 	 * @return
 	 */
-	ManagedExecution<?> toManagedExecution(Namespaces namespaces, UserId userId, DatasetId submittedDataset);
+	ManagedExecution<?> toManagedExecution(DatasetRegistry datasets, UserId userId, DatasetId submittedDataset);
 
 	
 	Set<ManagedExecutionId> collectRequiredQueries();

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
@@ -6,7 +6,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.metrics.ExecutionMetrics;
 import com.bakdata.conquery.models.auth.AuthorizationHelper;
 import com.bakdata.conquery.models.auth.entities.Group;
@@ -43,7 +43,7 @@ public class QueryProcessor {
 
 	@Getter
 	private final Namespaces namespaces;
-	private final MasterMetaStorage storage;
+	private final MetaStorage storage;
 
 	/**
 	 * Creates a query for all datasets, then submits it for execution on the

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
@@ -27,8 +27,8 @@ import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.QueryTranslator;
 import com.bakdata.conquery.models.query.Visitable;
 import com.bakdata.conquery.models.query.visitor.QueryVisitor;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.models.worker.Namespace;
-import com.bakdata.conquery.models.worker.Namespaces;
 import com.bakdata.conquery.util.QueryUtils;
 import com.bakdata.conquery.util.QueryUtils.NamespacedIdCollector;
 import com.google.common.collect.ClassToInstanceMap;
@@ -42,7 +42,7 @@ import org.apache.shiro.authz.Permission;
 public class QueryProcessor {
 
 	@Getter
-	private final Namespaces namespaces;
+	private final DatasetRegistry datasetRegistry;
 	private final MetaStorage storage;
 
 	/**
@@ -53,7 +53,7 @@ public class QueryProcessor {
 		authorize(user, dataset.getId(), Ability.READ);
 		
 		// Initialize the query
-		query = query.resolve(new QueryResolveContext(dataset.getId(), namespaces));
+		query = query.resolve(new QueryResolveContext(dataset.getId(), datasetRegistry));
 		
 		// This maps works as long as we have query visitors that are not configured in anyway.
 		// So adding a visitor twice would replace the previous one but both would have yielded the same result.
@@ -98,7 +98,7 @@ public class QueryProcessor {
 				log.info("Re-executing Query {}", executionId);
 
 
-				final ManagedExecution<?> mq = ExecutionManager.execute( namespaces, storage.getExecution(executionId));
+				final ManagedExecution<?> mq = ExecutionManager.execute( datasetRegistry, storage.getExecution(executionId));
 
 				return getStatus(dataset, mq, urlb, user);
 			}
@@ -106,7 +106,7 @@ public class QueryProcessor {
 		}
 		
 		// Run the query on behalf of the user
-		ManagedExecution<?> mq = ExecutionManager.runQuery(namespaces, query, user.getId(), dataset.getId());
+		ManagedExecution<?> mq = ExecutionManager.runQuery(datasetRegistry, query, user.getId(), dataset.getId());
 		
 		// Set abilities for submitted query
 		user.addPermission(storage, QueryPermission.onInstance(AbilitySets.QUERY_CREATOR, mq.getId()));
@@ -122,7 +122,7 @@ public class QueryProcessor {
 	private void translateToOtherDatasets(Dataset dataset, QueryDescription query, User user, ManagedExecution<?> mq) {
 		IQuery translateable = (IQuery) query;
 		// translate the query for all other datasets of user and submit it.
-		for (Namespace targetNamespace : namespaces.getNamespaces()) {
+		for (Namespace targetNamespace : datasetRegistry.getDatasets()) {
 			if (!user.isPermitted(DatasetPermission.onInstance(Ability.READ.asSet(), targetNamespace.getDataset().getId()))
 				|| targetNamespace.getDataset().equals(dataset)) {
 				continue;
@@ -137,8 +137,8 @@ public class QueryProcessor {
 			
 			try {
 				DatasetId targetDataset = targetNamespace.getDataset().getId();
-				IQuery translated = QueryTranslator.replaceDataset(namespaces, translateable, targetDataset);
-				final ManagedExecution<?> mqTranslated = ExecutionManager.createQuery(namespaces, translated, mq.getQueryId(), user.getId(), targetDataset);
+				IQuery translated = QueryTranslator.replaceDataset(datasetRegistry, translateable, targetDataset);
+				final ManagedExecution<?> mqTranslated = ExecutionManager.createQuery(datasetRegistry, translated, mq.getQueryId(), user.getId(), targetDataset);
 				
 				user.addPermission(storage, QueryPermission.onInstance(AbilitySets.QUERY_CREATOR, mqTranslated.getId()));
 			}

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesProcessor.java
@@ -1,7 +1,5 @@
 package com.bakdata.conquery.apiv1;
 
-import static com.bakdata.conquery.models.auth.AuthorizationHelper.*;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -23,7 +21,7 @@ import com.bakdata.conquery.models.execution.ManagedExecution;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
 import com.bakdata.conquery.models.query.ManagedQuery;
 import com.bakdata.conquery.models.query.concept.ConceptQuery;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,12 +29,12 @@ import lombok.extern.slf4j.Slf4j;
 public class StoredQueriesProcessor {
 
 	@Getter
-	private final Namespaces namespaces;
+	private final DatasetRegistry datasets;
 	private final MetaStorage storage;
 
-	public StoredQueriesProcessor(Namespaces namespaces) {
-		this.namespaces = namespaces;
-		this.storage = namespaces.getMetaStorage();
+	public StoredQueriesProcessor(DatasetRegistry datasets) {
+		this.datasets = datasets;
+		this.storage = datasets.getMetaStorage();
 	}
 
 	public Stream<ExecutionStatus> getAllQueries(Dataset dataset, HttpServletRequest req, User user) {
@@ -82,8 +80,8 @@ public class StoredQueriesProcessor {
 		storage.updateExecution(execution);
 		
 		// Patch this query in other datasets
-		List<Dataset> remainingDatasets = namespaces.getAllDatasets(() -> new ArrayList<>());
-		remainingDatasets.remove(namespaces.get(executionId.getDataset()).getDataset());
+		List<Dataset> remainingDatasets = datasets.getAllDatasets(() -> new ArrayList<>());
+		remainingDatasets.remove(datasets.get(executionId.getDataset()).getDataset());
 		for(Dataset dataset : remainingDatasets) {
 			ManagedExecutionId id = new ManagedExecutionId(dataset.getId(),executionId.getExecution());
 			execution = storage.getExecution(id);

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesProcessor.java
@@ -11,7 +11,7 @@ import java.util.stream.Stream;
 
 import javax.servlet.http.HttpServletRequest;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.auth.permissions.Ability;
 import com.bakdata.conquery.models.auth.permissions.QueryPermission;
@@ -32,7 +32,7 @@ public class StoredQueriesProcessor {
 
 	@Getter
 	private final Namespaces namespaces;
-	private final MasterMetaStorage storage;
+	private final MetaStorage storage;
 
 	public StoredQueriesProcessor(Namespaces namespaces) {
 		this.namespaces = namespaces;

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/auth/ProtoUser.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/auth/ProtoUser.java
@@ -7,7 +7,7 @@ import java.util.Set;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.UserManageable;
 import com.bakdata.conquery.models.auth.basic.LocalAuthenticationRealm;
 import com.bakdata.conquery.models.auth.entities.User;
@@ -61,7 +61,7 @@ public class ProtoUser {
 		return user;
 	}
 
-	public void registerForAuthorization(MasterMetaStorage storage, boolean override) {
+	public void registerForAuthorization(MetaStorage storage, boolean override) {
 		User user = this.getUser();
 		if(override) {			
 			storage.updateUser(user);

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/forms/Form.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/forms/Form.java
@@ -17,7 +17,7 @@ import com.bakdata.conquery.models.query.IQuery;
 import com.bakdata.conquery.models.query.ManagedQuery;
 import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.visitor.QueryVisitor;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ClassToInstanceMap;
 import lombok.NonNull;
@@ -33,10 +33,10 @@ public interface Form extends QueryDescription {
 		return this.getClass().getAnnotation(CPSType.class).id();
 	}
 
-	public abstract Map<String, List<ManagedQuery>> createSubQueries(Namespaces namespaces, UserId userId, DatasetId submittedDataset);
+	public abstract Map<String, List<ManagedQuery>> createSubQueries(DatasetRegistry datasets, UserId userId, DatasetId submittedDataset);
 	
 	@Override
-	public default ManagedForm toManagedExecution(Namespaces namespaces, UserId userId, DatasetId submittedDataset) {
+	public default ManagedForm toManagedExecution(DatasetRegistry datasets, UserId userId, DatasetId submittedDataset) {
 		return new ManagedForm(this, userId, submittedDataset);
 	}
 		
@@ -52,7 +52,7 @@ public interface Form extends QueryDescription {
 	 */
 	public static IQuery resolvePrerequisite(QueryResolveContext context, ManagedExecutionId prerequisiteId) {
 		// Resolve the prerequisite
-		ManagedExecution<?> prerequisiteExe = context.getNamespaces().getMetaStorage().getExecution(prerequisiteId);
+		ManagedExecution<?> prerequisiteExe = context.getDatasetRegistry().getMetaStorage().getExecution(prerequisiteId);
 		if(!(prerequisiteExe instanceof ManagedQuery)) {
 			throw new IllegalArgumentException("The prerequisite query must be of type " + ManagedQuery.class.getName());
 		}

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/forms/export_form/AbsoluteMode.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/forms/export_form/AbsoluteMode.java
@@ -16,7 +16,7 @@ import com.bakdata.conquery.models.query.IQuery;
 import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.Visitable;
 import com.bakdata.conquery.models.query.concept.CQElement;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.google.common.collect.ImmutableList;
 import lombok.Getter;
 import lombok.Setter;
@@ -37,8 +37,8 @@ public class AbsoluteMode extends Mode {
 	}
 
 	@Override
-	public IQuery createSpecializedQuery(Namespaces namespaces, UserId userId, DatasetId submittedDataset) {
-		return AbsExportGenerator.generate(namespaces, this, userId, submittedDataset);
+	public IQuery createSpecializedQuery(DatasetRegistry datasets, UserId userId, DatasetId submittedDataset) {
+		return AbsExportGenerator.generate(datasets, this, userId, submittedDataset);
 	}
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/forms/export_form/ExportForm.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/forms/export_form/ExportForm.java
@@ -24,7 +24,7 @@ import com.bakdata.conquery.models.query.ManagedQuery;
 import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.Visitable;
 import com.bakdata.conquery.models.query.concept.NamespacedIdHolding;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Getter;
@@ -62,12 +62,12 @@ public class ExportForm implements Form, NamespacedIdHolding {
 	}
 
 	@Override
-	public Map<String, List<ManagedQuery>> createSubQueries(Namespaces namespaces, UserId userId, DatasetId submittedDataset) {
+	public Map<String, List<ManagedQuery>> createSubQueries(DatasetRegistry datasets, UserId userId, DatasetId submittedDataset) {
 		return Map.of(
 			ConqueryConstants.SINGLE_RESULT_TABLE_NAME,
 			List.of(
-				timeMode.createSpecializedQuery(namespaces, userId, submittedDataset)
-					.toManagedExecution(namespaces, userId, submittedDataset)));
+				timeMode.createSpecializedQuery(datasets, userId, submittedDataset)
+					.toManagedExecution(datasets, userId, submittedDataset)));
 	}
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/forms/export_form/Mode.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/forms/export_form/Mode.java
@@ -6,7 +6,7 @@ import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
 import com.bakdata.conquery.models.query.IQuery;
 import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.Visitable;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -30,5 +30,5 @@ public abstract class Mode implements Visitable {
 
 	public abstract void resolve(QueryResolveContext context);
 	
-	public abstract IQuery createSpecializedQuery(Namespaces namespaces, UserId userId, DatasetId submittedDataset);
+	public abstract IQuery createSpecializedQuery(DatasetRegistry datasets, UserId userId, DatasetId submittedDataset);
 }

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/forms/export_form/RelativeMode.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/forms/export_form/RelativeMode.java
@@ -18,7 +18,7 @@ import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.Visitable;
 import com.bakdata.conquery.models.query.concept.CQElement;
 import com.bakdata.conquery.models.query.concept.specific.temporal.TemporalSampler;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.validator.constraints.NotEmpty;
@@ -48,8 +48,8 @@ public class RelativeMode extends Mode {
 	}
 	
 	@Override
-	public RelativeFormQuery createSpecializedQuery(Namespaces namespaces, UserId userId, DatasetId submittedDataset) {
-		return RelExportGenerator.generate(namespaces, this, userId, submittedDataset);
+	public RelativeFormQuery createSpecializedQuery(DatasetRegistry datasets, UserId userId, DatasetId submittedDataset) {
+		return RelExportGenerator.generate(datasets, this, userId, submittedDataset);
 	}
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/commands/ManagerNode.java
+++ b/backend/src/main/java/com/bakdata/conquery/commands/ManagerNode.java
@@ -56,7 +56,7 @@ import org.apache.mina.transport.socket.nio.NioSocketAcceptor;
 
 @Slf4j
 @Getter
-public class MasterCommand extends IoHandlerAdapter implements Managed {
+public class ManagerNode extends IoHandlerAdapter implements Managed {
 
 	private IoAcceptor acceptor;
 	private MasterMetaStorage storage;
@@ -78,7 +78,7 @@ public class MasterCommand extends IoHandlerAdapter implements Managed {
 			.add(NamespaceCollection.class, namespaces);
 
 
-		this.jobManager = new JobManager("master");
+		this.jobManager = new JobManager("ManagerNode");
 		this.environment = environment;
 		
 		// Initialization of internationalization
@@ -187,28 +187,28 @@ public class MasterCommand extends IoHandlerAdapter implements Managed {
 
 	@Override
 	public void sessionOpened(IoSession session) throws Exception {
-		ConqueryMDC.setLocation("Master["+session.getLocalAddress().toString()+"]");
+		ConqueryMDC.setLocation("ManagerNode["+session.getLocalAddress().toString()+"]");
 		log.info("New client {} connected, waiting for identity", session.getRemoteAddress());
 	}
 
 	@Override
 	public void sessionClosed(IoSession session) throws Exception {
-		ConqueryMDC.setLocation("Master[" + session.getLocalAddress().toString() + "]");
+		ConqueryMDC.setLocation("ManagerNode[" + session.getLocalAddress().toString() + "]");
 		log.info("Client '{}' disconnected ", session.getAttribute(MinaAttributes.IDENTIFIER));
 	}
 
 	@Override
 	public void exceptionCaught(IoSession session, Throwable cause) throws Exception {
-		ConqueryMDC.setLocation("Master[" + session.getLocalAddress().toString() + "]");
+		ConqueryMDC.setLocation("ManagerNode[" + session.getLocalAddress().toString() + "]");
 		log.error("caught exception", cause);
 	}
 
 	@Override
 	public void messageReceived(IoSession session, Object message) throws Exception {
-		ConqueryMDC.setLocation("Master[" + session.getLocalAddress().toString() + "]");
+		ConqueryMDC.setLocation("ManagerNode[" + session.getLocalAddress().toString() + "]");
 		if (message instanceof MasterMessage) {
 			MasterMessage mrm = (MasterMessage) message;
-			log.trace("Master received {} from {}", message.getClass().getSimpleName(), session.getRemoteAddress());
+			log.trace("ManagerNode received {} from {}", message.getClass().getSimpleName(), session.getRemoteAddress());
 			ReactingJob<MasterMessage, NetworkMessageContext.Master> job = new ReactingJob<>(mrm, new NetworkMessageContext.Master(
 				jobManager,
 				new NetworkSession(session),
@@ -237,7 +237,7 @@ public class MasterCommand extends IoHandlerAdapter implements Managed {
 		acceptor.setHandler(this);
 		acceptor.getSessionConfig().setAll(config.getCluster().getMina());
 		acceptor.bind(new InetSocketAddress(config.getCluster().getPort()));
-		log.info("Started master @ {}", acceptor.getLocalAddress());
+		log.info("Started ManagerNode @ {}", acceptor.getLocalAddress());
 	}
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/commands/ManagerNode.java
+++ b/backend/src/main/java/com/bakdata/conquery/commands/ManagerNode.java
@@ -34,7 +34,7 @@ import com.bakdata.conquery.models.messages.SlowMessage;
 import com.bakdata.conquery.models.messages.network.MessageToManagerNode;
 import com.bakdata.conquery.models.messages.network.NetworkMessageContext;
 import com.bakdata.conquery.models.worker.Namespace;
-import com.bakdata.conquery.models.worker.NamespaceCollection;
+import com.bakdata.conquery.models.worker.IdResolveContext;
 import com.bakdata.conquery.models.worker.Namespaces;
 import com.bakdata.conquery.resources.ResourcesProvider;
 import com.bakdata.conquery.resources.admin.AdminServlet;
@@ -75,7 +75,7 @@ public class ManagerNode extends IoHandlerAdapter implements Managed {
 	public void run(ConqueryConfig config, Environment environment) throws InterruptedException {
 		//inject namespaces into the objectmapper
 		((MutableInjectableValues)environment.getObjectMapper().getInjectableValues())
-			.add(NamespaceCollection.class, namespaces);
+			.add(IdResolveContext.class, namespaces);
 
 
 		this.jobManager = new JobManager("ManagerNode");

--- a/backend/src/main/java/com/bakdata/conquery/commands/ManagerNode.java
+++ b/backend/src/main/java/com/bakdata/conquery/commands/ManagerNode.java
@@ -21,8 +21,8 @@ import com.bakdata.conquery.io.mina.ChunkReader;
 import com.bakdata.conquery.io.mina.ChunkWriter;
 import com.bakdata.conquery.io.mina.MinaAttributes;
 import com.bakdata.conquery.io.mina.NetworkSession;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
-import com.bakdata.conquery.io.xodus.MasterMetaStorageImpl;
+import com.bakdata.conquery.io.xodus.MetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorageImpl;
 import com.bakdata.conquery.io.xodus.NamespaceStorage;
 import com.bakdata.conquery.models.auth.AuthorizationController;
 import com.bakdata.conquery.models.config.ConqueryConfig;
@@ -59,7 +59,7 @@ import org.apache.mina.transport.socket.nio.NioSocketAcceptor;
 public class ManagerNode extends IoHandlerAdapter implements Managed {
 
 	private IoAcceptor acceptor;
-	private MasterMetaStorage storage;
+	private MetaStorage storage;
 	private JobManager jobManager;
 	private Validator validator;
 	private ConqueryConfig config;
@@ -129,7 +129,7 @@ public class ManagerNode extends IoHandlerAdapter implements Managed {
 		log.info("All stores loaded: {}", namespaces.getNamespaces());
 		
 		
-		this.storage = new MasterMetaStorageImpl(namespaces, environment.getValidator(), config.getStorage());
+		this.storage = new MetaStorageImpl(namespaces, environment.getValidator(), config.getStorage());
 		this.storage.loadData();
 		log.info("MetaStorage loaded {}", this.storage);
 

--- a/backend/src/main/java/com/bakdata/conquery/commands/ManagerNode.java
+++ b/backend/src/main/java/com/bakdata/conquery/commands/ManagerNode.java
@@ -31,7 +31,7 @@ import com.bakdata.conquery.models.i18n.I18n;
 import com.bakdata.conquery.models.jobs.JobManager;
 import com.bakdata.conquery.models.jobs.ReactingJob;
 import com.bakdata.conquery.models.messages.SlowMessage;
-import com.bakdata.conquery.models.messages.network.MasterMessage;
+import com.bakdata.conquery.models.messages.network.MessageToManagerNode;
 import com.bakdata.conquery.models.messages.network.NetworkMessageContext;
 import com.bakdata.conquery.models.worker.Namespace;
 import com.bakdata.conquery.models.worker.NamespaceCollection;
@@ -206,10 +206,10 @@ public class ManagerNode extends IoHandlerAdapter implements Managed {
 	@Override
 	public void messageReceived(IoSession session, Object message) throws Exception {
 		ConqueryMDC.setLocation("ManagerNode[" + session.getLocalAddress().toString() + "]");
-		if (message instanceof MasterMessage) {
-			MasterMessage mrm = (MasterMessage) message;
+		if (message instanceof MessageToManagerNode) {
+			MessageToManagerNode mrm = (MessageToManagerNode) message;
 			log.trace("ManagerNode received {} from {}", message.getClass().getSimpleName(), session.getRemoteAddress());
-			ReactingJob<MasterMessage, NetworkMessageContext.Master> job = new ReactingJob<>(mrm, new NetworkMessageContext.Master(
+			ReactingJob<MessageToManagerNode, NetworkMessageContext.ManagerNodeRxTxContext> job = new ReactingJob<>(mrm, new NetworkMessageContext.ManagerNodeRxTxContext(
 				jobManager,
 				new NetworkSession(session),
 				namespaces

--- a/backend/src/main/java/com/bakdata/conquery/commands/ManagerNode.java
+++ b/backend/src/main/java/com/bakdata/conquery/commands/ManagerNode.java
@@ -209,7 +209,7 @@ public class ManagerNode extends IoHandlerAdapter implements Managed {
 		if (message instanceof MessageToManagerNode) {
 			MessageToManagerNode mrm = (MessageToManagerNode) message;
 			log.trace("ManagerNode received {} from {}", message.getClass().getSimpleName(), session.getRemoteAddress());
-			ReactingJob<MessageToManagerNode, NetworkMessageContext.ManagerNodeRxTxContext> job = new ReactingJob<>(mrm, new NetworkMessageContext.ManagerNodeRxTxContext(
+			ReactingJob<MessageToManagerNode, NetworkMessageContext.ManagerNodeNetworkContext> job = new ReactingJob<>(mrm, new NetworkMessageContext.ManagerNodeNetworkContext(
 				jobManager,
 				new NetworkSession(session),
 				namespaces

--- a/backend/src/main/java/com/bakdata/conquery/commands/SlaveCommand.java
+++ b/backend/src/main/java/com/bakdata/conquery/commands/SlaveCommand.java
@@ -62,7 +62,7 @@ public class SlaveCommand extends ConqueryCommand implements IoHandler, Managed 
 
 
 	public SlaveCommand() {
-		super("slave", "Connects this instance as a slave to a running master.");
+		super("slave", "Connects this instance as a slave to a running ManagerNode.");
 	}
 
 
@@ -155,9 +155,9 @@ public class SlaveCommand extends ConqueryCommand implements IoHandler, Managed 
 		NetworkSession networkSession = new NetworkSession(session);
 
 		context = new NetworkMessageContext.Slave(jobManager, networkSession, workers, config, validator);
-		log.info("Connected to master @ {}", session.getRemoteAddress());
+		log.info("Connected to ManagerNode @ {}", session.getRemoteAddress());
 
-		// Authenticate with Master
+		// Authenticate with ManagerNode
 		context.send(new AddSlave());
 
 		for (Worker w : workers.getWorkers().values()) {
@@ -171,7 +171,7 @@ public class SlaveCommand extends ConqueryCommand implements IoHandler, Managed 
 	@Override
 	public void sessionClosed(IoSession session) throws Exception {
 		setLocation(session);
-		log.info("Disconnected from master");
+		log.info("Disconnected from ManagerNode");
 	}
 
 	@Override
@@ -211,7 +211,7 @@ public class SlaveCommand extends ConqueryCommand implements IoHandler, Managed 
 		connector.getSessionConfig().setAll(config.getCluster().getMina());
 
 		InetSocketAddress address = new InetSocketAddress(
-				config.getCluster().getMasterURL().getHostAddress(),
+				config.getCluster().getManagerURL().getHostAddress(),
 				config.getCluster().getPort()
 		);
 
@@ -249,7 +249,7 @@ public class SlaveCommand extends ConqueryCommand implements IoHandler, Managed 
 		if (context != null) {
 			context.awaitClose();
 		}
-		log.info("Connection was closed by master");
+		log.info("Connection was closed by ManagerNode");
 		connector.dispose();
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/commands/StandaloneCommand.java
+++ b/backend/src/main/java/com/bakdata/conquery/commands/StandaloneCommand.java
@@ -30,7 +30,7 @@ public class StandaloneCommand extends io.dropwizard.cli.ServerCommand<ConqueryC
 
 	private final Conquery conquery;
 	private ManagerNode manager;
-	private final List<SlaveCommand> slaves = new Vector<>();
+	private final List<ShardNode> shardNodes = new Vector<>();
 
 	public StandaloneCommand(Conquery conquery) {
 		super(conquery, "standalone", "starts a server and a client at the same time.");
@@ -64,46 +64,46 @@ public class StandaloneCommand extends io.dropwizard.cli.ServerCommand<ConqueryC
 		managerConfig.getStorage().getDirectory().mkdir();
 		conquery.run(managerConfig, environment);
 		
-		//create thread pool to start multiple slaves at the same time
+		//create thread pool to start multiple ShardNodes at the same time
 		ExecutorService starterPool = Executors.newFixedThreadPool(
-			config.getStandalone().getNumberOfSlaves(),
+			config.getStandalone().getNumberOfShardNodes(),
 			new ThreadFactoryBuilder()
-				.setNameFormat("Slave Storage Loader %d")
+				.setNameFormat("ShardNode Storage Loader %d")
 				.setUncaughtExceptionHandler((t, e) -> {
 					ConqueryMDC.setLocation(t.getName());
-					log.error(t.getName()+" failed to init storage of slave", e);
+					log.error(t.getName()+" failed to init storage of ShardNode", e);
 				})
 				.build()
 		);
 		
-		List<Future<SlaveCommand>> tasks = new ArrayList<>();
-		for(int i=0;i<config.getStandalone().getNumberOfSlaves();i++) {
+		List<Future<ShardNode>> tasks = new ArrayList<>();
+		for(int i=0;i<config.getStandalone().getNumberOfShardNodes();i++) {
 			final int id = i;
 			tasks.add(starterPool.submit(() -> {
-				ConqueryMDC.setLocation("Slave " + id);
+				ShardNode sc = new ShardNode("ShardNode " + id);
+				this.shardNodes.add(sc);
+				
+				ConqueryMDC.setLocation(sc.getName());
 				ConqueryConfig clone = Cloner.clone(config, Map.of(Validator.class, environment.getValidator()));
-				clone.getStorage().setDirectory(new File(clone.getStorage().getDirectory(), "slave_" + id));
+				clone.getStorage().setDirectory(new File(clone.getStorage().getDirectory(), "shard_" + id));
 				clone.getStorage().getDirectory().mkdir();
 
-				SlaveCommand sc = new SlaveCommand();
-				sc.setLabel("slave " + id);
-				this.slaves.add(sc);
 				sc.run(environment, namespace, clone);
 				return sc;
 			}));
 		}
 		ConqueryMDC.setLocation("ManagerNode");
-		log.debug("Waiting for slaves to start");
+		log.debug("Waiting for ShardNodes to start");
 		starterPool.shutdown();
 		starterPool.awaitTermination(1, TimeUnit.HOURS);
 		//catch exceptions on tasks
 		boolean failed = false;
-		for(Future<SlaveCommand> f : tasks) {
+		for(Future<ShardNode> f : tasks) {
 			try {
 				f.get();
 			}
 			catch(ExecutionException e) {
-				log.error("during slave creation", e);
+				log.error("during ShardNodes creation", e);
 				failed = true;
 			}
 		}

--- a/backend/src/main/java/com/bakdata/conquery/commands/StandaloneCommand.java
+++ b/backend/src/main/java/com/bakdata/conquery/commands/StandaloneCommand.java
@@ -29,7 +29,7 @@ import net.sourceforge.argparse4j.inf.Namespace;
 public class StandaloneCommand extends io.dropwizard.cli.ServerCommand<ConqueryConfig> {
 
 	private final Conquery conquery;
-	private MasterCommand master;
+	private ManagerNode manager;
 	private final List<SlaveCommand> slaves = new Vector<>();
 
 	public StandaloneCommand(Conquery conquery) {
@@ -56,13 +56,13 @@ public class StandaloneCommand extends io.dropwizard.cli.ServerCommand<ConqueryC
 	}
 
 	protected void startStandalone(Environment environment, Namespace namespace, ConqueryConfig config) throws Exception {
-		// start master
-		ConqueryMDC.setLocation("Master");
-		log.debug("Starting Master");
-		ConqueryConfig masterConfig = Cloner.clone(config, Map.of(Validator.class, environment.getValidator()));
-		masterConfig.getStorage().setDirectory(new File(masterConfig.getStorage().getDirectory(), "master"));
-		masterConfig.getStorage().getDirectory().mkdir();
-		conquery.run(masterConfig, environment);
+		// start ManagerNode
+		ConqueryMDC.setLocation("ManagerNode");
+		log.debug("Starting ManagerNode");
+		ConqueryConfig managerConfig = Cloner.clone(config, Map.of(Validator.class, environment.getValidator()));
+		managerConfig.getStorage().setDirectory(new File(managerConfig.getStorage().getDirectory(), "manager"));
+		managerConfig.getStorage().getDirectory().mkdir();
+		conquery.run(managerConfig, environment);
 		
 		//create thread pool to start multiple slaves at the same time
 		ExecutorService starterPool = Executors.newFixedThreadPool(
@@ -92,7 +92,7 @@ public class StandaloneCommand extends io.dropwizard.cli.ServerCommand<ConqueryC
 				return sc;
 			}));
 		}
-		ConqueryMDC.setLocation("Master");
+		ConqueryMDC.setLocation("ManagerNode");
 		log.debug("Waiting for slaves to start");
 		starterPool.shutdown();
 		starterPool.awaitTermination(1, TimeUnit.HOURS);
@@ -115,6 +115,6 @@ public class StandaloneCommand extends io.dropwizard.cli.ServerCommand<ConqueryC
 		log.debug("Starting REST Server");
 		ConqueryMDC.setLocation(null);
 		super.run(environment, namespace, config);
-		master = conquery.getMaster();
+		manager = conquery.getManager();
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/io/jackson/InternalOnly.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/jackson/InternalOnly.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
 import com.fasterxml.jackson.annotation.JsonView;
 
-/** Jackson view for fields only used in the master slave connection **/
+/** Jackson view for fields only used in the manager slave connection **/
 @Retention(RetentionPolicy.RUNTIME)
 @JacksonAnnotationsInside
 @JsonView(InternalOnly.class)

--- a/backend/src/main/java/com/bakdata/conquery/io/jackson/InternalOnly.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/jackson/InternalOnly.java
@@ -3,10 +3,12 @@ package com.bakdata.conquery.io.jackson;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+import com.bakdata.conquery.commands.ManagerNode;
+import com.bakdata.conquery.commands.ShardNode;
 import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
 import com.fasterxml.jackson.annotation.JsonView;
 
-/** Jackson view for fields only used in the manager slave connection **/
+/** Jackson view for fields only used in the {@link ManagerNode}-{@link ShardNode}-connection **/
 @Retention(RetentionPolicy.RUNTIME)
 @JacksonAnnotationsInside
 @JsonView(InternalOnly.class)

--- a/backend/src/main/java/com/bakdata/conquery/io/jackson/serializer/BucketDeserializer.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/jackson/serializer/BucketDeserializer.java
@@ -3,7 +3,7 @@ package com.bakdata.conquery.io.jackson.serializer;
 import com.bakdata.conquery.models.datasets.Import;
 import com.bakdata.conquery.models.events.Bucket;
 import com.bakdata.conquery.models.identifiable.ids.specific.ImportId;
-import com.bakdata.conquery.models.worker.NamespaceCollection;
+import com.bakdata.conquery.models.worker.IdResolveContext;
 import com.esotericsoftware.kryo.io.Input;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -37,7 +37,7 @@ public class BucketDeserializer extends JsonDeserializer<Bucket> {
 		if (!p.nextFieldName(FIELD_IMPORT)) {
 			ctxt.handleUnexpectedToken(Bucket.class, p.currentToken(), p, "expected field 'imp'");
 		}
-		Import imp = NamespaceCollection.get(ctxt).resolve(ImportId.Parser.INSTANCE.parse(p.nextTextValue()));
+		Import imp = IdResolveContext.get(ctxt).resolve(ImportId.Parser.INSTANCE.parse(p.nextTextValue()));
 		
 		if (!p.nextFieldName(FIELD_NUMBER_OF_EVENTS)) {
 			ctxt.handleUnexpectedToken(Bucket.class, p.currentToken(), p, "expected field 'numberOfEvents'");

--- a/backend/src/main/java/com/bakdata/conquery/io/jackson/serializer/CBlockDeserializer.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/jackson/serializer/CBlockDeserializer.java
@@ -7,7 +7,7 @@ import com.bakdata.conquery.models.concepts.Concept;
 import com.bakdata.conquery.models.concepts.Connector;
 import com.bakdata.conquery.models.concepts.tree.TreeConcept;
 import com.bakdata.conquery.models.events.CBlock;
-import com.bakdata.conquery.models.worker.NamespaceCollection;
+import com.bakdata.conquery.models.worker.IdResolveContext;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.BeanDescription;
@@ -31,7 +31,7 @@ public class CBlockDeserializer extends JsonDeserializer<CBlock> implements Cont
 	public CBlock deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
 		CBlock block = beanDeserializer.deserialize(p, ctxt);
 		
-		Connector con = NamespaceCollection.get(ctxt).getOptional(block.getConnector()).get();
+		Connector con = IdResolveContext.get(ctxt).getOptional(block.getConnector()).get();
 		Concept<?> concept = con.getConcept();
 		if(concept instanceof TreeConcept && block.getMostSpecificChildren() != null) {
 			TreeConcept tree = (TreeConcept) concept;

--- a/backend/src/main/java/com/bakdata/conquery/io/jackson/serializer/NsIdReferenceDeserializer.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/jackson/serializer/NsIdReferenceDeserializer.java
@@ -11,7 +11,7 @@ import com.bakdata.conquery.models.identifiable.ids.IId;
 import com.bakdata.conquery.models.identifiable.ids.IId.Parser;
 import com.bakdata.conquery.models.identifiable.ids.NamespacedId;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
-import com.bakdata.conquery.models.worker.NamespaceCollection;
+import com.bakdata.conquery.models.worker.IdResolveContext;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.BeanDescription;
@@ -59,7 +59,7 @@ public class NsIdReferenceDeserializer<ID extends NamespacedId&IId<T>, T extends
 					id = idParser.parse(text);
 				}
 				
-				Optional<T> result = NamespaceCollection.get(ctxt).getOptional(id);
+				Optional<T> result = IdResolveContext.get(ctxt).getOptional(id);
 
 				if (!result.isPresent()) {
 					throw new IdReferenceResolvingException(parser, "Could not find entry "+id+" of type "+type.getName(), text, type);

--- a/backend/src/main/java/com/bakdata/conquery/io/mina/BinaryJacksonCoder.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/mina/BinaryJacksonCoder.java
@@ -25,12 +25,12 @@ public class BinaryJacksonCoder implements CQCoder<NetworkMessage<?>> {
 	private final ObjectWriter writer;
 	private final ObjectReader reader;
 
-	public BinaryJacksonCoder(IdResolveContext namespaces, Validator validator) {
+	public BinaryJacksonCoder(IdResolveContext datasets, Validator validator) {
 		this.validator = validator;
 		this.writer = Jackson.BINARY_MAPPER
 			.writerFor(NetworkMessage.class)
 			.withView(InternalOnly.class);
-		this.reader = namespaces
+		this.reader = datasets
 				.injectInto(Jackson.BINARY_MAPPER.readerFor(NetworkMessage.class))
 				.without(Feature.AUTO_CLOSE_SOURCE)
 				.withView(InternalOnly.class);

--- a/backend/src/main/java/com/bakdata/conquery/io/mina/BinaryJacksonCoder.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/mina/BinaryJacksonCoder.java
@@ -9,7 +9,7 @@ import com.bakdata.conquery.io.jackson.InternalOnly;
 import com.bakdata.conquery.io.jackson.Jackson;
 import com.bakdata.conquery.models.exceptions.ValidatorHelper;
 import com.bakdata.conquery.models.messages.network.NetworkMessage;
-import com.bakdata.conquery.models.worker.NamespaceCollection;
+import com.bakdata.conquery.models.worker.IdResolveContext;
 import com.bakdata.conquery.util.io.EndCheckableInputStream;
 import com.fasterxml.jackson.core.JsonParser.Feature;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -25,7 +25,7 @@ public class BinaryJacksonCoder implements CQCoder<NetworkMessage<?>> {
 	private final ObjectWriter writer;
 	private final ObjectReader reader;
 
-	public BinaryJacksonCoder(NamespaceCollection namespaces, Validator validator) {
+	public BinaryJacksonCoder(IdResolveContext namespaces, Validator validator) {
 		this.validator = validator;
 		this.writer = Jackson.BINARY_MAPPER
 			.writerFor(NetworkMessage.class)

--- a/backend/src/main/java/com/bakdata/conquery/io/xodus/MetaStorage.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/xodus/MetaStorage.java
@@ -2,6 +2,7 @@ package com.bakdata.conquery.io.xodus;
 
 import java.util.Collection;
 
+import com.bakdata.conquery.commands.ManagerNode;
 import com.bakdata.conquery.models.auth.entities.Group;
 import com.bakdata.conquery.models.auth.entities.Role;
 import com.bakdata.conquery.models.auth.entities.User;
@@ -15,7 +16,10 @@ import com.bakdata.conquery.models.identifiable.ids.specific.RoleId;
 import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
 import com.bakdata.conquery.models.worker.Namespaces;
 
-public interface MasterMetaStorage extends ConqueryStorage {
+/**
+ * Interface for the persistent data of the {@link ManagerNode} 
+ */
+public interface MetaStorage extends ConqueryStorage {
 
 	void addExecution(ManagedExecution<?> query);
 	ManagedExecution getExecution(ManagedExecutionId id);

--- a/backend/src/main/java/com/bakdata/conquery/io/xodus/MetaStorage.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/xodus/MetaStorage.java
@@ -14,7 +14,7 @@ import com.bakdata.conquery.models.identifiable.ids.specific.GroupId;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
 import com.bakdata.conquery.models.identifiable.ids.specific.RoleId;
 import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 
 /**
  * Interface for the persistent data of the {@link ManagerNode} 
@@ -122,10 +122,10 @@ public interface MetaStorage extends ConqueryStorage {
 	void updateGroup(Group group);
 	
 	/**
-	 * Return the namespaces used in the instance of conquery.
-	 * @return The namespaces.
+	 * Return the datasets used in the instance of conquery.
+	 * @return The datasets.
 	 */
-	Namespaces getNamespaces();
+	DatasetRegistry getDatasetRegistry();
 	
 	/**
 	 * Gets the FormConfig with the specified id from the storage.

--- a/backend/src/main/java/com/bakdata/conquery/io/xodus/MetaStorageImpl.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/xodus/MetaStorageImpl.java
@@ -22,7 +22,7 @@ import com.bakdata.conquery.models.identifiable.ids.specific.GroupId;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
 import com.bakdata.conquery.models.identifiable.ids.specific.RoleId;
 import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.util.functions.Collector;
 import jetbrains.exodus.env.Environment;
 import jetbrains.exodus.env.Environments;
@@ -39,7 +39,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MetaStorageImpl extends ConqueryStorageImpl implements MetaStorage, ConqueryStorage {
 
-	private SingletonStore<Namespaces> meta;
+	private SingletonStore<DatasetRegistry> meta;
 	private IdentifiableStore<ManagedExecution<?>> executions;
 	private IdentifiableStore<FormConfig> formConfigs;
 	private IdentifiableStore<User> authUser;
@@ -47,7 +47,7 @@ public class MetaStorageImpl extends ConqueryStorageImpl implements MetaStorage,
 	private IdentifiableStore<Group> authGroup;
 
 	@Getter
-	private Namespaces namespaces;
+	private DatasetRegistry datasetRegistry;
 
 	@Getter
 	private final Environment executionsEnvironment;
@@ -64,7 +64,7 @@ public class MetaStorageImpl extends ConqueryStorageImpl implements MetaStorage,
 	@Getter
 	private final Environment groupsEnvironment;
 
-	public MetaStorageImpl(Namespaces namespaces, Validator validator, StorageConfig config) {
+	public MetaStorageImpl(DatasetRegistry datasets, Validator validator, StorageConfig config) {
 		super(validator, config, new File(config.getDirectory(), "meta"));
 
 		executionsEnvironment = Environments.newInstance(new File(config.getDirectory(), "executions"), config.getXodus().createConfig());
@@ -77,7 +77,7 @@ public class MetaStorageImpl extends ConqueryStorageImpl implements MetaStorage,
 
 		groupsEnvironment = Environments.newInstance(new File(config.getDirectory(), "groups"), config.getXodus().createConfig());
 
-		this.namespaces = namespaces;
+		this.datasetRegistry = datasets;
 	}
 
 	@Override
@@ -86,7 +86,7 @@ public class MetaStorageImpl extends ConqueryStorageImpl implements MetaStorage,
 		meta = StoreInfo.NAMESPACES.singleton(getConfig(), getEnvironment(), getValidator());
 
 		executions = StoreInfo.EXECUTIONS
-			.<ManagedExecution<?>>identifiable(getConfig(), getExecutionsEnvironment(), getValidator(), getCentralRegistry(), namespaces);
+			.<ManagedExecution<?>>identifiable(getConfig(), getExecutionsEnvironment(), getValidator(), getCentralRegistry(), datasetRegistry);
 		authRole = StoreInfo.AUTH_ROLE.identifiable(getConfig(), getRolesEnvironment(), getValidator(), getCentralRegistry());
 
 		authUser = StoreInfo.AUTH_USER.identifiable(getConfig(), getUsersEnvironment(), getValidator(), getCentralRegistry());

--- a/backend/src/main/java/com/bakdata/conquery/io/xodus/MetaStorageImpl.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/xodus/MetaStorageImpl.java
@@ -31,13 +31,13 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Implementation of the {@link MasterMetaStorage} using {@link XodusStore}s
+ * Implementation of the {@link MetaStorage} using {@link XodusStore}s
  * under the hood. All elements are stored as binary JSON in the Smile format.
  * The {@link JSONException}s that can be thrown by this serdes process are sneakily
  * converted into {@link RuntimeException}s by this implementation.
  */
 @Slf4j
-public class MasterMetaStorageImpl extends ConqueryStorageImpl implements MasterMetaStorage, ConqueryStorage {
+public class MetaStorageImpl extends ConqueryStorageImpl implements MetaStorage, ConqueryStorage {
 
 	private SingletonStore<Namespaces> meta;
 	private IdentifiableStore<ManagedExecution<?>> executions;
@@ -64,7 +64,7 @@ public class MasterMetaStorageImpl extends ConqueryStorageImpl implements Master
 	@Getter
 	private final Environment groupsEnvironment;
 
-	public MasterMetaStorageImpl(Namespaces namespaces, Validator validator, StorageConfig config) {
+	public MetaStorageImpl(Namespaces namespaces, Validator validator, StorageConfig config) {
 		super(validator, config, new File(config.getDirectory(), "meta"));
 
 		executionsEnvironment = Environments.newInstance(new File(config.getDirectory(), "executions"), config.getXodus().createConfig());

--- a/backend/src/main/java/com/bakdata/conquery/io/xodus/NamespaceStorage.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/xodus/NamespaceStorage.java
@@ -29,8 +29,8 @@ public interface NamespaceStorage extends NamespacedStorage {
 		return storage;
 	}
 	
-	MasterMetaStorage getMetaStorage();
-	void setMetaStorage(@NonNull MasterMetaStorage storage);
+	MetaStorage getMetaStorage();
+	void setMetaStorage(@NonNull MetaStorage storage);
 	
 	StructureNode[] getStructure();
 	void updateStructure(StructureNode[] structure) throws JSONException;

--- a/backend/src/main/java/com/bakdata/conquery/io/xodus/NamespaceStorageImpl.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/xodus/NamespaceStorageImpl.java
@@ -22,7 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 public class NamespaceStorageImpl extends NamespacedStorageImpl implements NamespaceStorage {
 	
 	@Getter @Setter @NonNull
-	private MasterMetaStorage metaStorage;
+	private MetaStorage metaStorage;
 	protected SingletonStore<PersistentIdMap> idMapping;
 	protected SingletonStore<StructureNode[]> structure;
 	

--- a/backend/src/main/java/com/bakdata/conquery/io/xodus/StoreInfo.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/xodus/StoreInfo.java
@@ -41,7 +41,7 @@ import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
 import com.bakdata.conquery.models.identifiable.mapping.PersistentIdMap;
 import com.bakdata.conquery.models.worker.Namespaces;
 import com.bakdata.conquery.models.worker.SingletonNamespaceCollection;
-import com.bakdata.conquery.models.worker.SlaveInformation;
+import com.bakdata.conquery.models.worker.ShardNodeInformation;
 import com.bakdata.conquery.models.worker.WorkerInformation;
 import jetbrains.exodus.env.Environment;
 import lombok.Getter;
@@ -58,7 +58,7 @@ public enum StoreInfo implements IStoreInfo {
 	DATASET(Dataset.class, Boolean.class),
 	ID_MAPPING(PersistentIdMap.class, Boolean.class),
 	NAMESPACES(Namespaces.class, Boolean.class),
-	SLAVE(SlaveInformation.class, Boolean.class),
+	SLAVE(ShardNodeInformation.class, Boolean.class),
 	DICTIONARIES(Dictionary.class, DictionaryId.class),
 	IMPORTS(Import.class, ImportId.class),
 	CONCEPTS(Concept.class, ConceptId.class),

--- a/backend/src/main/java/com/bakdata/conquery/io/xodus/StoreInfo.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/xodus/StoreInfo.java
@@ -39,7 +39,7 @@ import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
 import com.bakdata.conquery.models.identifiable.ids.specific.RoleId;
 import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
 import com.bakdata.conquery.models.identifiable.mapping.PersistentIdMap;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.models.worker.SingletonNamespaceCollection;
 import com.bakdata.conquery.models.worker.ShardNodeInformation;
 import com.bakdata.conquery.models.worker.WorkerInformation;
@@ -57,7 +57,7 @@ import lombok.RequiredArgsConstructor;
 public enum StoreInfo implements IStoreInfo {
 	DATASET(Dataset.class, Boolean.class),
 	ID_MAPPING(PersistentIdMap.class, Boolean.class),
-	NAMESPACES(Namespaces.class, Boolean.class),
+	NAMESPACES(DatasetRegistry.class, Boolean.class),
 	SLAVE(ShardNodeInformation.class, Boolean.class),
 	DICTIONARIES(Dictionary.class, DictionaryId.class),
 	IMPORTS(Import.class, ImportId.class),

--- a/backend/src/main/java/com/bakdata/conquery/metrics/ActiveUsersFilter.java
+++ b/backend/src/main/java/com/bakdata/conquery/metrics/ActiveUsersFilter.java
@@ -11,7 +11,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.PreMatching;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.AuthorizationHelper;
 import com.bakdata.conquery.models.auth.entities.Group;
 import com.bakdata.conquery.models.auth.entities.User;
@@ -33,7 +33,7 @@ public class ActiveUsersFilter implements ContainerRequestFilter {
 	private static final String USERS = "users";
 	private static final String ACTIVE = "active";
 
-	private final MasterMetaStorage storage;
+	private final MetaStorage storage;
 	private final Duration activeUserDuration;
 
 	private final Table<Group, User, LocalDateTime> activeUsers = HashBasedTable.create();

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/AuthorizationController.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/AuthorizationController.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.bakdata.conquery.apiv1.auth.ProtoUser;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.conquerytoken.ConqueryTokenRealm;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.auth.web.DefaultAuthFilter;
@@ -47,7 +47,7 @@ public final class AuthorizationController implements Managed{
 	private final List<AuthenticationConfig> authenticationConfigs;
 	@NonNull
 	@Getter
-	private final MasterMetaStorage storage;
+	private final MetaStorage storage;
 
 	@Getter
 	private ConqueryTokenRealm centralTokenRealm;
@@ -113,7 +113,7 @@ public final class AuthorizationController implements Managed{
 	 * @param storage
 	 *            A storage, where the handler might add a new users.
 	 */
-	private static void initializeAuthConstellation(AuthorizationConfig config, List<Realm> realms, MasterMetaStorage storage) {
+	private static void initializeAuthConstellation(AuthorizationConfig config, List<Realm> realms, MetaStorage storage) {
 		for (ProtoUser pUser : config.getInitialUsers()) {
 			pUser.registerForAuthorization(storage, true);
 			for (Realm realm : realms) {

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/AuthorizationHelper.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/AuthorizationHelper.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.Group;
 import com.bakdata.conquery.models.auth.entities.PermissionOwner;
 import com.bakdata.conquery.models.auth.entities.Role;
@@ -123,7 +123,7 @@ public class AuthorizationHelper {
 	 * @param permission The permission to add.
 	 * @param storage A storage where the permission are added for persistence.
 	 */
-	public static void addPermission(@NonNull PermissionOwner<?> owner, @NonNull ConqueryPermission permission, @NonNull MasterMetaStorage storage) {
+	public static void addPermission(@NonNull PermissionOwner<?> owner, @NonNull ConqueryPermission permission, @NonNull MetaStorage storage) {
 		owner.addPermission(storage, permission);
 	}
 	
@@ -133,11 +133,11 @@ public class AuthorizationHelper {
 	 * @param permission The permission to remove.
 	 * @param storage A storage where the permission is removed from.
 	 */
-	public static void removePermission(@NonNull PermissionOwner<?> owner, @NonNull Permission permission, @NonNull MasterMetaStorage storage) {
+	public static void removePermission(@NonNull PermissionOwner<?> owner, @NonNull Permission permission, @NonNull MetaStorage storage) {
 		owner.removePermission(storage, permission);
 	}
 	
-	public static List<Group> getGroupsOf(@NonNull User user, @NonNull MasterMetaStorage storage){
+	public static List<Group> getGroupsOf(@NonNull User user, @NonNull MetaStorage storage){
 		List<Group> userGroups = new ArrayList<>();
 		for (Group group : storage.getAllGroups()) {
 			if(group.containsMember(user)) {
@@ -151,7 +151,7 @@ public class AuthorizationHelper {
 	 * Find the primary group of the user. All users must have a primary group.
 	 * @implNote Currently this is the first group of a user and should also be the only group.
 	 */
-	public static Optional<Group> getPrimaryGroup(@NonNull User user, @NonNull MasterMetaStorage storage) {
+	public static Optional<Group> getPrimaryGroup(@NonNull User user, @NonNull MetaStorage storage) {
 		List<Group> groups = getGroupsOf(user, storage);
 		if(groups.isEmpty()) {
 			return Optional.empty();
@@ -167,7 +167,7 @@ public class AuthorizationHelper {
 	 * the permission of the roles it inherits.
 	 * @return Owned and inherited permissions.
 	 */
-	public static Set<Permission> getEffectiveUserPermissions(UserId userId, MasterMetaStorage storage) {
+	public static Set<Permission> getEffectiveUserPermissions(UserId userId, MetaStorage storage) {
 		User user = Objects.requireNonNull(storage.getUser(userId), () -> String.format("User with id %s was not found", userId));
 		Set<Permission> userPermissions = user.getPermissions();
 		Set<Permission> tmpView = userPermissions;
@@ -193,7 +193,7 @@ public class AuthorizationHelper {
 	 * @param storage
 	 * @return
 	 */
-	public static Set<Permission> getEffectiveGroupPermissions(GroupId groupId, MasterMetaStorage storage) {
+	public static Set<Permission> getEffectiveGroupPermissions(GroupId groupId, MetaStorage storage) {
 		Group group = Objects.requireNonNull(
 			storage.getGroup(groupId),
 			() -> String.format("User with id %s was not found", groupId));
@@ -214,7 +214,7 @@ public class AuthorizationHelper {
 	 * the permission of the roles it inherits. The query can be filtered by the Permission domain.
 	 * @return Owned and inherited permissions.
 	 */
-	public static Multimap<String, ConqueryPermission> getEffectiveUserPermissions(UserId userId, List<String> domainSpecifier, MasterMetaStorage storage) {
+	public static Multimap<String, ConqueryPermission> getEffectiveUserPermissions(UserId userId, List<String> domainSpecifier, MetaStorage storage) {
 		Set<Permission> permissions = getEffectiveUserPermissions(userId, storage);
 		Multimap<String, ConqueryPermission> mappedPerms = ArrayListMultimap.create();
 		for(Permission perm : permissions) {
@@ -231,7 +231,7 @@ public class AuthorizationHelper {
 	
 
 	
-	public static <P extends PermissionOwner<?>> void addRoleTo(MasterMetaStorage storage, PermissionOwnerId<P> ownerId, RoleId roleId) {
+	public static <P extends PermissionOwner<?>> void addRoleTo(MetaStorage storage, PermissionOwnerId<P> ownerId, RoleId roleId) {
 		Role role = Objects.requireNonNull(roleId.getPermissionOwner(storage));
 		P owner = Objects.requireNonNull(ownerId.getPermissionOwner(storage));
 		
@@ -243,7 +243,7 @@ public class AuthorizationHelper {
 		log.trace("Added role {} to {}", role, owner);
 	}
 	
-	public static <P extends PermissionOwner<?>> void deleteRoleFrom(MasterMetaStorage storage, PermissionOwnerId<P> ownerId, RoleId roleId) {
+	public static <P extends PermissionOwner<?>> void deleteRoleFrom(MetaStorage storage, PermissionOwnerId<P> ownerId, RoleId roleId) {
 		Role role = Objects.requireNonNull(roleId.getPermissionOwner(storage));
 		P owner = Objects.requireNonNull(ownerId.getPermissionOwner(storage));
 		
@@ -256,7 +256,7 @@ public class AuthorizationHelper {
 		log.trace("Deleted role {} from {}", role, owner);
 	}
 
-	public static void deleteRole(MasterMetaStorage storage, RoleId roleId) {
+	public static void deleteRole(MetaStorage storage, RoleId roleId) {
 		log.info("Deleting mandator: {}", roleId);
 		Role role = storage.getRole(roleId);
 		for (User user : storage.getAllUsers()) {
@@ -270,11 +270,11 @@ public class AuthorizationHelper {
 	
 
 
-	public static List<User> getUsersByRole(MasterMetaStorage storage, Role role) {
+	public static List<User> getUsersByRole(MetaStorage storage, Role role) {
 		return storage.getAllUsers().stream().filter(u -> u.getRoles().contains(role)).collect(Collectors.toList());
 	}
 
-	public static List<Group> getGroupsByRole(MasterMetaStorage storage, Role role) {
+	public static List<Group> getGroupsByRole(MetaStorage storage, Role role) {
 		return storage.getAllGroups().stream().filter(g -> g.getRoles().contains(role)).collect(Collectors.toList());
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/ConqueryAuthenticator.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/ConqueryAuthenticator.java
@@ -2,7 +2,7 @@ package com.bakdata.conquery.models.auth;
 
 import java.util.Optional;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.auth.web.AuthenticationExceptionMapper;
 import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
@@ -24,7 +24,7 @@ import org.apache.shiro.authc.AuthenticationToken;
 @RequiredArgsConstructor
 public class ConqueryAuthenticator implements Authenticator<AuthenticationToken, User>{
 	
-	private final MasterMetaStorage storage;
+	private final MetaStorage storage;
 
 	/**
 	 * The execeptions thrown by Shiro will be catched by {@link AuthenticationExceptionMapper}.  
@@ -36,7 +36,7 @@ public class ConqueryAuthenticator implements Authenticator<AuthenticationToken,
 		// All authenticating realms must return a UserId as identifying principal
 		UserId userId = (UserId)info.getPrincipals().getPrimaryPrincipal();
 
-		// The UserId is queried in the MasterMetaStorage, the central place for authorization information
+		// The UserId is queried in the MetaStorage, the central place for authorization information
 		User user = storage.getUser(userId);
 		
 		if(user != null) {

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/ConqueryAuthorizationRealm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/ConqueryAuthorizationRealm.java
@@ -5,7 +5,7 @@ import java.util.ConcurrentModificationException;
 import java.util.Objects;
 import java.util.Set;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
 import com.google.common.collect.Sets;
 import lombok.RequiredArgsConstructor;
@@ -20,12 +20,12 @@ import org.apache.shiro.subject.PrincipalCollection;
 
 /**
  * This realms only provides authorization information for a given {@link UserId}.
- * For now there is only one such authorizing realm. This queries the {@link MasterMetaStorage}.
+ * For now there is only one such authorizing realm. This queries the {@link MetaStorage}.
  */
 @RequiredArgsConstructor
 public class ConqueryAuthorizationRealm extends AuthorizingRealm {
 	
-	public final MasterMetaStorage storage;
+	public final MetaStorage storage;
 	
 	@Override
 	protected void onInit() {

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/UserManageable.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/UserManageable.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import com.bakdata.conquery.Conquery;
 import com.bakdata.conquery.apiv1.auth.CredentialType;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
 
@@ -29,7 +29,7 @@ public interface UserManageable {
 	boolean updateUser(User user, List<CredentialType> credentials);
 
 	/**
-	 * Removes a user from the realm only but not from the local permission storage (i.e. {@link MasterMetaStorage}).
+	 * Removes a user from the realm only but not from the local permission storage (i.e. {@link MetaStorage}).
 	 */
 	boolean removeUser(User user);
 

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/basic/LocalAuthenticationRealm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/basic/LocalAuthenticationRealm.java
@@ -64,7 +64,7 @@ public class LocalAuthenticationRealm extends ConqueryAuthenticationRealm implem
 
 	private static final int ENVIRONMNENT_CLOSING_RETRYS = 2;
 	private static final int ENVIRONMNENT_CLOSING_TIMEOUT = 2; // seconds
-	// Get the path for the storage here so it is set when as soon the first class is instantiated (in the MasterCommand)
+	// Get the path for the storage here so it is set when as soon the first class is instantiated (in the ManagerNode)
 	// In the StandaloneCommand this directory is overriden multiple times before LocalAuthenticationRealm::onInit for the slaves, so this is a problem.
 	private static final File STORE_DIR = ConqueryConfig.getInstance().getStorage().getDirectory();
 

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/basic/LocalAuthenticationRealm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/basic/LocalAuthenticationRealm.java
@@ -65,7 +65,7 @@ public class LocalAuthenticationRealm extends ConqueryAuthenticationRealm implem
 	private static final int ENVIRONMNENT_CLOSING_RETRYS = 2;
 	private static final int ENVIRONMNENT_CLOSING_TIMEOUT = 2; // seconds
 	// Get the path for the storage here so it is set when as soon the first class is instantiated (in the ManagerNode)
-	// In the StandaloneCommand this directory is overriden multiple times before LocalAuthenticationRealm::onInit for the slaves, so this is a problem.
+	// In the StandaloneCommand this directory is overriden multiple times before LocalAuthenticationRealm::onInit for the ShardNodes, so this is a problem.
 	private static final File STORE_DIR = ConqueryConfig.getInstance().getStorage().getDirectory();
 
 	private final XodusConfig passwordStoreConfig;

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/basic/LocalAuthenticationRealm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/basic/LocalAuthenticationRealm.java
@@ -11,7 +11,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import com.bakdata.conquery.Conquery;
 import com.bakdata.conquery.apiv1.auth.CredentialType;
 import com.bakdata.conquery.apiv1.auth.PasswordCredential;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.io.xodus.stores.IStoreInfo;
 import com.bakdata.conquery.io.xodus.stores.XodusStore;
 import com.bakdata.conquery.models.auth.AuthorizationController;
@@ -54,8 +54,8 @@ import org.glassfish.hk2.utilities.binding.AbstractBinder;
  * is given a signed JWT for further authentication over following requests. The
  * realm offers a basic user management, which is decoupled form the
  * authorization related user information that is saved in the
- * {@link MasterMetaStorage}. So adding or removing a user in this realm does
- * not change the {@link MasterMetaStorage}. {@link Conquery} interacts with
+ * {@link MetaStorage}. So adding or removing a user in this realm does
+ * not change the {@link MetaStorage}. {@link Conquery} interacts with
  * this realm using the Shiro frame work. However, endusers can interface it
  * through specific endpoints that are registerd by this realm.
  */
@@ -77,7 +77,7 @@ public class LocalAuthenticationRealm extends ConqueryAuthenticationRealm implem
 	private XodusStore passwordStore;
 
 	@JsonIgnore
-	private final MasterMetaStorage storage;
+	private final MetaStorage storage;
 	@JsonIgnore
 	private final ConqueryTokenRealm centralTokenRealm;
 

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/basic/UserAuthenticationManagementProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/basic/UserAuthenticationManagementProcessor.java
@@ -3,7 +3,7 @@ package com.bakdata.conquery.models.auth.basic;
 import java.util.Objects;
 
 import com.bakdata.conquery.apiv1.auth.ProtoUser;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
 import com.bakdata.conquery.resources.admin.rest.UserAuthenticationManagementResource;
@@ -18,7 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 public class UserAuthenticationManagementProcessor {
 
 	private final LocalAuthenticationRealm realm;
-	private final MasterMetaStorage storage;
+	private final MetaStorage storage;
 
 	public boolean addUser(ProtoUser pUser) {
 		// Throws an exception if it would override the existing user

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/conquerytoken/ConqueryTokenRealm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/conquerytoken/ConqueryTokenRealm.java
@@ -10,7 +10,7 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.ConqueryAuthenticationInfo;
 import com.bakdata.conquery.models.auth.ConqueryAuthenticationRealm;
 import com.bakdata.conquery.models.auth.basic.TokenHandler;
@@ -33,13 +33,13 @@ public class ConqueryTokenRealm extends ConqueryAuthenticationRealm {
 
 	private static final Class<? extends AuthenticationToken> TOKEN_CLASS = JwtToken.class;
 
-	private final MasterMetaStorage storage;
+	private final MetaStorage storage;
 	
 	@Setter
 	private JWTConfig jwtConfig = new JWTConfig();
 	
 	
-	public ConqueryTokenRealm(MasterMetaStorage storage) {
+	public ConqueryTokenRealm(MetaStorage storage) {
 		this.storage = storage;
 		setAuthenticationTokenClass(TOKEN_CLASS);
 		setCredentialsMatcher(new SkippingCredentialsMatcher());

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/entities/Group.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/entities/Group.java
@@ -5,7 +5,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.bakdata.conquery.io.jackson.serializer.MetaIdRefCollection;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.identifiable.ids.specific.GroupId;
 import lombok.extern.slf4j.Slf4j;
 
@@ -28,7 +28,7 @@ public class Group extends PermissionOwner<GroupId> implements RoleOwner {
 	}
 
 	@Override
-	protected void updateStorage(MasterMetaStorage storage) {
+	protected void updateStorage(MetaStorage storage) {
 		storage.updateGroup(this);
 	}
 
@@ -37,14 +37,14 @@ public class Group extends PermissionOwner<GroupId> implements RoleOwner {
 		return new GroupId(name);
 	}
 
-	public void addMember(MasterMetaStorage storage, User user) {
+	public void addMember(MetaStorage storage, User user) {
 		if(members.add(user)) {
 			log.trace("Added user {} to group {}", user.getId(), getId());
 			updateStorage(storage);
 		}
 	}
 
-	public void removeMember(MasterMetaStorage storage, User user) {
+	public void removeMember(MetaStorage storage, User user) {
 		if(members.remove(user)) {
 			log.trace("Removed user {} from group {}", user.getId(), getId());				
 			updateStorage(storage);
@@ -59,14 +59,14 @@ public class Group extends PermissionOwner<GroupId> implements RoleOwner {
 		return Collections.unmodifiableSet(members);
 	}
 
-	public void addRole(MasterMetaStorage storage, Role role) {
+	public void addRole(MetaStorage storage, Role role) {
 		if (roles.add(role)) {
 			log.trace("Added role {} to group {}", role.getId(), getId());
 			updateStorage(storage);
 		}
 	}
 
-	public void removeRole(MasterMetaStorage storage, Role role) {
+	public void removeRole(MetaStorage storage, Role role) {
 		if (roles.remove(role)) {
 			log.trace("Removed role {} from group {}", role.getId(), getId());
 			updateStorage(storage);

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/entities/PermissionOwner.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/entities/PermissionOwner.java
@@ -5,6 +5,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 import com.bakdata.conquery.io.xodus.MetaStorage;
@@ -17,7 +18,6 @@ import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shiro.authz.Permission;
-import org.hibernate.validator.constraints.NotEmpty;
 
 /**
  * The base class of security subjects in this project. Used to represent

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/entities/PermissionOwner.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/entities/PermissionOwner.java
@@ -7,7 +7,7 @@ import java.util.Set;
 
 import javax.validation.constraints.NotNull;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.permissions.ConqueryPermission;
 import com.bakdata.conquery.models.identifiable.IdentifiableImpl;
 import com.bakdata.conquery.models.identifiable.ids.specific.PermissionOwnerId;
@@ -63,7 +63,7 @@ public abstract class PermissionOwner<T extends PermissionOwnerId<? extends Perm
 	 *            The permission to add.
 	 * @return Returns the added Permission
 	 */
-	public Set<ConqueryPermission> addPermissions(MasterMetaStorage storage, Set<ConqueryPermission> permissions) {
+	public Set<ConqueryPermission> addPermissions(MetaStorage storage, Set<ConqueryPermission> permissions) {
 		HashSet<ConqueryPermission> addedPermissions = new HashSet<>();
 		for (ConqueryPermission permission : permissions) {
 			addedPermissions.add(addPermission(storage, permission));
@@ -71,7 +71,7 @@ public abstract class PermissionOwner<T extends PermissionOwnerId<? extends Perm
 		return addedPermissions;
 	}
 
-	public ConqueryPermission addPermission(MasterMetaStorage storage, ConqueryPermission permission) {
+	public ConqueryPermission addPermission(MetaStorage storage, ConqueryPermission permission) {
 		if (permissions.add(permission)) {
 			updateStorage(storage);
 			log.trace("Added permission {} to owner {}", permission, getId());
@@ -88,13 +88,13 @@ public abstract class PermissionOwner<T extends PermissionOwnerId<? extends Perm
 	 *            The permission to add.
 	 * @return Returns the added Permission
 	 */
-	public void removePermissions(MasterMetaStorage storage, Set<ConqueryPermission> permissions) {
+	public void removePermissions(MetaStorage storage, Set<ConqueryPermission> permissions) {
 		for (ConqueryPermission permission : permissions) {
 			removePermission(storage, permission);
 		}
 	}
 
-	public void removePermission(MasterMetaStorage storage, Permission delPermission) {
+	public void removePermission(MetaStorage storage, Permission delPermission) {
 		if (permissions.remove(delPermission)) {
 			this.updateStorage(storage);
 			log.trace("Removed permission {} from owner {}", delPermission, getId());
@@ -130,16 +130,16 @@ public abstract class PermissionOwner<T extends PermissionOwnerId<? extends Perm
 		this.permissions.addAll(permissions);
 	}
 
-	public void setPermissions(MasterMetaStorage storage, Set<ConqueryPermission> permissionsNew) {
+	public void setPermissions(MetaStorage storage, Set<ConqueryPermission> permissionsNew) {
 		permissions.clear();
 		permissions.addAll(permissionsNew);
 		updateStorage(storage);
 	}
 
 	/**
-	 * Update this instance in the {@link MasterMetaStorage}.
+	 * Update this instance in the {@link MetaStorage}.
 	 */
-	protected abstract void updateStorage(MasterMetaStorage storage);
+	protected abstract void updateStorage(MetaStorage storage);
 	
 	
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/entities/Role.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/entities/Role.java
@@ -1,6 +1,6 @@
 package com.bakdata.conquery.models.auth.entities;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.identifiable.ids.specific.RoleId;
 
 public class Role extends PermissionOwner<RoleId> {
@@ -16,7 +16,7 @@ public class Role extends PermissionOwner<RoleId> {
 	}
 	
 	@Override
-	protected void updateStorage(MasterMetaStorage storage) {
+	protected void updateStorage(MetaStorage storage) {
 		storage.updateRole(this);
 		
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/entities/RoleOwner.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/entities/RoleOwner.java
@@ -2,14 +2,14 @@ package com.bakdata.conquery.models.auth.entities;
 
 import java.util.Set;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public interface RoleOwner {
 
-	void addRole(MasterMetaStorage storage, Role role);
+	void addRole(MetaStorage storage, Role role);
 
-	void removeRole(MasterMetaStorage storage, Role role);
+	void removeRole(MetaStorage storage, Role role);
 
 	/**
 	 * Return a copy of the roles hold by the owner.

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/entities/User.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/entities/User.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.bakdata.conquery.io.jackson.serializer.MetaIdRefCollection;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.util.SinglePrincipalCollection;
 import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -70,7 +70,7 @@ public class User extends FilteredUser<UserId> implements Principal, RoleOwner {
 		return new UserId(name);
 	}
 
-	public void addRole(MasterMetaStorage storage, Role role) {
+	public void addRole(MetaStorage storage, Role role) {
 		if(roles.add(role)) {
 			log.trace("Added role {} to user {}", role.getId(), getId());
 			updateStorage(storage);
@@ -78,7 +78,7 @@ public class User extends FilteredUser<UserId> implements Principal, RoleOwner {
 	}
 	
 	@Override
-	public void removeRole(MasterMetaStorage storage, Role role) {
+	public void removeRole(MetaStorage storage, Role role) {
 		if(roles.remove(role)) {
 			log.trace("Removed role {} from user {}", role.getId(), getId());				
 			updateStorage(storage);
@@ -90,7 +90,7 @@ public class User extends FilteredUser<UserId> implements Principal, RoleOwner {
 	}
 	
 	@Override
-	protected void updateStorage(MasterMetaStorage storage) {
+	protected void updateStorage(MetaStorage storage) {
 		storage.updateUser(this);
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/oidc/passwordflow/OIDCResourceOwnerPasswordCredentialRealm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/oidc/passwordflow/OIDCResourceOwnerPasswordCredentialRealm.java
@@ -2,7 +2,6 @@ package com.bakdata.conquery.models.auth.oidc.passwordflow;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.concurrent.TimeUnit;
@@ -10,7 +9,7 @@ import java.util.concurrent.TimeUnit;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.UriBuilder;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.ConqueryAuthenticationInfo;
 import com.bakdata.conquery.models.auth.ConqueryAuthenticationRealm;
 import com.bakdata.conquery.models.auth.basic.TokenHandler;
@@ -66,7 +65,7 @@ public class OIDCResourceOwnerPasswordCredentialRealm extends ConqueryAuthentica
 
 	private static final Class<? extends AuthenticationToken> TOKEN_CLASS = JwtToken.class;
 	
-	private final MasterMetaStorage storage;
+	private final MetaStorage storage;
 	private final OIDCResourceOwnerPasswordCredentialRealmFactory config;
 	
 	private ClientAuthentication clientAuthentication;

--- a/backend/src/main/java/com/bakdata/conquery/models/config/ClusterConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/ClusterConfig.java
@@ -16,7 +16,7 @@ public class ClusterConfig extends Configuration {
 	@PortRange
 	private int port = 16170;
 	@Valid @NotNull
-	private InetAddress masterURL = InetAddress.getLoopbackAddress();
+	private InetAddress managerURL = InetAddress.getLoopbackAddress();
 	@Valid @NotNull
 	private MinaConfig mina = new MinaConfig();
 	@Min(1)

--- a/backend/src/main/java/com/bakdata/conquery/models/config/StandaloneConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/StandaloneConfig.java
@@ -5,5 +5,5 @@ import lombok.Setter;
 
 @Getter @Setter
 public class StandaloneConfig {
-	private int numberOfSlaves = 2;
+	private int numberOfShardNodes = 2;
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/BucketManager.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/BucketManager.java
@@ -31,7 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  *
- * @implNote This class is only used per {@link Worker}. And NOT in the Master.
+ * @implNote This class is only used per {@link Worker}. And NOT in the ManagerNode.
  */
 @Slf4j
 public class BucketManager {

--- a/backend/src/main/java/com/bakdata/conquery/models/events/BucketManager.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/BucketManager.java
@@ -24,7 +24,6 @@ import com.bakdata.conquery.models.jobs.CalculateCBlocksJob;
 import com.bakdata.conquery.models.jobs.JobManager;
 import com.bakdata.conquery.models.query.entity.Entity;
 import com.bakdata.conquery.models.worker.Worker;
-import com.bakdata.conquery.models.worker.WorkerInformation;
 import it.unimi.dsi.fastutil.ints.Int2ObjectAVLTreeMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import lombok.Getter;
@@ -45,15 +44,17 @@ public class BucketManager {
 	private final IdMap<CBlockId, CBlock> cBlocks = new IdMap<>();
 	@Getter
 	private final Int2ObjectMap<Entity> entities = new Int2ObjectAVLTreeMap<>();
-	private final WorkerInformation workerInformation;
+	
+	//Backreference
+	private final Worker worker;
 
-	public BucketManager(JobManager jobManager, WorkerStorage storage, WorkerInformation workerInformation) {
-		this.jobManager = jobManager;
-		this.storage = storage;
+	public BucketManager(Worker worker) {
+		this.jobManager = worker.getJobManager();
+		this.storage = worker.getStorage();
 		this.concepts.addAll(storage.getAllConcepts());
 		this.buckets.addAll(storage.getAllBuckets());
 		this.cBlocks.addAll(storage.getAllCBlocks());
-		this.workerInformation = workerInformation;
+		this.worker = worker;
 	}
 
 	public void fullUpdate() {
@@ -64,7 +65,7 @@ public class BucketManager {
 					CalculateCBlocksJob job = new CalculateCBlocksJob(storage, this, con, t);
 					ConnectorId conName = con.getId();
 					for (Import imp : t.findImports(storage)) {
-						for (int bucketNumber : workerInformation.getIncludedBuckets()) {
+						for (int bucketNumber : worker.getInfo().getIncludedBuckets()) {
 							BucketId bucketId = new BucketId(imp.getId(), bucketNumber);
 							Optional<Bucket> bucket = buckets.getOptional(bucketId);
 							if (bucket.isPresent()) {
@@ -168,7 +169,7 @@ public class BucketManager {
 				Table t = con.getTable();
 				CalculateCBlocksJob job = new CalculateCBlocksJob(storage, this, con, t);
 				for (Import imp : t.findImports(storage)) {
-					for (int bucketNumber : workerInformation.getIncludedBuckets()) {
+					for (int bucketNumber : worker.getInfo().getIncludedBuckets()) {
 
 						BucketId bucketId = new BucketId(imp.getId(), bucketNumber);
 
@@ -265,7 +266,7 @@ public class BucketManager {
 
 		for (Connector con : c.getConnectors()) {
 			for (Import imp : con.getTable().findImports(storage)) {
-				for (int bucketNumber : workerInformation.getIncludedBuckets()) {
+				for (int bucketNumber : worker.getInfo().getIncludedBuckets()) {
 
 					BucketId bucketId = new BucketId(imp.getId(), bucketNumber);
 
@@ -286,7 +287,7 @@ public class BucketManager {
 	 * Remove all buckets comprising the import. Which will in-turn remove all CBLocks.
 	 */
 	public void removeImport(ImportId imp) {
-		for (int bucketNumber : workerInformation.getIncludedBuckets()) {
+		for (int bucketNumber : worker.getInfo().getIncludedBuckets()) {
 
 			BucketId bucketId = new BucketId(imp, bucketNumber);
 

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
@@ -300,7 +300,7 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 	public abstract void addResult(@NonNull MasterMetaStorage storage, R result);
 
 	/**
-	 * Initializes the result that is send from a worker to the Master.
+	 * Initializes the result that is send from a worker to the ManagerNode.
 	 * E.g. this function enables the {@link ManagedForm} to prepare the result in order to be
 	 * matched to its subqueries.
 	 */

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
@@ -45,7 +45,7 @@ import com.bakdata.conquery.models.query.QueryPlanContext;
 import com.bakdata.conquery.models.query.queryplan.QueryPlan;
 import com.bakdata.conquery.models.query.results.ShardResult;
 import com.bakdata.conquery.models.worker.Namespace;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.util.QueryUtils;
 import com.bakdata.conquery.util.QueryUtils.NamespacedIdCollector;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -105,14 +105,14 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 	 * Executed right before execution submission.
 	 * @param namespaces
 	 */
-	public abstract void initExecutable(Namespaces namespaces);
+	public abstract void initExecutable(DatasetRegistry namespaces);
 
 	/**
 	 * Returns the set of namespaces, this execution needs to be executed on.
 	 * The {@link ExecutionManager} then submits the queries to these namespaces.
 	 */
 	@JsonIgnore
-	public abstract Set<Namespace> getRequiredNamespaces();
+	public abstract Set<Namespace> getRequiredDatasets();
 
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
@@ -25,7 +25,7 @@ import javax.ws.rs.core.StreamingOutput;
 import com.bakdata.conquery.apiv1.QueryDescription;
 import com.bakdata.conquery.apiv1.URLBuilder;
 import com.bakdata.conquery.io.cps.CPSBase;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.auth.permissions.Ability;
 import com.bakdata.conquery.models.auth.permissions.DatasetPermission;
@@ -126,7 +126,7 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 	/**
 	 * Fails the execution and log the occurred error.
 	 */
-	protected void fail(MasterMetaStorage storage, ConqueryErrorInfo error) {
+	protected void fail(MetaStorage storage, ConqueryErrorInfo error) {
 		if(this.error != null && !this.error.equalsRegardingCodeAndMessage(error)) {
 			// Warn only again if the error is different (failed might by called per collected result)
 			log.warn("The execution [{}] failed again with:\n\t{}\n\tThe previous error was: {}", getId(), this.error, error);
@@ -144,7 +144,7 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 		state = ExecutionState.RUNNING;
 	}
 
-	protected void finish(MasterMetaStorage storage, ExecutionState executionState) {
+	protected void finish(MetaStorage storage, ExecutionState executionState) {
 		if (getState() == ExecutionState.NEW) {
 			log.error("Query[{}] was never run.", getId());			
 		}
@@ -192,7 +192,7 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 		}
 	}
 
-	protected void setStatusBase(@NonNull MasterMetaStorage storage, URLBuilder url, @NonNull  User user, @NonNull ExecutionStatus status) {
+	protected void setStatusBase(@NonNull MetaStorage storage, URLBuilder url, @NonNull  User user, @NonNull ExecutionStatus status) {
 		status.setLabel(label == null ? queryId.toString() : label);
 		status.setPristineLabel(label == null || queryId.toString().equals(label));
 		status.setId(getId());
@@ -219,14 +219,14 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 	 */
 	protected abstract URL getDownloadURL(URLBuilder url);
 
-	public ExecutionStatus buildStatus(@NonNull MasterMetaStorage storage, URLBuilder url, User user) {
+	public ExecutionStatus buildStatus(@NonNull MetaStorage storage, URLBuilder url, User user) {
 		return buildStatus(storage, url, user, EnumSet.noneOf(ExecutionStatus.CreationFlag.class));
 	}
-	public ExecutionStatus buildStatus(@NonNull MasterMetaStorage storage, URLBuilder url, User user, @NonNull ExecutionStatus.CreationFlag creationFlag) {
+	public ExecutionStatus buildStatus(@NonNull MetaStorage storage, URLBuilder url, User user, @NonNull ExecutionStatus.CreationFlag creationFlag) {
 		return buildStatus(storage, url, user, EnumSet.of(creationFlag));
 	}
 	
-	public ExecutionStatus buildStatus(@NonNull MasterMetaStorage storage, URLBuilder url, User user, @NonNull EnumSet<ExecutionStatus.CreationFlag> creationFlags) {
+	public ExecutionStatus buildStatus(@NonNull MetaStorage storage, URLBuilder url, User user, @NonNull EnumSet<ExecutionStatus.CreationFlag> creationFlags) {
 		ExecutionStatus status = new ExecutionStatus();
 		setStatusBase(storage, url, user, status);
 		for(CreationFlag flag : creationFlags) {
@@ -245,14 +245,14 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 		
 	}
 
-	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MasterMetaStorage storage, URLBuilder url, User user, ExecutionStatus status) {
+	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MetaStorage storage, URLBuilder url, User user, ExecutionStatus status) {
 		// Implementation specific
 	}
 
 	/**
 	 * Sets additional fields of an {@link ExecutionStatus} when a more specific status is requested.
 	 */
-	protected void setAdditionalFieldsForStatusWithSource(@NonNull MasterMetaStorage storage, URLBuilder url, User user, ExecutionStatus status) {
+	protected void setAdditionalFieldsForStatusWithSource(@NonNull MetaStorage storage, URLBuilder url, User user, ExecutionStatus status) {
 		QueryDescription query = getSubmitted();
 		NamespacedIdCollector namespacesIdCollector = new NamespacedIdCollector();
 		query.visit(namespacesIdCollector);
@@ -297,7 +297,7 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 	 */
 	public abstract Map<ManagedExecutionId,QueryPlan> createQueryPlans(QueryPlanContext context);
 
-	public abstract void addResult(@NonNull MasterMetaStorage storage, R result);
+	public abstract void addResult(@NonNull MetaStorage storage, R result);
 
 	/**
 	 * Initializes the result that is send from a worker to the ManagerNode.

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ResultProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ResultProcessor.java
@@ -21,7 +21,7 @@ import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
 import com.bakdata.conquery.models.identifiable.mapping.IdMappingState;
 import com.bakdata.conquery.models.query.PrintSettings;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.util.io.ConqueryMDC;
 import lombok.extern.slf4j.Slf4j;
 
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ResultProcessor {
 	
-	public static ResponseBuilder getResult(User user, DatasetId datasetId, ManagedExecutionId queryId, String userAgent, String queryCharset, Namespaces namespaces, ConqueryConfig config) {
+	public static ResponseBuilder getResult(User user, DatasetId datasetId, ManagedExecutionId queryId, String userAgent, String queryCharset, DatasetRegistry namespaces, ConqueryConfig config) {
 		ConqueryMDC.setLocation(user.getName());
 		log.info("Downloading results for {} on dataset {}", queryId, datasetId);
 		authorize(user, datasetId, Ability.READ);

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/Shareable.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/Shareable.java
@@ -7,7 +7,7 @@ import java.util.stream.Collectors;
 
 import com.bakdata.conquery.apiv1.MetaDataPatch;
 import com.bakdata.conquery.apiv1.MetaDataPatch.PermissionCreator;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.AuthorizationHelper;
 import com.bakdata.conquery.models.auth.entities.Group;
 import com.bakdata.conquery.models.auth.entities.PermissionOwner;
@@ -36,7 +36,7 @@ public interface  Shareable {
 	
 	
 	default  <ID extends IId<?>,S extends Identifiable<? extends ID> & Shareable> Consumer<ShareInformation> sharer(
-		MasterMetaStorage storage,
+		MetaStorage storage,
 		User user,
 		PermissionCreator<ID> sharedPermissionCreator) {
 		if(!(this instanceof Identifiable<?>)) {
@@ -73,7 +73,7 @@ public interface  Shareable {
 	 * Does persist this change made to the {@link Shareable}. 
 	 */
 	public static <ID extends IId<?>, S extends Identifiable<? extends ID> & Shareable, O extends PermissionOwner<? extends IId<O>>> void shareWithOther(
-		@NonNull MasterMetaStorage storage,
+		@NonNull MetaStorage storage,
 		@NonNull User user,
 		@NonNull S shareable,
 		@NonNull PermissionCreator<ID> sharedPermissionCreator,

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/configs/FormConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/configs/FormConfig.java
@@ -10,7 +10,7 @@ import java.util.function.Consumer;
 import javax.validation.constraints.NotNull;
 
 import com.bakdata.conquery.apiv1.FormConfigPatch;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.execution.Labelable;
 import com.bakdata.conquery.models.execution.Shareable;
@@ -78,7 +78,7 @@ public class FormConfig extends IdentifiableImpl<FormConfigId> implements Sharea
 	 * Provides an overview (meta data) of this form configuration without the
 	 * actual form field values.
 	 */
-	public FormConfigOverviewRepresentation overview(MasterMetaStorage storage, User user) {
+	public FormConfigOverviewRepresentation overview(MetaStorage storage, User user) {
 		String ownerName = Optional.ofNullable(storage.getUser(owner)).map(User::getLabel).orElse(null);
 
 		return FormConfigOverviewRepresentation.builder()
@@ -138,7 +138,7 @@ public class FormConfig extends IdentifiableImpl<FormConfigId> implements Sharea
 	/**
 	 * Return the full representation of the configuration with the configured form fields and meta data.
 	 */
-	public FormConfigFullRepresentation fullRepresentation(MasterMetaStorage storage, User requestingUser){
+	public FormConfigFullRepresentation fullRepresentation(MetaStorage storage, User requestingUser){
 		String ownerName = Optional.ofNullable(storage.getUser(owner)).map(User::getLabel).orElse(null);
 		return FormConfigFullRepresentation.builder()
 			.id(getId()).formType(formType)

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/export/AbsExportGenerator.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/export/AbsExportGenerator.java
@@ -15,14 +15,14 @@ import com.bakdata.conquery.models.query.IQuery;
 import com.bakdata.conquery.models.query.concept.ArrayConceptQuery;
 import com.bakdata.conquery.models.query.concept.CQElement;
 import com.bakdata.conquery.models.query.concept.ConceptQuery;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public class AbsExportGenerator {
 	
 
-	public static AbsoluteFormQuery generate(Namespaces namespaces, AbsoluteMode mode, UserId userId, DatasetId submittedDataset) {
+	public static AbsoluteFormQuery generate(DatasetRegistry namespaces, AbsoluteMode mode, UserId userId, DatasetId submittedDataset) {
 		
 		List<DateContextMode> resolutions = null;
 		if(mode.getForm().isAlsoCreateCoarserSubdivisions()) {
@@ -37,7 +37,7 @@ public class AbsExportGenerator {
 		return generate(namespaces, resolutions, userId, submittedDataset, mode.getFeatures(), mode.getForm().getPrerequisite(), mode.getDateRange());
 	}
 	
-	public static AbsoluteFormQuery generate(Namespaces namespaces, List<DateContextMode> resolutions, UserId userId, DatasetId submittedDataset, List<CQElement> features, IQuery queryGroup, Range<LocalDate> dateRange) {
+	public static AbsoluteFormQuery generate(DatasetRegistry namespaces, List<DateContextMode> resolutions, UserId userId, DatasetId submittedDataset, List<CQElement> features, IQuery queryGroup, Range<LocalDate> dateRange) {
 		
 		// Apply defaults to user concept
 		ConceptManipulator.DEFAULT_SELECTS_WHEN_EMPTY.consume(features, namespaces);

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/export/RelExportGenerator.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/export/RelExportGenerator.java
@@ -16,14 +16,14 @@ import com.bakdata.conquery.models.query.concept.CQElement;
 import com.bakdata.conquery.models.query.concept.ConceptQuery;
 import com.bakdata.conquery.models.query.concept.specific.ResultInfoDecorator;
 import com.bakdata.conquery.models.query.concept.specific.temporal.TemporalSampler;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.google.common.collect.ImmutableClassToInstanceMap;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public class RelExportGenerator {
 	
-	public static RelativeFormQuery generate(Namespaces namespaces, RelativeMode mode, UserId userId, DatasetId submittedDataset) {
+	public static RelativeFormQuery generate(DatasetRegistry namespaces, RelativeMode mode, UserId userId, DatasetId submittedDataset) {
 		
 		List<DateContextMode> resolutions = null;
 		if(mode.getForm().isAlsoCreateCoarserSubdivisions()) {
@@ -39,7 +39,7 @@ public class RelExportGenerator {
 		return generate(mode.getForm().getPrerequisite(), mode.getFeatures(), mode.getOutcomes(), mode.getIndexSelector(), mode.getIndexPlacement(), mode.getTimeCountBefore(), mode.getTimeCountAfter(), mode.getTimeUnit(), resolutions, namespaces);
 	}
 	
-	public static RelativeFormQuery generate(IQuery query, List<CQElement> features, List<CQElement> outcomes, TemporalSampler indexSelector, IndexPlacement indexPlacement, int timeCountBefore, int timeCountAfter, DateContextMode timeUnit, List<DateContextMode> resolutions, Namespaces namespaces) {
+	public static RelativeFormQuery generate(IQuery query, List<CQElement> features, List<CQElement> outcomes, TemporalSampler indexSelector, IndexPlacement indexPlacement, int timeCountBefore, int timeCountAfter, DateContextMode timeUnit, List<DateContextMode> resolutions, DatasetRegistry namespaces) {
 		ConceptManipulator.DEFAULT_SELECTS_WHEN_EMPTY.consume(features, namespaces);
 		ConceptManipulator.DEFAULT_SELECTS_WHEN_EMPTY.consume(outcomes, namespaces);
 

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/frontendconfiguration/FormConfigProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/frontendconfiguration/FormConfigProcessor.java
@@ -92,7 +92,7 @@ public class FormConfigProcessor {
 	public FormConfigId addConfig(User user, DatasetId targetDataset, FormConfigAPI config) {
 		user.checkPermission(DatasetPermission.onInstance(Ability.READ.asSet(), targetDataset));
 
-		List<DatasetId> translateToDatasets = storage.getNamespaces().getAllDatasets().stream()
+		List<DatasetId> translateToDatasets = storage.getDatasetRegistry().getAllDatasets().stream()
 			.map(Identifiable::getId)
 			.filter(dId -> user.isPermitted(DatasetPermission.onInstance(Ability.READ.asSet(), dId)))
 			.collect(Collectors.toList());

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/frontendconfiguration/FormConfigProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/frontendconfiguration/FormConfigProcessor.java
@@ -15,7 +15,7 @@ import javax.validation.Validator;
 import com.bakdata.conquery.apiv1.FormConfigPatch;
 import com.bakdata.conquery.apiv1.forms.FormConfigAPI;
 import com.bakdata.conquery.io.jackson.Jackson;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.auth.permissions.Ability;
 import com.bakdata.conquery.models.auth.permissions.AbilitySets;
@@ -52,7 +52,7 @@ import org.jetbrains.annotations.TestOnly;
 public class FormConfigProcessor {
 	
 	private final Validator validator;
-	private final MasterMetaStorage storage;
+	private final MetaStorage storage;
 	@Getter(onMethod = @__({@TestOnly}))
 	private final static ObjectMapper MAPPER = Jackson.MAPPER.copy().disable(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS, SerializationFeature.WRITE_NULL_MAP_VALUES);;
 	

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
@@ -33,8 +33,8 @@ import com.bakdata.conquery.models.query.PrintSettings;
 import com.bakdata.conquery.models.query.QueryPlanContext;
 import com.bakdata.conquery.models.query.queryplan.QueryPlan;
 import com.bakdata.conquery.models.query.results.ShardResult;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.models.worker.Namespace;
-import com.bakdata.conquery.models.worker.Namespaces;
 import com.bakdata.conquery.resources.ResourceConstants;
 import com.bakdata.conquery.resources.api.ResultCSVResource;
 import com.bakdata.conquery.util.QueryUtils.NamespacedIdCollector;
@@ -86,11 +86,11 @@ public class ManagedForm extends ManagedExecution<FormSharedResult> {
 
 
 	@Override
-	public void initExecutable(@NonNull Namespaces namespaces) {
+	public void initExecutable(@NonNull DatasetRegistry datasets) {
 		// init all subqueries
 		synchronized (getExecution()) {
-			subQueries = submittedForm.createSubQueries(namespaces, super.getOwner(), super.getDataset());
-			subQueries.values().stream().flatMap(List::stream).forEach(mq -> mq.initExecutable(namespaces));
+			subQueries = submittedForm.createSubQueries(datasets, super.getOwner(), super.getDataset());
+			subQueries.values().stream().flatMap(List::stream).forEach(mq -> mq.initExecutable(datasets));
 		}
 	}
 	
@@ -194,9 +194,9 @@ public class ManagedForm extends ManagedExecution<FormSharedResult> {
 	}
 
 	@Override
-	public Set<Namespace> getRequiredNamespaces() {
+	public Set<Namespace> getRequiredDatasets() {
 		return flatSubQueries.values().stream()
-			.map(ManagedQuery::getRequiredNamespaces)
+			.map(ManagedQuery::getRequiredDatasets)
 			.flatMap(Set::stream)
 			.collect(Collectors.toSet());
 	}
@@ -223,7 +223,7 @@ public class ManagedForm extends ManagedExecution<FormSharedResult> {
 		// Set the ColumnDescription if the Form only consits of a single subquery
 		if(subQueries == null) {
 			// If subqueries was not set the Execution was not initialized
-			this.initExecutable(storage.getNamespaces());
+			this.initExecutable(storage.getDatasetRegistry());
 		}
 		if(subQueries.size() != 1) {
 			// The sub-query size might also be zero if the backend just delegates the form further to another backend. Forms with more subqueries are not yet supported

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
@@ -16,7 +16,7 @@ import com.bakdata.conquery.apiv1.URLBuilder;
 import com.bakdata.conquery.apiv1.forms.Form;
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.io.jackson.InternalOnly;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.execution.ExecutionState;
 import com.bakdata.conquery.models.execution.ExecutionStatus;
@@ -132,7 +132,7 @@ public class ManagedForm extends ManagedExecution<FormSharedResult> {
 	 * Distribute the result to a sub query.
 	 */
 	@Override
-	public void addResult(@NonNull MasterMetaStorage storage, FormSharedResult result) {
+	public void addResult(@NonNull MetaStorage storage, FormSharedResult result) {
 		ManagedExecutionId subquery = result.getSubqueryId();
 		if(result.getError().isPresent()) {
 			fail(storage, result.getError().get());
@@ -218,7 +218,7 @@ public class ManagedForm extends ManagedExecution<FormSharedResult> {
 	}
 	
 	@Override
-	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MasterMetaStorage storage, URLBuilder url, User user, ExecutionStatus status) {
+	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MetaStorage storage, URLBuilder url, User user, ExecutionStatus status) {
 		super.setAdditionalFieldsForStatusWithColumnDescription(storage, url, user, status);
 		// Set the ColumnDescription if the Form only consits of a single subquery
 		if(subQueries == null) {

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/util/ConceptManipulator.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/util/ConceptManipulator.java
@@ -7,15 +7,15 @@ import com.bakdata.conquery.models.query.Visitable;
 import com.bakdata.conquery.models.query.concept.CQElement;
 import com.bakdata.conquery.models.query.concept.specific.CQConcept;
 import com.bakdata.conquery.models.query.visitor.QueryVisitor;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 
 public interface ConceptManipulator {
 	// Often used manipulators, that can be statically instantiated
 	public final static ConceptManipulator DEFAULT_SELECTS_WHEN_EMPTY = new DefaultSelectConceptManipulator(FillMethod.ADD_TO_COMPLETE_EMPTY);
 	
-	void consume(CQConcept concept, Namespaces namespaces);
+	void consume(CQConcept concept, DatasetRegistry namespaces);
 	
-	default void consume(List<? extends CQElement> userFeatures, Namespaces namespaces) {
+	default void consume(List<? extends CQElement> userFeatures, DatasetRegistry namespaces) {
 		for(CQElement feature : userFeatures) {
 			feature.visit(new QueryVisitor() {
 				

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/util/DefaultSelectConceptManipulator.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/util/DefaultSelectConceptManipulator.java
@@ -12,7 +12,7 @@ import com.bakdata.conquery.models.concepts.select.Select;
 import com.bakdata.conquery.models.identifiable.ids.specific.ConceptElementId;
 import com.bakdata.conquery.models.query.concept.filter.CQTable;
 import com.bakdata.conquery.models.query.concept.specific.CQConcept;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
@@ -31,7 +31,7 @@ public class DefaultSelectConceptManipulator implements ConceptManipulator {
 	private  FillMethod method = FillMethod.ADD_TO_COMPLETE_EMPTY;
 
 	@Override
-	public void consume(CQConcept concept, Namespaces namespaces) {
+	public void consume(CQConcept concept, DatasetRegistry namespaces) {
 		// Obtain the concept Id
 		List<ConceptElementId<?>> conceptIds = concept.getIds();
 		if(conceptIds.isEmpty()) {

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/util/FilteringConceptManipulator.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/util/FilteringConceptManipulator.java
@@ -12,7 +12,7 @@ import com.bakdata.conquery.models.identifiable.ids.specific.ConceptSelectId;
 import com.bakdata.conquery.models.identifiable.ids.specific.ConnectorId;
 import com.bakdata.conquery.models.query.concept.filter.CQTable;
 import com.bakdata.conquery.models.query.concept.specific.CQConcept;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -86,7 +86,7 @@ public class FilteringConceptManipulator implements ConceptManipulator{
 		}
 	}
 
-	public void consume(CQConcept concept, Namespaces namespaces) {
+	public void consume(CQConcept concept, DatasetRegistry namespaces) {
 
 		List<Select> selects = concept.getSelects();
 		if (!selectBlacklist.isEmpty()) {

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/util/FilteringConceptManipulator.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/util/FilteringConceptManipulator.java
@@ -19,12 +19,12 @@ import lombok.Setter;
 import lombok.ToString;
 
 /**
- * Manipulates a given Concept based on the provided blacklisting or
- * whitelisting for {@link ConceptSelectId} and {@link CQTable}s. After this
+ * Manipulates a given Concept based on the provided blocklisting or
+ * allowlisting for {@link ConceptSelectId} and {@link CQTable}s. After this
  * filtering, the defined default values are added if the corresponding list is
  * empty.
  *
- * For whitelisted tables a {@link TableManipulator} can be defined, that
+ * For allowlisted tables a {@link TableManipulator} can be defined, that
  * applies the filtering on specific tables.
  */
 @Getter
@@ -34,66 +34,66 @@ import lombok.ToString;
 public class FilteringConceptManipulator implements ConceptManipulator{
 
 	@Builder.Default
-	private List<ConceptSelectId> selectBlacklist = Collections.emptyList();
+	private List<ConceptSelectId> selectBlockList = Collections.emptyList();
 	@Builder.Default
-	private List<ConceptSelectId> selectWhitelist = Collections.emptyList();
+	private List<ConceptSelectId> selectAllowList = Collections.emptyList();
 	@Builder.Default
 	private List<ConceptSelectId> selectDefault = Collections.emptyList();
 
 	@Builder.Default
-	private List<ConnectorId> tableBlacklist = Collections.emptyList();
+	private List<ConnectorId> tableBlockList = Collections.emptyList();
 	@Builder.Default
-	private Map<ConnectorId, TableManipulator> tableWhitelist = Collections.emptyMap();
+	private Map<ConnectorId, TableManipulator> tableAllowList = Collections.emptyMap();
 	@Builder.Default
 	private List<CQTable> tableDefault = Collections.emptyList();
 
 	private void init() {
 
-		if (!selectBlacklist.isEmpty() && !selectWhitelist.isEmpty()) {
-			throw new IllegalArgumentException("Either select blacklist or whitelist needs to be empty.");
+		if (!selectBlockList.isEmpty() && !selectAllowList.isEmpty()) {
+			throw new IllegalArgumentException("Either select blocklist or allowlist needs to be empty.");
 		}
 
-		Set<ConceptSelectId> blackDefaultSelectIntersection = selectBlacklist
+		Set<ConceptSelectId> blockDefaultSelectIntersection = selectBlockList
 			.stream()
 			.distinct()
 			.filter(selectDefault::contains)
 			.collect(Collectors.toSet());
-		if (!blackDefaultSelectIntersection.isEmpty()) {
+		if (!blockDefaultSelectIntersection.isEmpty()) {
 			throw new IllegalArgumentException(
 				String
 					.format(
-						"The list of default selects intersects with the blacklist. Intersecting Elements:\t",
-						blackDefaultSelectIntersection.toString()));
+						"The list of default selects intersects with the blocklist. Intersecting Elements:\t",
+						blockDefaultSelectIntersection.toString()));
 		}
 
 		// Check tables
-		if (!tableBlacklist.isEmpty() && !tableWhitelist.isEmpty()) {
-			throw new IllegalArgumentException("Either table blacklist or whitelist needs to be empty.");
+		if (!tableBlockList.isEmpty() && !tableAllowList.isEmpty()) {
+			throw new IllegalArgumentException("Either table blocklist or allowlist needs to be empty.");
 		}
 
-		Set<ConnectorId> blackDefaultTableIntersection = tableDefault
+		Set<ConnectorId> blockDefaultTableIntersection = tableDefault
 			.stream()
 			.map(CQTable::getId)
 			.distinct()
-			.filter(tableBlacklist::contains)
+			.filter(tableBlockList::contains)
 			.collect(Collectors.toSet());
-		if (!blackDefaultTableIntersection.isEmpty()) {
+		if (!blockDefaultTableIntersection.isEmpty()) {
 			throw new IllegalArgumentException(
 				String
 					.format(
-						"The list of default tables intersects with the blacklist. Intersecting Elements:\t",
-						blackDefaultTableIntersection.toString()));
+						"The list of default tables intersects with the blocklist. Intersecting Elements:\t",
+						blockDefaultTableIntersection.toString()));
 		}
 	}
 
 	public void consume(CQConcept concept, DatasetRegistry namespaces) {
 
 		List<Select> selects = concept.getSelects();
-		if (!selectBlacklist.isEmpty()) {
-			selects.removeIf(s -> selectBlacklist.contains(s.getId()));
+		if (!selectBlockList.isEmpty()) {
+			selects.removeIf(s -> selectBlockList.contains(s.getId()));
 		}
-		else if (!selectWhitelist.isEmpty()) {
-			selects.removeIf(s -> !selectWhitelist.contains(s.getId()));
+		else if (!selectAllowList.isEmpty()) {
+			selects.removeIf(s -> !selectAllowList.contains(s.getId()));
 		}
 
 		// Add default selects if none is present anymore
@@ -106,15 +106,15 @@ public class FilteringConceptManipulator implements ConceptManipulator{
 		Iterator<CQTable> it = tables.iterator();
 		while(it.hasNext()) {
 			CQTable table = it.next();
-			if (tableBlacklist.contains(table.getId())) {
+			if (tableBlockList.contains(table.getId())) {
 				it.remove();
 			}
-			if (!tableWhitelist.containsKey(table.getId())) {
+			if (!tableAllowList.containsKey(table.getId())) {
 				it.remove();
 			}
 			else {
-				// If table is whitelisted apply a table manipulator if one exist
-				TableManipulator tableMan = tableWhitelist.get(table.getId());
+				// If table is allowlisted apply a table manipulator if one exist
+				TableManipulator tableMan = tableAllowList.get(table.getId());
 				if (tableMan != null) {
 					tableMan.consume(table, namespaces);
 				}

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/util/FixedQueriesLoadingUtil.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/util/FixedQueriesLoadingUtil.java
@@ -11,7 +11,7 @@ import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.query.concept.CQElement;
 import com.bakdata.conquery.models.query.concept.ConceptQuery;
 import com.bakdata.conquery.models.query.concept.filter.FilterValue;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.github.powerlibraries.io.In;
 import lombok.experimental.UtilityClass;
@@ -41,7 +41,7 @@ public class FixedQueriesLoadingUtil {
 	/**
 	 * Parses the query template with the supplied dataset.
 	 */
-	public static List<ConceptQuery> parseQueriesWithDataset(String queryString, DatasetId datasetId, Namespaces namespaces) {
+	public static List<ConceptQuery> parseQueriesWithDataset(String queryString, DatasetId datasetId, DatasetRegistry namespaces) {
 		queryString = queryString.replace("${dataset}", datasetId.toString());
 		ObjectReader reader = namespaces.injectInto(Jackson.MAPPER.copy().readerFor(ConceptQuery[].class));
 		try {
@@ -55,7 +55,7 @@ public class FixedQueriesLoadingUtil {
 	/**
 	 * Parses the query template with the supplied dataset.
 	 */
-	public static List<CQElement> parseFeaturesWithDataset(String featureString, DatasetId datasetId, Namespaces namespaces) {
+	public static List<CQElement> parseFeaturesWithDataset(String featureString, DatasetId datasetId, DatasetRegistry namespaces) {
 		featureString = featureString.replace("${dataset}", datasetId.toString());
 		ObjectReader reader = namespaces.injectInto(Jackson.MAPPER.copy().readerFor(CQElement[].class));
 		try {
@@ -69,7 +69,7 @@ public class FixedQueriesLoadingUtil {
 	/**
 	 * Parses the query template with the supplied dataset.
 	 */
-	public static List<FilterValue<?>> parseFiltersWithDataset(String featureString, DatasetId datasetId, Namespaces namespaces) {
+	public static List<FilterValue<?>> parseFiltersWithDataset(String featureString, DatasetId datasetId, DatasetRegistry namespaces) {
 		featureString = featureString.replace("${dataset}", datasetId.toString());
 		ObjectReader reader = namespaces.injectInto(Jackson.MAPPER.copy().readerFor(FilterValue[].class));
 		try {

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/util/TableManipulator.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/util/TableManipulator.java
@@ -14,7 +14,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 /**
- * Manipulates a given Table based on the provided blacklisting or whitelisting
+ * Manipulates a given Table based on the provided blocklisting or allowlisting
  * for {@link ConnectorSelectId}s. After this filtering, the defined default
  * values are added if the corresponding list is empty.
  */
@@ -24,29 +24,29 @@ import lombok.Setter;
 public class TableManipulator {
 
 	@Builder.Default
-	private List<ConnectorSelectId> selectBlacklist = Collections.emptyList();
+	private List<ConnectorSelectId> selectBlockList = Collections.emptyList();
 	@Builder.Default
-	private List<ConnectorSelectId> selectWhitelist = Collections.emptyList();
+	private List<ConnectorSelectId> selectAllowList = Collections.emptyList();
 	@Builder.Default
 	private List<ConnectorSelectId> selectDefault = Collections.emptyList();
 
 	private void init() {
 
-		if (!selectBlacklist.isEmpty() && !selectWhitelist.isEmpty()) {
-			throw new IllegalArgumentException("Either blacklist or whitelist needs to be empty.");
+		if (!selectBlockList.isEmpty() && !selectAllowList.isEmpty()) {
+			throw new IllegalArgumentException("Either blacklist or allowlist needs to be empty.");
 		}
 
-		Set<ConnectorSelectId> blackDefaultIntersection = selectBlacklist
+		Set<ConnectorSelectId> blockDefaultIntersection = selectBlockList
 			.stream()
 			.distinct()
 			.filter(selectDefault::contains)
 			.collect(Collectors.toSet());
-		if (!blackDefaultIntersection.isEmpty()) {
+		if (!blockDefaultIntersection.isEmpty()) {
 			throw new IllegalArgumentException(
 				String
 					.format(
-						"The list of default selects intersects with the blacklist. Intersecting Elements:\t",
-						blackDefaultIntersection.toString()));
+						"The list of default selects intersects with the blocklist. Intersecting Elements:\t",
+						blockDefaultIntersection.toString()));
 		}
 
 	}
@@ -54,11 +54,11 @@ public class TableManipulator {
 	public void consume(CQTable table, DatasetRegistry namespaces) {
 
 		List<Select> selects = table.getSelects();
-		if (!selectBlacklist.isEmpty()) {
-			selects.removeIf(s -> selectBlacklist.contains(s.getId()));
+		if (!selectBlockList.isEmpty()) {
+			selects.removeIf(s -> selectBlockList.contains(s.getId()));
 		}
-		else if (!selectWhitelist.isEmpty()) {
-			selects.removeIf(s -> !selectWhitelist.contains(s.getId()));
+		else if (!selectAllowList.isEmpty()) {
+			selects.removeIf(s -> !selectAllowList.contains(s.getId()));
 		}
 
 		// Add default selects if none is present anymore

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/util/TableManipulator.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/util/TableManipulator.java
@@ -8,7 +8,7 @@ import java.util.stream.Collectors;
 import com.bakdata.conquery.models.concepts.select.Select;
 import com.bakdata.conquery.models.identifiable.ids.specific.ConnectorSelectId;
 import com.bakdata.conquery.models.query.concept.filter.CQTable;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -51,7 +51,7 @@ public class TableManipulator {
 
 	}
 
-	public void consume(CQTable table, Namespaces namespaces) {
+	public void consume(CQTable table, DatasetRegistry namespaces) {
 
 		List<Select> selects = table.getSelects();
 		if (!selectBlacklist.isEmpty()) {

--- a/backend/src/main/java/com/bakdata/conquery/models/identifiable/CentralRegistry.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/identifiable/CentralRegistry.java
@@ -10,7 +10,7 @@ import com.bakdata.conquery.io.jackson.MutableInjectableValues;
 import com.bakdata.conquery.models.error.ConqueryError.ExecutionCreationResolveError;
 import com.bakdata.conquery.models.identifiable.ids.IId;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
-import com.bakdata.conquery.models.worker.NamespaceCollection;
+import com.bakdata.conquery.models.worker.IdResolveContext;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import lombok.NoArgsConstructor;
@@ -70,7 +70,7 @@ public class CentralRegistry implements Injectable {
 	public static CentralRegistry get(DeserializationContext ctxt) throws JsonMappingException {
 		CentralRegistry result = (CentralRegistry) ctxt.findInjectableValue(CentralRegistry.class.getName(), null, null);
 		if(result == null) {
-			NamespaceCollection alternative = (NamespaceCollection)ctxt.findInjectableValue(NamespaceCollection.class.getName(), null, null);
+			IdResolveContext alternative = (IdResolveContext)ctxt.findInjectableValue(IdResolveContext.class.getName(), null, null);
 			if(alternative == null) {
 				return null;
 			}
@@ -84,7 +84,7 @@ public class CentralRegistry implements Injectable {
 	}
 
 	public static CentralRegistry getForDataset(DeserializationContext ctxt, DatasetId datasetId) throws JsonMappingException {
-		NamespaceCollection alternative = (NamespaceCollection)ctxt.findInjectableValue(NamespaceCollection.class.getName(), null, null);
+		IdResolveContext alternative = (IdResolveContext)ctxt.findInjectableValue(IdResolveContext.class.getName(), null, null);
 
 		if(alternative == null)
 			return null;

--- a/backend/src/main/java/com/bakdata/conquery/models/identifiable/ids/specific/GroupId.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/identifiable/ids/specific/GroupId.java
@@ -2,7 +2,7 @@ package com.bakdata.conquery.models.identifiable.ids.specific;
 
 import java.util.List;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.Group;
 import com.bakdata.conquery.models.identifiable.ids.IId;
 import com.bakdata.conquery.models.identifiable.ids.IdIterator;
@@ -38,7 +38,7 @@ public class GroupId extends PermissionOwnerId<Group> {
 	}
 
 	@Override
-	public Group getPermissionOwner(MasterMetaStorage storage) {
+	public Group getPermissionOwner(MetaStorage storage) {
 		return storage.getGroup(this);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/identifiable/ids/specific/PermissionOwnerId.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/identifiable/ids/specific/PermissionOwnerId.java
@@ -2,7 +2,7 @@ package com.bakdata.conquery.models.identifiable.ids.specific;
 
 import java.util.List;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.PermissionOwner;
 import com.bakdata.conquery.models.identifiable.ids.AId;
 import com.bakdata.conquery.models.identifiable.ids.IId;
@@ -38,5 +38,5 @@ public abstract class PermissionOwnerId<T extends PermissionOwner<?>> extends AI
 		}
 	}
 	
-	public abstract T getPermissionOwner(MasterMetaStorage storage);
+	public abstract T getPermissionOwner(MetaStorage storage);
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/identifiable/ids/specific/RoleId.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/identifiable/ids/specific/RoleId.java
@@ -2,7 +2,7 @@ package com.bakdata.conquery.models.identifiable.ids.specific;
 
 import java.util.List;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.Role;
 import com.bakdata.conquery.models.identifiable.ids.IId;
 import com.bakdata.conquery.models.identifiable.ids.IdIterator;
@@ -37,7 +37,7 @@ public class RoleId extends PermissionOwnerId<Role> {
 	}
 
 	@Override
-	public Role getPermissionOwner(MasterMetaStorage storage) {
+	public Role getPermissionOwner(MetaStorage storage) {
 		return storage.getRole(this);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/identifiable/ids/specific/UserId.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/identifiable/ids/specific/UserId.java
@@ -2,7 +2,7 @@ package com.bakdata.conquery.models.identifiable.ids.specific;
 
 import java.util.List;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.identifiable.ids.IId;
 import com.bakdata.conquery.models.identifiable.ids.IdIterator;
@@ -38,7 +38,7 @@ public class UserId extends PermissionOwnerId<User> {
 	}
 
 	@Override
-	public User getPermissionOwner(MasterMetaStorage storage) {
+	public User getPermissionOwner(MetaStorage storage) {
 		return storage.getUser(this);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/jobs/ImportJob.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/jobs/ImportJob.java
@@ -268,7 +268,7 @@ public class ImportJob extends Job {
 				mappingRequired |= createSharedDictionary(col, tableCol);
 			}
 
-			//store external infos into master and slaves
+			//store external infos into ManagerNode and slaves
 			col.getType().storeExternalInfos(
 					namespace.getStorage(),
 					(Consumer<Dictionary>) (dict -> {

--- a/backend/src/main/java/com/bakdata/conquery/models/jobs/ImportJob.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/jobs/ImportJob.java
@@ -86,7 +86,7 @@ public class ImportJob extends Job {
 
 			DictionaryMapping primaryMapping = header.getPrimaryColumn().getValueMapping();
 
-			// Distribute the new IDs between the slaves
+			// Distribute the new IDs between the ShardNodes
 			log.debug("\tpartition new IDs");
 
 			// Allocate a responsibility for all yet unassigned buckets.
@@ -212,7 +212,7 @@ public class ImportJob extends Job {
 				throw new IllegalStateException("No responsible worker for bucket " + bucketNumber);
 			}
 			try {
-				responsibleWorker.getConnectedSlave().waitForFreeJobqueue();
+				responsibleWorker.getConnectedShardNode().waitForFreeJobqueue();
 			}
 			catch (InterruptedException e) {
 				log.error("Interrupted while waiting for worker " + responsibleWorker + " to have free space in queue", e);
@@ -268,7 +268,7 @@ public class ImportJob extends Job {
 				mappingRequired |= createSharedDictionary(col, tableCol);
 			}
 
-			//store external infos into ManagerNode and slaves
+			//store external infos into ManagerNode and ShardNodes
 			col.getType().storeExternalInfos(
 					namespace.getStorage(),
 					(Consumer<Dictionary>) (dict -> {

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/namespaces/specific/CollectQueryResult.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/namespaces/specific/CollectQueryResult.java
@@ -12,7 +12,7 @@ import lombok.Setter;
 import lombok.ToString;
 
 /**
- * Workers send their part of the query result to master for assembly.
+ * Workers send their part of the query result to ManagerNode for assembly.
  */
 @CPSType(id="COLLECT_QUERY_RESULT", base=NamespacedMessage.class)
 @AllArgsConstructor @NoArgsConstructor @Getter @Setter @ToString(of = "result")

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/namespaces/specific/ExecuteQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/namespaces/specific/ExecuteQuery.java
@@ -48,7 +48,7 @@ public class ExecuteQuery extends WorkerMessage {
 			ConqueryError err = asConqueryError(e);
 			log.warn("Failed to create query plans for {}.", execution.getId(), err );
 			ShardResult result = execution.getInitializedShardResult(null);
-			sendFailureToMaster(result, context, err);
+			sendFailureToManagerNode(result, context, err);
 			return;
 		}
 		
@@ -62,13 +62,13 @@ public class ExecuteQuery extends WorkerMessage {
 			} catch(Exception e) {
 				ConqueryError err = asConqueryError(e);
 				log.warn("Error while executing {} (with subquery: {})", execution.getId(), entry.getKey(), err );
-				sendFailureToMaster(result, context,  asConqueryError(err));
+				sendFailureToManagerNode(result, context,  asConqueryError(err));
 				return;
 			}
 		}
 	}
 
-	private static void sendFailureToMaster(ShardResult result,Worker context, ConqueryError error) {
+	private static void sendFailureToManagerNode(ShardResult result,Worker context, ConqueryError error) {
 		result.setError(Optional.of(error));
 		result.finish();
 		context.send(new CollectQueryResult(result));

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/namespaces/specific/UpdateWorkerBucket.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/namespaces/specific/UpdateWorkerBucket.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-@CPSType(id="UPDATE_SLAVE_IDENTITY", base=NamespacedMessage.class) @Slf4j
+@CPSType(id="UPDATE_SHARD_WORKER_IDENTITY", base=NamespacedMessage.class) @Slf4j
 @RequiredArgsConstructor(onConstructor_=@JsonCreator) @Getter
 public class UpdateWorkerBucket extends WorkerMessage {
 

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/namespaces/specific/UpdateWorkerBucket.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/namespaces/specific/UpdateWorkerBucket.java
@@ -6,7 +6,6 @@ import com.bakdata.conquery.models.messages.namespaces.WorkerMessage;
 import com.bakdata.conquery.models.worker.Worker;
 import com.bakdata.conquery.models.worker.WorkerInformation;
 import com.fasterxml.jackson.annotation.JsonCreator;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,7 +19,6 @@ public class UpdateWorkerBucket extends WorkerMessage {
 	@Override
 	public void react(Worker context) throws Exception {
 		//new included buckets from master
-		context.getInfo().setIncludedBuckets(info.getIncludedBuckets());
 		context.getStorage().updateWorker(info);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/MessageToManagerNode.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/MessageToManagerNode.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.Setter;
 
-public abstract class MessageToManagerNode extends NetworkMessage<NetworkMessageContext.ManagerNodeRxTxContext> {
+public abstract class MessageToManagerNode extends NetworkMessage<NetworkMessageContext.ManagerNodeNetworkContext> {
 
 	public static abstract class Slow extends MessageToManagerNode implements SlowMessage {
 		@JsonIgnore @Getter @Setter

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/MessageToManagerNode.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/MessageToManagerNode.java
@@ -7,9 +7,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.Setter;
 
-public abstract class MasterMessage extends NetworkMessage<NetworkMessageContext.Master> {
+public abstract class MessageToManagerNode extends NetworkMessage<NetworkMessageContext.ManagerNodeRxTxContext> {
 
-	public static abstract class Slow extends MasterMessage implements SlowMessage {
+	public static abstract class Slow extends MessageToManagerNode implements SlowMessage {
 		@JsonIgnore @Getter @Setter
 		private ProgressReporter progressReporter;
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/MessageToShardNode.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/MessageToShardNode.java
@@ -7,9 +7,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.Setter;
 
-public abstract class SlaveMessage extends NetworkMessage<NetworkMessageContext.Slave> {
+public abstract class MessageToShardNode extends NetworkMessage<NetworkMessageContext.ShardNodeNetworkContext> {
 
-	public static abstract class Slow extends SlaveMessage implements SlowMessage {
+	public static abstract class Slow extends MessageToShardNode implements SlowMessage {
 		@JsonIgnore @Getter @Setter
 		private ProgressReporter progressReporter;
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/NetworkMessageContext.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/NetworkMessageContext.java
@@ -25,7 +25,7 @@ public abstract class NetworkMessageContext<MESSAGE extends NetworkMessage<?>> e
 	}
 
 	@Getter
-	public static class Slave extends NetworkMessageContext<MasterMessage> {
+	public static class Slave extends NetworkMessageContext<MessageToManagerNode> {
 		
 		private final Workers workers;
 		private final ConqueryConfig config;
@@ -42,11 +42,11 @@ public abstract class NetworkMessageContext<MESSAGE extends NetworkMessage<?>> e
 	}
 	
 	@Getter
-	public static class Master extends NetworkMessageContext<SlaveMessage> {
+	public static class ManagerNodeRxTxContext extends NetworkMessageContext<SlaveMessage> {
 
 		private final Namespaces namespaces;
 		
-		public Master(JobManager jobManager, NetworkSession session, Namespaces namespaces) {
+		public ManagerNodeRxTxContext(JobManager jobManager, NetworkSession session, Namespaces namespaces) {
 			super(jobManager, session);
 			this.namespaces = namespaces;
 		}

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/NetworkMessageContext.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/NetworkMessageContext.java
@@ -8,7 +8,7 @@ import com.bakdata.conquery.io.mina.MessageSender;
 import com.bakdata.conquery.io.mina.NetworkSession;
 import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.jobs.JobManager;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.models.worker.Workers;
 import lombok.Getter;
 
@@ -51,9 +51,9 @@ public abstract class NetworkMessageContext<MESSAGE extends NetworkMessage<?>> e
 	@Getter
 	public static class ManagerNodeNetworkContext extends NetworkMessageContext<MessageToShardNode> {
 
-		private final Namespaces namespaces;
+		private final DatasetRegistry namespaces;
 		
-		public ManagerNodeNetworkContext(JobManager jobManager, NetworkSession session, Namespaces namespaces) {
+		public ManagerNodeNetworkContext(JobManager jobManager, NetworkSession session, DatasetRegistry namespaces) {
 			super(jobManager, session);
 			this.namespaces = namespaces;
 		}

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/NetworkMessageContext.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/NetworkMessageContext.java
@@ -2,13 +2,14 @@ package com.bakdata.conquery.models.messages.network;
 
 import javax.validation.Validator;
 
+import com.bakdata.conquery.commands.ManagerNode;
+import com.bakdata.conquery.commands.ShardNode;
 import com.bakdata.conquery.io.mina.MessageSender;
 import com.bakdata.conquery.io.mina.NetworkSession;
 import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.jobs.JobManager;
 import com.bakdata.conquery.models.worker.Namespaces;
 import com.bakdata.conquery.models.worker.Workers;
-
 import lombok.Getter;
 
 public abstract class NetworkMessageContext<MESSAGE extends NetworkMessage<?>> extends MessageSender.Simple<MESSAGE> {
@@ -24,15 +25,18 @@ public abstract class NetworkMessageContext<MESSAGE extends NetworkMessage<?>> e
 		return session != null;
 	}
 
+	/**
+	 * Is used on a {@link ShardNode} for sending messages to the {@link ManagerNode} and is injected into messages from the {@link ManagerNode}.
+	 */
 	@Getter
-	public static class Slave extends NetworkMessageContext<MessageToManagerNode> {
+	public static class ShardNodeNetworkContext extends NetworkMessageContext<MessageToManagerNode> {
 		
 		private final Workers workers;
 		private final ConqueryConfig config;
 		private final Validator validator;
 		private NetworkSession rawSession;
 
-		public Slave(JobManager jobManager, NetworkSession session, Workers workers, ConqueryConfig config, Validator validator) {
+		public ShardNodeNetworkContext(JobManager jobManager, NetworkSession session, Workers workers, ConqueryConfig config, Validator validator) {
 			super(jobManager, session);
 			this.workers = workers;
 			this.config = config;
@@ -41,12 +45,15 @@ public abstract class NetworkMessageContext<MESSAGE extends NetworkMessage<?>> e
 		}
 	}
 	
+	/**
+	 * Is used on a {@link ManagerNode} for sending messages to a {@link ShardNode} and is injected into messages from the {@link ShardNode}.
+	 */
 	@Getter
-	public static class ManagerNodeRxTxContext extends NetworkMessageContext<SlaveMessage> {
+	public static class ManagerNodeNetworkContext extends NetworkMessageContext<MessageToShardNode> {
 
 		private final Namespaces namespaces;
 		
-		public ManagerNodeRxTxContext(JobManager jobManager, NetworkSession session, Namespaces namespaces) {
+		public ManagerNodeNetworkContext(JobManager jobManager, NetworkSession session, Namespaces namespaces) {
 			super(jobManager, session);
 			this.namespaces = namespaces;
 		}

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/AddShardNode.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/AddShardNode.java
@@ -5,7 +5,7 @@ import com.bakdata.conquery.io.mina.NetworkSession;
 import com.bakdata.conquery.models.messages.network.MessageToManagerNode;
 import com.bakdata.conquery.models.messages.network.NetworkMessage;
 import com.bakdata.conquery.models.messages.network.NetworkMessageContext;
-import com.bakdata.conquery.models.worker.SlaveInformation;
+import com.bakdata.conquery.models.worker.ShardNodeInformation;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -15,13 +15,13 @@ import lombok.extern.slf4j.Slf4j;
  * Dummy message that is sent to ManagerNode, to authenticate the connection as a ShardNode connection.
  * This helps to avoids retaining connections from non-ShardNodes.
  */
-@CPSType(id="ADD_SLAVE", base=NetworkMessage.class)
+@CPSType(id="ADD_SHARD_NODE", base=NetworkMessage.class)
 @RequiredArgsConstructor(onConstructor_=@JsonCreator) @Getter @Slf4j
-public class AddSlave extends MessageToManagerNode {
+public class AddShardNode extends MessageToManagerNode {
 
 	@Override
-	public void react(NetworkMessageContext.ManagerNodeRxTxContext context) throws Exception {
-		context.getNamespaces().getShardNodes().put(context.getRemoteAddress(), new SlaveInformation(new NetworkSession(context.getSession().getSession())));
+	public void react(NetworkMessageContext.ManagerNodeNetworkContext context) throws Exception {
+		context.getNamespaces().getShardNodes().put(context.getRemoteAddress(), new ShardNodeInformation(new NetworkSession(context.getSession().getSession())));
 
 		log.info("ShardNode {} registered.", context.getRemoteAddress());
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/AddSlave.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/AddSlave.java
@@ -12,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Dummy message that is sent to Master, to authenticate the connection as a Slave connection.
+ * Dummy message that is sent to ManagerNode, to authenticate the connection as a Slave connection.
  * This helps to avoids retaining connections from non-slaves.
  */
 @CPSType(id="ADD_SLAVE", base=NetworkMessage.class)

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/AddSlave.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/AddSlave.java
@@ -12,8 +12,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Dummy message that is sent to ManagerNode, to authenticate the connection as a Slave connection.
- * This helps to avoids retaining connections from non-slaves.
+ * Dummy message that is sent to ManagerNode, to authenticate the connection as a ShardNode connection.
+ * This helps to avoids retaining connections from non-ShardNodes.
  */
 @CPSType(id="ADD_SLAVE", base=NetworkMessage.class)
 @RequiredArgsConstructor(onConstructor_=@JsonCreator) @Getter @Slf4j
@@ -21,8 +21,8 @@ public class AddSlave extends MessageToManagerNode {
 
 	@Override
 	public void react(NetworkMessageContext.ManagerNodeRxTxContext context) throws Exception {
-		context.getNamespaces().getSlaves().put(context.getRemoteAddress(), new SlaveInformation(new NetworkSession(context.getSession().getSession())));
+		context.getNamespaces().getShardNodes().put(context.getRemoteAddress(), new SlaveInformation(new NetworkSession(context.getSession().getSession())));
 
-		log.info("Slave {} registered.", context.getRemoteAddress());
+		log.info("ShardNode {} registered.", context.getRemoteAddress());
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/AddSlave.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/AddSlave.java
@@ -2,7 +2,7 @@ package com.bakdata.conquery.models.messages.network.specific;
 
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.io.mina.NetworkSession;
-import com.bakdata.conquery.models.messages.network.MasterMessage;
+import com.bakdata.conquery.models.messages.network.MessageToManagerNode;
 import com.bakdata.conquery.models.messages.network.NetworkMessage;
 import com.bakdata.conquery.models.messages.network.NetworkMessageContext;
 import com.bakdata.conquery.models.worker.SlaveInformation;
@@ -17,10 +17,10 @@ import lombok.extern.slf4j.Slf4j;
  */
 @CPSType(id="ADD_SLAVE", base=NetworkMessage.class)
 @RequiredArgsConstructor(onConstructor_=@JsonCreator) @Getter @Slf4j
-public class AddSlave extends MasterMessage {
+public class AddSlave extends MessageToManagerNode {
 
 	@Override
-	public void react(NetworkMessageContext.Master context) throws Exception {
+	public void react(NetworkMessageContext.ManagerNodeRxTxContext context) throws Exception {
 		context.getNamespaces().getSlaves().put(context.getRemoteAddress(), new SlaveInformation(new NetworkSession(context.getSession().getSession())));
 
 		log.info("Slave {} registered.", context.getRemoteAddress());

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/AddWorker.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/AddWorker.java
@@ -7,8 +7,8 @@ import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.messages.network.NetworkMessage;
-import com.bakdata.conquery.models.messages.network.NetworkMessageContext.Slave;
-import com.bakdata.conquery.models.messages.network.SlaveMessage;
+import com.bakdata.conquery.models.messages.network.NetworkMessageContext.ShardNodeNetworkContext;
+import com.bakdata.conquery.models.messages.network.MessageToShardNode;
 import com.bakdata.conquery.models.worker.Worker;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
@@ -17,12 +17,12 @@ import lombok.extern.slf4j.Slf4j;
 
 @CPSType(id="ADD_WORKER", base=NetworkMessage.class)
 @RequiredArgsConstructor(onConstructor_=@JsonCreator) @Getter @Slf4j
-public class AddWorker extends SlaveMessage.Slow {
+public class AddWorker extends MessageToShardNode.Slow {
 
 	private final Dataset dataset;
 	
 	@Override
-	public void react(Slave context) throws Exception {
+	public void react(ShardNodeNetworkContext context) throws Exception {
 		log.info("creating a new worker for {}", dataset);
 		ConqueryConfig config = context.getConfig();
 
@@ -33,7 +33,7 @@ public class AddWorker extends SlaveMessage.Slow {
 		context.send(new RegisterWorker(worker.getInfo()));
 	}
 
-	private File createWorkerName(Slave context) {
+	private File createWorkerName(ShardNodeNetworkContext context) {
 		String name = "worker_"+dataset.getName()+"_"+UUID.randomUUID().toString();
 		return new File(context.getConfig().getStorage().getDirectory(), name);
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/CancelJobMessage.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/CancelJobMessage.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.models.messages.network.NetworkMessage;
 import com.bakdata.conquery.models.messages.network.NetworkMessageContext;
-import com.bakdata.conquery.models.messages.network.SlaveMessage;
+import com.bakdata.conquery.models.messages.network.MessageToShardNode;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import lombok.Getter;
@@ -13,13 +13,13 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(onConstructor_ = @JsonCreator)
 @CPSType(id="CANCEL_JOB", base= NetworkMessage.class)
-public class CancelJobMessage extends SlaveMessage {
+public class CancelJobMessage extends MessageToShardNode {
 
 	@Getter
 	private final UUID jobId;
 
 	@Override
-	public void react(NetworkMessageContext.Slave context) throws Exception {
+	public void react(NetworkMessageContext.ShardNodeNetworkContext context) throws Exception {
 		context.getWorkers().getWorkers().forEach((id, worker) -> worker.getJobManager().cancelJob(getJobId()));
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/ForwardToNamespace.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/ForwardToNamespace.java
@@ -8,7 +8,7 @@ import com.bakdata.conquery.models.messages.SlowMessage;
 import com.bakdata.conquery.models.messages.namespaces.NamespaceMessage;
 import com.bakdata.conquery.models.messages.network.MessageToManagerNode;
 import com.bakdata.conquery.models.messages.network.NetworkMessage;
-import com.bakdata.conquery.models.messages.network.NetworkMessageContext.ManagerNodeRxTxContext;
+import com.bakdata.conquery.models.messages.network.NetworkMessageContext.ManagerNodeNetworkContext;
 import com.bakdata.conquery.models.worker.Namespace;
 import com.bakdata.conquery.util.io.ConqueryMDC;
 import com.bakdata.conquery.util.progressreporter.ProgressReporter;
@@ -24,7 +24,7 @@ public class ForwardToNamespace extends MessageToManagerNode implements SlowMess
 	private final NamespaceMessage message;
 	
 	@Override
-	public void react(ManagerNodeRxTxContext context) throws Exception {
+	public void react(ManagerNodeNetworkContext context) throws Exception {
 		Namespace ns = Objects.requireNonNull(context.getNamespaces().get(datasetId));
 		ConqueryMDC.setLocation(ns.getStorage().getDataset().toString());
 		message.react(ns);

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/ForwardToNamespace.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/ForwardToNamespace.java
@@ -6,9 +6,9 @@ import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.messages.SlowMessage;
 import com.bakdata.conquery.models.messages.namespaces.NamespaceMessage;
-import com.bakdata.conquery.models.messages.network.MasterMessage;
+import com.bakdata.conquery.models.messages.network.MessageToManagerNode;
 import com.bakdata.conquery.models.messages.network.NetworkMessage;
-import com.bakdata.conquery.models.messages.network.NetworkMessageContext.Master;
+import com.bakdata.conquery.models.messages.network.NetworkMessageContext.ManagerNodeRxTxContext;
 import com.bakdata.conquery.models.worker.Namespace;
 import com.bakdata.conquery.util.io.ConqueryMDC;
 import com.bakdata.conquery.util.progressreporter.ProgressReporter;
@@ -18,13 +18,13 @@ import lombok.RequiredArgsConstructor;
 
 @CPSType(id="FORWARD_TO_NAMESPACE", base=NetworkMessage.class)
 @RequiredArgsConstructor @Getter
-public class ForwardToNamespace extends MasterMessage implements SlowMessage {
+public class ForwardToNamespace extends MessageToManagerNode implements SlowMessage {
 
 	private final DatasetId datasetId;
 	private final NamespaceMessage message;
 	
 	@Override
-	public void react(Master context) throws Exception {
+	public void react(ManagerNodeRxTxContext context) throws Exception {
 		Namespace ns = Objects.requireNonNull(context.getNamespaces().get(datasetId));
 		ConqueryMDC.setLocation(ns.getStorage().getDataset().toString());
 		message.react(ns);

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/ForwardToWorker.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/ForwardToWorker.java
@@ -7,8 +7,8 @@ import com.bakdata.conquery.models.identifiable.ids.specific.WorkerId;
 import com.bakdata.conquery.models.messages.SlowMessage;
 import com.bakdata.conquery.models.messages.namespaces.WorkerMessage;
 import com.bakdata.conquery.models.messages.network.NetworkMessage;
-import com.bakdata.conquery.models.messages.network.NetworkMessageContext.Slave;
-import com.bakdata.conquery.models.messages.network.SlaveMessage;
+import com.bakdata.conquery.models.messages.network.NetworkMessageContext.ShardNodeNetworkContext;
+import com.bakdata.conquery.models.messages.network.MessageToShardNode;
 import com.bakdata.conquery.models.worker.Worker;
 import com.bakdata.conquery.util.io.ConqueryMDC;
 import com.bakdata.conquery.util.progressreporter.ProgressReporter;
@@ -18,13 +18,13 @@ import lombok.RequiredArgsConstructor;
 
 @CPSType(id="FORWARD_TO_WORKER", base=NetworkMessage.class)
 @RequiredArgsConstructor @Getter
-public class ForwardToWorker extends SlaveMessage implements SlowMessage {
+public class ForwardToWorker extends MessageToShardNode implements SlowMessage {
 
 	private final WorkerId workerId;
 	private final WorkerMessage message;
 	
 	@Override
-	public void react(Slave context) throws Exception {
+	public void react(ShardNodeNetworkContext context) throws Exception {
 		Worker w = Objects.requireNonNull(context.getWorkers().getWorker(workerId));
 		ConqueryMDC.setLocation(w.toString());
 		message.react(w);

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RegisterWorker.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RegisterWorker.java
@@ -9,13 +9,12 @@ import com.bakdata.conquery.models.messages.network.NetworkMessageContext.Manage
 import com.bakdata.conquery.models.worker.SlaveInformation;
 import com.bakdata.conquery.models.worker.WorkerInformation;
 import com.bakdata.conquery.util.Wait;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@CPSType(id="UPDATE_SLAVE_IDENTITY", base=NetworkMessage.class)
+@CPSType(id="REGISTER_SHARD_WORKER_IDENTITY", base=NetworkMessage.class)
 @AllArgsConstructor @NoArgsConstructor @Getter @Setter
 public class RegisterWorker extends MessageToManagerNode {
 
@@ -23,19 +22,19 @@ public class RegisterWorker extends MessageToManagerNode {
 	
 	@Override
 	public void react(ManagerNodeRxTxContext context) throws Exception {
-		SlaveInformation slave = getSlave(context);
+		SlaveInformation slave = getShardNode(context);
 		Wait
 			.builder()
 			.attempts(6)
 			.stepTime(1)
 			.stepUnit(TimeUnit.SECONDS)
 			.build()
-			.until(()->getSlave(context));
+			.until(()->getShardNode(context));
 		
 		if(slave == null) {
 			throw new IllegalStateException("Could not find the slave "+context.getRemoteAddress()+" to register worker "+info.getId());
 		}
-		info.setConnectedSlave(slave);
+		info.setConnectedShardNode(slave);
 		context.getNamespaces().register(slave, info);
 	}
 
@@ -44,9 +43,9 @@ public class RegisterWorker extends MessageToManagerNode {
 	 * @param context the network context
 	 * @return the found slave or null if none was found
 	 */
-	private SlaveInformation getSlave(ManagerNodeRxTxContext context) {
+	private SlaveInformation getShardNode(ManagerNodeRxTxContext context) {
 		return context.getNamespaces()
-			.getSlaves()
+			.getShardNodes()
 			.get(context.getRemoteAddress());
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RegisterWorker.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RegisterWorker.java
@@ -3,9 +3,9 @@ package com.bakdata.conquery.models.messages.network.specific;
 import java.util.concurrent.TimeUnit;
 
 import com.bakdata.conquery.io.cps.CPSType;
-import com.bakdata.conquery.models.messages.network.MasterMessage;
+import com.bakdata.conquery.models.messages.network.MessageToManagerNode;
 import com.bakdata.conquery.models.messages.network.NetworkMessage;
-import com.bakdata.conquery.models.messages.network.NetworkMessageContext.Master;
+import com.bakdata.conquery.models.messages.network.NetworkMessageContext.ManagerNodeRxTxContext;
 import com.bakdata.conquery.models.worker.SlaveInformation;
 import com.bakdata.conquery.models.worker.WorkerInformation;
 import com.bakdata.conquery.util.Wait;
@@ -17,12 +17,12 @@ import lombok.Setter;
 
 @CPSType(id="UPDATE_SLAVE_IDENTITY", base=NetworkMessage.class)
 @AllArgsConstructor @NoArgsConstructor @Getter @Setter
-public class RegisterWorker extends MasterMessage {
+public class RegisterWorker extends MessageToManagerNode {
 
 	private WorkerInformation info;
 	
 	@Override
-	public void react(Master context) throws Exception {
+	public void react(ManagerNodeRxTxContext context) throws Exception {
 		SlaveInformation slave = getSlave(context);
 		Wait
 			.builder()
@@ -44,7 +44,7 @@ public class RegisterWorker extends MasterMessage {
 	 * @param context the network context
 	 * @return the found slave or null if none was found
 	 */
-	private SlaveInformation getSlave(Master context) {
+	private SlaveInformation getSlave(ManagerNodeRxTxContext context) {
 		return context.getNamespaces()
 			.getSlaves()
 			.get(context.getRemoteAddress());

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RegisterWorker.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RegisterWorker.java
@@ -5,8 +5,8 @@ import java.util.concurrent.TimeUnit;
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.models.messages.network.MessageToManagerNode;
 import com.bakdata.conquery.models.messages.network.NetworkMessage;
-import com.bakdata.conquery.models.messages.network.NetworkMessageContext.ManagerNodeRxTxContext;
-import com.bakdata.conquery.models.worker.SlaveInformation;
+import com.bakdata.conquery.models.messages.network.NetworkMessageContext.ManagerNodeNetworkContext;
+import com.bakdata.conquery.models.worker.ShardNodeInformation;
 import com.bakdata.conquery.models.worker.WorkerInformation;
 import com.bakdata.conquery.util.Wait;
 import lombok.AllArgsConstructor;
@@ -21,8 +21,8 @@ public class RegisterWorker extends MessageToManagerNode {
 	private WorkerInformation info;
 	
 	@Override
-	public void react(ManagerNodeRxTxContext context) throws Exception {
-		SlaveInformation slave = getShardNode(context);
+	public void react(ManagerNodeNetworkContext context) throws Exception {
+		ShardNodeInformation node = getShardNode(context);
 		Wait
 			.builder()
 			.attempts(6)
@@ -31,11 +31,11 @@ public class RegisterWorker extends MessageToManagerNode {
 			.build()
 			.until(()->getShardNode(context));
 		
-		if(slave == null) {
+		if(node == null) {
 			throw new IllegalStateException("Could not find the slave "+context.getRemoteAddress()+" to register worker "+info.getId());
 		}
-		info.setConnectedShardNode(slave);
-		context.getNamespaces().register(slave, info);
+		info.setConnectedShardNode(node);
+		context.getNamespaces().register(node, info);
 	}
 
 	/**
@@ -43,7 +43,7 @@ public class RegisterWorker extends MessageToManagerNode {
 	 * @param context the network context
 	 * @return the found slave or null if none was found
 	 */
-	private SlaveInformation getShardNode(ManagerNodeRxTxContext context) {
+	private ShardNodeInformation getShardNode(ManagerNodeNetworkContext context) {
 		return context.getNamespaces()
 			.getShardNodes()
 			.get(context.getRemoteAddress());

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RemoveShardNode.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RemoveShardNode.java
@@ -15,15 +15,15 @@ import lombok.extern.slf4j.Slf4j;
  * @deprecated Doesn't do much at this moment (and is not stable at this moment), as the data is distributed ahead of time, but it can later be used.
  */
 @Deprecated
-@CPSType(id = "REMOVE_SLAVE", base = NetworkMessage.class)
+@CPSType(id = "REMOVE_SHARD_NODE", base = NetworkMessage.class)
 @RequiredArgsConstructor(onConstructor_ = @JsonCreator)
 @Getter
 @Slf4j
-public class RemoveSlave extends MessageToManagerNode {
+public class RemoveShardNode extends MessageToManagerNode {
 
 	@Override
-	public void react(NetworkMessageContext.ManagerNodeRxTxContext context) throws Exception {
-		log.info("Slave {} unregistered.", context.getRemoteAddress());
+	public void react(NetworkMessageContext.ManagerNodeNetworkContext context) throws Exception {
+		log.info("ShardNode {} unregistered.", context.getRemoteAddress());
 		context.getNamespaces().getShardNodes().remove(context.getRemoteAddress());
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RemoveSlave.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RemoveSlave.java
@@ -24,6 +24,6 @@ public class RemoveSlave extends MessageToManagerNode {
 	@Override
 	public void react(NetworkMessageContext.ManagerNodeRxTxContext context) throws Exception {
 		log.info("Slave {} unregistered.", context.getRemoteAddress());
-		context.getNamespaces().getSlaves().remove(context.getRemoteAddress());
+		context.getNamespaces().getShardNodes().remove(context.getRemoteAddress());
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RemoveSlave.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RemoveSlave.java
@@ -1,7 +1,7 @@
 package com.bakdata.conquery.models.messages.network.specific;
 
 import com.bakdata.conquery.io.cps.CPSType;
-import com.bakdata.conquery.models.messages.network.MasterMessage;
+import com.bakdata.conquery.models.messages.network.MessageToManagerNode;
 import com.bakdata.conquery.models.messages.network.NetworkMessage;
 import com.bakdata.conquery.models.messages.network.NetworkMessageContext;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,10 +19,10 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor(onConstructor_ = @JsonCreator)
 @Getter
 @Slf4j
-public class RemoveSlave extends MasterMessage {
+public class RemoveSlave extends MessageToManagerNode {
 
 	@Override
-	public void react(NetworkMessageContext.Master context) throws Exception {
+	public void react(NetworkMessageContext.ManagerNodeRxTxContext context) throws Exception {
 		log.info("Slave {} unregistered.", context.getRemoteAddress());
 		context.getNamespaces().getSlaves().remove(context.getRemoteAddress());
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RemoveSlave.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RemoveSlave.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Message that allows salves to safely disconnect from Master node.
+ * Message that allows salves to safely disconnect from ManagerNode node.
  *
  * @deprecated Doesn't do much at this moment (and is not stable at this moment), as the data is distributed ahead of time, but it can later be used.
  */

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RemoveWorker.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RemoveWorker.java
@@ -3,8 +3,8 @@ package com.bakdata.conquery.models.messages.network.specific;
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.messages.network.NetworkMessage;
-import com.bakdata.conquery.models.messages.network.NetworkMessageContext.Slave;
-import com.bakdata.conquery.models.messages.network.SlaveMessage;
+import com.bakdata.conquery.models.messages.network.NetworkMessageContext.ShardNodeNetworkContext;
+import com.bakdata.conquery.models.messages.network.MessageToShardNode;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import lombok.Getter;
@@ -13,12 +13,12 @@ import lombok.extern.slf4j.Slf4j;
 
 @CPSType(id="REMOVE_WORKER", base=NetworkMessage.class)
 @RequiredArgsConstructor(onConstructor_=@JsonCreator) @Getter @Slf4j
-public class RemoveWorker extends SlaveMessage.Slow {
+public class RemoveWorker extends MessageToShardNode.Slow {
 
 	private final DatasetId dataset;
 	
 	@Override
-	public void react(Slave context) throws Exception {
+	public void react(ShardNodeNetworkContext context) throws Exception {
 		log.info("removing worker for {}", dataset);
 		context.getWorkers().removeWorkersFor(dataset);
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/UpdateJobManagerStatus.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/UpdateJobManagerStatus.java
@@ -25,11 +25,11 @@ public class UpdateJobManagerStatus extends MessageToManagerNode {
 	@Override
 	public void react(ManagerNodeRxTxContext context) throws Exception {
 		SlaveInformation slave = context.getNamespaces()
-										 .getSlaves()
+										 .getShardNodes()
 										 .get(context.getRemoteAddress());
 
 		if (slave == null) {
-			log.error("Could not find slave {}, I only know of {}", context.getRemoteAddress(), context.getNamespaces().getSlaves().keySet());
+			log.error("Could not find ShardNode {}, I only know of {}", context.getRemoteAddress(), context.getNamespaces().getShardNodes().keySet());
 		}
 		else {
 			slave.setJobManagerStatus(status);

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/UpdateJobManagerStatus.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/UpdateJobManagerStatus.java
@@ -4,9 +4,9 @@ import javax.validation.constraints.NotNull;
 
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.models.jobs.JobManagerStatus;
-import com.bakdata.conquery.models.messages.network.MasterMessage;
+import com.bakdata.conquery.models.messages.network.MessageToManagerNode;
 import com.bakdata.conquery.models.messages.network.NetworkMessage;
-import com.bakdata.conquery.models.messages.network.NetworkMessageContext.Master;
+import com.bakdata.conquery.models.messages.network.NetworkMessageContext.ManagerNodeRxTxContext;
 import com.bakdata.conquery.models.worker.SlaveInformation;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -18,12 +18,12 @@ import lombok.extern.slf4j.Slf4j;
 @CPSType(id="UPDATE_JOB_MANAGER_STATUS", base=NetworkMessage.class)
 @NoArgsConstructor @AllArgsConstructor @Getter @Setter @ToString(of = "status")
 @Slf4j
-public class UpdateJobManagerStatus extends MasterMessage {
+public class UpdateJobManagerStatus extends MessageToManagerNode {
 	@NotNull
 	private JobManagerStatus status;
 
 	@Override
-	public void react(Master context) throws Exception {
+	public void react(ManagerNodeRxTxContext context) throws Exception {
 		SlaveInformation slave = context.getNamespaces()
 										 .getSlaves()
 										 .get(context.getRemoteAddress());

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/UpdateJobManagerStatus.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/UpdateJobManagerStatus.java
@@ -6,8 +6,8 @@ import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.models.jobs.JobManagerStatus;
 import com.bakdata.conquery.models.messages.network.MessageToManagerNode;
 import com.bakdata.conquery.models.messages.network.NetworkMessage;
-import com.bakdata.conquery.models.messages.network.NetworkMessageContext.ManagerNodeRxTxContext;
-import com.bakdata.conquery.models.worker.SlaveInformation;
+import com.bakdata.conquery.models.messages.network.NetworkMessageContext.ManagerNodeNetworkContext;
+import com.bakdata.conquery.models.worker.ShardNodeInformation;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,16 +23,16 @@ public class UpdateJobManagerStatus extends MessageToManagerNode {
 	private JobManagerStatus status;
 
 	@Override
-	public void react(ManagerNodeRxTxContext context) throws Exception {
-		SlaveInformation slave = context.getNamespaces()
+	public void react(ManagerNodeNetworkContext context) throws Exception {
+		ShardNodeInformation node = context.getNamespaces()
 										 .getShardNodes()
 										 .get(context.getRemoteAddress());
 
-		if (slave == null) {
+		if (node == null) {
 			log.error("Could not find ShardNode {}, I only know of {}", context.getRemoteAddress(), context.getNamespaces().getShardNodes().keySet());
 		}
 		else {
-			slave.setJobManagerStatus(status);
+			node.setJobManagerStatus(status);
 		}
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/query/ExecutionManager.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/ExecutionManager.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 import com.bakdata.conquery.apiv1.QueryDescription;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.metrics.ExecutionMetrics;
 import com.bakdata.conquery.models.auth.AuthorizationHelper;
 import com.bakdata.conquery.models.auth.entities.Group;
@@ -62,7 +62,7 @@ public class ExecutionManager {
 
 		execution.start();
 
-		final MasterMetaStorage storage = namespaces.getMetaStorage();
+		final MetaStorage storage = namespaces.getMetaStorage();
 		final String primaryGroupName = AuthorizationHelper.getPrimaryGroup(storage.getUser(execution.getOwner()), storage).map(Group::getName).orElse("none");
 		ExecutionMetrics.getRunningQueriesCounter(primaryGroupName).inc();
 
@@ -88,7 +88,7 @@ public class ExecutionManager {
 	 * @param result
 	 */
 	public <R extends ShardResult, E extends ManagedExecution<R>> void addQueryResult(R result) {
-		final MasterMetaStorage storage = namespace.getNamespaces().getMetaStorage();
+		final MetaStorage storage = namespace.getNamespaces().getMetaStorage();
 
 		final E query = (E) getQuery(result.getQueryId());
 		query.addResult(storage, result);

--- a/backend/src/main/java/com/bakdata/conquery/models/query/IQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/IQuery.java
@@ -11,7 +11,7 @@ import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
 import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
 import com.bakdata.conquery.models.query.queryplan.QueryPlan;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.util.QueryUtils;
 import com.bakdata.conquery.util.QueryUtils.NamespacedIdCollector;
 import com.google.common.collect.MoreCollectors;
@@ -42,7 +42,7 @@ public abstract class IQuery implements QueryDescription {
 	public abstract void collectResultInfos(ResultInfoCollector collector);
 	
 	@Override
-	public ManagedQuery toManagedExecution(Namespaces namespaces, UserId userId, DatasetId submittedDataset) {
+	public ManagedQuery toManagedExecution(DatasetRegistry namespaces, UserId userId, DatasetId submittedDataset) {
 		return new ManagedQuery(this,userId, submittedDataset);
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
@@ -34,7 +34,7 @@ import com.bakdata.conquery.models.query.results.ContainedEntityResult;
 import com.bakdata.conquery.models.query.results.EntityResult;
 import com.bakdata.conquery.models.query.results.ShardResult;
 import com.bakdata.conquery.models.worker.Namespace;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.resources.ResourceConstants;
 import com.bakdata.conquery.resources.api.ResultCSVResource;
 import com.bakdata.conquery.util.QueryUtils.NamespacedIdCollector;
@@ -81,7 +81,7 @@ public class ManagedQuery extends ManagedExecution<ShardResult> {
 	}
 
 	@Override
-	public void initExecutable(@NonNull Namespaces namespaces) {
+	public void initExecutable(@NonNull DatasetRegistry namespaces) {
 		synchronized (getExecution()) {
 			this.namespace = namespaces.get(getDataset());
 			this.involvedWorkers = namespace.getWorkers().size();
@@ -192,7 +192,7 @@ public class ManagedQuery extends ManagedExecution<ShardResult> {
 	}
 
 	@Override
-	public Set<Namespace> getRequiredNamespaces() {
+	public Set<Namespace> getRequiredDatasets() {
 		return Set.of(namespace);
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
@@ -16,7 +16,7 @@ import com.bakdata.conquery.ConqueryConstants;
 import com.bakdata.conquery.apiv1.QueryDescription;
 import com.bakdata.conquery.apiv1.URLBuilder;
 import com.bakdata.conquery.io.cps.CPSType;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.execution.ExecutionState;
@@ -89,7 +89,7 @@ public class ManagedQuery extends ManagedExecution<ShardResult> {
 	}
 	
 	@Override
-	public void addResult(@NonNull MasterMetaStorage storage, ShardResult result) {
+	public void addResult(@NonNull MetaStorage storage, ShardResult result) {
 		log.debug("Received Result[size={}] for Query[{}]", result.getResults().size(), result.getQueryId());
 
 		if(result.getError().isPresent()) {
@@ -120,7 +120,7 @@ public class ManagedQuery extends ManagedExecution<ShardResult> {
 	}
 
 	@Override
-	protected void finish(@NonNull MasterMetaStorage storage, ExecutionState executionState) {
+	protected void finish(@NonNull MetaStorage storage, ExecutionState executionState) {
 		lastResultCount = results.stream().flatMap(ContainedEntityResult::filterCast).count();
 
 		super.finish(storage, executionState);
@@ -136,13 +136,13 @@ public class ManagedQuery extends ManagedExecution<ShardResult> {
 	}
 	
 	@Override
-	protected void setStatusBase(@NonNull MasterMetaStorage storage, URLBuilder url, @NonNull User user, @NonNull ExecutionStatus status) {
+	protected void setStatusBase(@NonNull MetaStorage storage, URLBuilder url, @NonNull User user, @NonNull ExecutionStatus status) {
 		super.setStatusBase(storage, url, user, status);
 		status.setNumberOfResults(lastResultCount);
 	}
 	
 	@Override
-	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MasterMetaStorage storage, URLBuilder url, User user, ExecutionStatus status) {
+	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MetaStorage storage, URLBuilder url, User user, ExecutionStatus status) {
 		super.setAdditionalFieldsForStatusWithColumnDescription(storage, url, user, status);
 		if (columnDescriptions == null) {
 			columnDescriptions = generateColumnDescriptions();

--- a/backend/src/main/java/com/bakdata/conquery/models/query/QueryResolveContext.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/QueryResolveContext.java
@@ -2,16 +2,16 @@ package com.bakdata.conquery.models.query;
 
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.worker.Namespace;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
 @Data @RequiredArgsConstructor
 public class QueryResolveContext {
 	private final DatasetId submittedDataset;
-	private final Namespaces namespaces;
+	private final DatasetRegistry datasetRegistry;
 	
 	public Namespace getNamespace() {
-		return namespaces.get(submittedDataset);
+		return datasetRegistry.get(submittedDataset);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/query/QueryTranslator.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/QueryTranslator.java
@@ -8,14 +8,14 @@ import com.bakdata.conquery.models.identifiable.ids.NamespacedId;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.query.concept.CQElement;
 import com.bakdata.conquery.models.query.concept.ConceptQuery;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.util.QueryUtils.NamespacedIdCollector;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class QueryTranslator {
 
-	public <T extends IQuery> T replaceDataset(Namespaces namespaces, T element, DatasetId target) {
+	public <T extends IQuery> T replaceDataset(DatasetRegistry namespaces, T element, DatasetId target) {
 		if(element instanceof ConceptQuery) {
 			CQElement root = replaceDataset(namespaces, ((ConceptQuery) element).getRoot(), target);
 			return (T) new ConceptQuery(root);
@@ -23,7 +23,7 @@ public class QueryTranslator {
 		throw new IllegalStateException(String.format("Can't translate non ConceptQuery IQueries: %s", element.getClass()));
 	}
 	
-	public <T extends Visitable> T replaceDataset(Namespaces namespaces, T element, DatasetId target) {
+	public <T extends Visitable> T replaceDataset(DatasetRegistry namespaces, T element, DatasetId target) {
 		try {
 			String value = Jackson.MAPPER.writeValueAsString(element);
 			

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQConceptDeserializer.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQConceptDeserializer.java
@@ -43,8 +43,8 @@ public class CQConceptDeserializer extends JsonDeserializer<CQConcept> {
 			final ScanResult scan = new ClassGraph()
 											.enableClassInfo()
 											.enableAnnotationInfo()
-											//blacklist some packages that contain large libraries
-											.blacklistPackages(
+											//reject some packages that contain large libraries
+											.rejectPackages(
 													"groovy",
 													"org.codehaus.groovy",
 													"org.apache",

--- a/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQReusedQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/concept/specific/CQReusedQuery.java
@@ -50,7 +50,7 @@ public class CQReusedQuery implements CQElement, NamespacedIdHolding {
 	
 	@Override
 	public CQElement resolve(QueryResolveContext context) {
-		resolvedQuery = ((ManagedQuery)Objects.requireNonNull(context.getNamespaces().getMetaStorage().getExecution(query), "Unable to resolve stored query")).getQuery();
+		resolvedQuery = ((ManagedQuery)Objects.requireNonNull(context.getDatasetRegistry().getMetaStorage().getExecution(query), "Unable to resolve stored query")).getQuery();
 		return this;
 	}
 	

--- a/backend/src/main/java/com/bakdata/conquery/models/query/entity/Entity.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/entity/Entity.java
@@ -21,7 +21,7 @@ import lombok.ToString;
 /**
  * All associated data to a single entity (usually a person), over all {@link Table}s and {@link com.bakdata.conquery.models.concepts.Concept}s.
  *
- * @implNote The ManagerNode does not hold any data of Entities, only the Slaves do (via Workers). Additionally, all data of a single Entity must be held by a single Worker only (See {@link com.bakdata.conquery.models.worker.Namespace::getResponsibleWorker}).
+ * @implNote The ManagerNode does not hold any data of Entities, only the ShardNodes do (via Workers). Additionally, all data of a single Entity must be held by a single Worker only (See {@link com.bakdata.conquery.models.worker.Namespace::getResponsibleWorker}).
  */
 @RequiredArgsConstructor
 @ToString(of = "id")

--- a/backend/src/main/java/com/bakdata/conquery/models/query/entity/Entity.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/entity/Entity.java
@@ -21,7 +21,7 @@ import lombok.ToString;
 /**
  * All associated data to a single entity (usually a person), over all {@link Table}s and {@link com.bakdata.conquery.models.concepts.Concept}s.
  *
- * @implNote The master does not hold any data of Entities, only the Slaves do (via Workers). Additionally, all data of a single Entity must be held by a single Worker only (See {@link com.bakdata.conquery.models.worker.Namespace::getResponsibleWorker}).
+ * @implNote The ManagerNode does not hold any data of Entities, only the Slaves do (via Workers). Additionally, all data of a single Entity must be held by a single Worker only (See {@link com.bakdata.conquery.models.worker.Namespace::getResponsibleWorker}).
  */
 @RequiredArgsConstructor
 @ToString(of = "id")

--- a/backend/src/main/java/com/bakdata/conquery/models/types/parser/specific/string/TypeGuesser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/types/parser/specific/string/TypeGuesser.java
@@ -3,7 +3,6 @@ package com.bakdata.conquery.models.types.parser.specific.string;
 import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.types.parser.Transformer;
 import com.bakdata.conquery.models.types.specific.AStringType;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -20,7 +19,7 @@ public interface TypeGuesser{
 		private final long typeMemoryEstimate;
 		
 		public long estimate() {
-			int instances = ConqueryConfig.getInstance().getStandalone().getNumberOfSlaves() + 1;
+			int instances = ConqueryConfig.getInstance().getStandalone().getNumberOfShardNodes() + 1;
 			return memoryEstimate + instances * typeMemoryEstimate;
 		}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/DatasetRegistry.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/DatasetRegistry.java
@@ -25,7 +25,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class Namespaces extends IdResolveContext implements Closeable {
+public class DatasetRegistry extends IdResolveContext implements Closeable {
 
 	private ConcurrentMap<DatasetId, Namespace> datasets = new ConcurrentHashMap<>();
 	@NotNull
@@ -105,7 +105,7 @@ public class Namespaces extends IdResolveContext implements Closeable {
 		return datasets.values().stream().map(Namespace::getStorage).map(NamespaceStorage::getDataset).collect(Collectors.toCollection(collectionSupplier));
 	}
 
-	public Collection<Namespace> getNamespaces() {
+	public Collection<Namespace> getDatasets() {
 		return datasets.values();
 	}
 	

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/IdResolveContext.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/IdResolveContext.java
@@ -14,22 +14,20 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 
-public abstract class NamespaceCollection implements Injectable {
+public abstract class IdResolveContext implements Injectable {
 
-	public static NamespaceCollection get(DeserializationContext ctxt) throws JsonMappingException {
-		NamespaceCollection namespaces = (NamespaceCollection) ctxt
-				.findInjectableValue(NamespaceCollection.class.getName(), null, null);
+	public static IdResolveContext get(DeserializationContext ctxt) throws JsonMappingException {
+		IdResolveContext namespaces = (IdResolveContext) ctxt
+				.findInjectableValue(IdResolveContext.class.getName(), null, null);
 		if(namespaces == null) {
 			throw new NoSuchElementException("Could not find injected namespaces");
 		}
-		else {
-			return namespaces;
-		}
+		return namespaces;
 	}
 	
 	@Override
 	public MutableInjectableValues inject(MutableInjectableValues values) {
-		return values.add(NamespaceCollection.class, this);
+		return values.add(IdResolveContext.class, this);
 	}
 
 	public abstract CentralRegistry findRegistry(DatasetId dataset) throws NoSuchElementException;

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/Namespace.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/Namespace.java
@@ -70,7 +70,7 @@ public class Namespace implements Closeable {
 
 	public void checkConnections() {
 		List<WorkerInformation> l = new ArrayList<>(workers);
-		l.removeIf(w -> w.getConnectedSlave() != null);
+		l.removeIf(w -> w.getConnectedShardNode() != null);
 
 		if (!l.isEmpty()) {
 			throw new IllegalStateException("Not all known slaves are connected. Missing " + l);
@@ -112,7 +112,7 @@ public class Namespace implements Closeable {
 	}
 
 	public synchronized void addWorker(WorkerInformation info) {
-		Objects.requireNonNull(info.getConnectedSlave(), () -> String.format("No open connections found for Worker[%s]", info.getId()));
+		Objects.requireNonNull(info.getConnectedShardNode(), () -> String.format("No open connections found for Worker[%s]", info.getId()));
 
 		Set<WorkerInformation> l = new HashSet<>(workers);
 		l.add(info);

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/Namespace.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/Namespace.java
@@ -57,7 +57,7 @@ public class Namespace implements Closeable {
 	private transient Int2ObjectMap<WorkerInformation> bucket2WorkerMap = new Int2ObjectArrayMap<>();
 
 	@JsonIgnore
-	private transient Namespaces namespaces;
+	private transient DatasetRegistry namespaces;
 
 	public Namespace(NamespaceStorage storage) {
 		this.storage = storage;

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/Namespace.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/Namespace.java
@@ -26,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 
 
 /**
- * Keep track of all data assigned to a single dataset. Each Slave has one {@link Worker} per {@link Dataset} / {@link Namespace}.
+ * Keep track of all data assigned to a single dataset. Each ShardNode has one {@link Worker} per {@link Dataset} / {@link Namespace}.
  * Every Worker is assigned a partition of the loaded {@link Entity}s via {@link Entity::getBucket}.
  */
 @Slf4j
@@ -73,7 +73,7 @@ public class Namespace implements Closeable {
 		l.removeIf(w -> w.getConnectedShardNode() != null);
 
 		if (!l.isEmpty()) {
-			throw new IllegalStateException("Not all known slaves are connected. Missing " + l);
+			throw new IllegalStateException("Not all known ShardNodes are connected. Missing " + l);
 		}
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/Namespaces.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/Namespaces.java
@@ -34,7 +34,7 @@ public class Namespaces extends NamespaceCollection implements Closeable {
 	private IdMap<WorkerId, WorkerInformation> workers = new IdMap<>(); // TODO remove this and take it from Namespaces.datasets
 	@Getter
 	@JsonIgnore
-	private transient ConcurrentMap<SocketAddress, SlaveInformation> slaves = new ConcurrentHashMap<>();
+	private transient ConcurrentMap<SocketAddress, SlaveInformation> shardNodes = new ConcurrentHashMap<>();
 	@Getter @Setter @JsonIgnore
 	private transient MetaStorage metaStorage;
 
@@ -82,10 +82,10 @@ public class Namespaces extends NamespaceCollection implements Closeable {
 		WorkerInformation old = workers.getOptional(info.getId()).orElse(null);
 		if (old != null) {
 			old.setIncludedBuckets(info.getIncludedBuckets());
-			old.setConnectedSlave(slave);
+			old.setConnectedShardNode(slave);
 		}
 		else {
-			info.setConnectedSlave(slave);
+			info.setConnectedShardNode(slave);
 			workers.add(info);
 		}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/Namespaces.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/Namespaces.java
@@ -25,7 +25,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class Namespaces extends NamespaceCollection implements Closeable {
+public class Namespaces extends IdResolveContext implements Closeable {
 
 	private ConcurrentMap<DatasetId, Namespace> datasets = new ConcurrentHashMap<>();
 	@NotNull

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/Namespaces.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/Namespaces.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.io.xodus.NamespaceStorage;
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.identifiable.CentralRegistry;
@@ -36,7 +36,7 @@ public class Namespaces extends NamespaceCollection implements Closeable {
 	@JsonIgnore
 	private transient ConcurrentMap<SocketAddress, SlaveInformation> slaves = new ConcurrentHashMap<>();
 	@Getter @Setter @JsonIgnore
-	private transient MasterMetaStorage metaStorage;
+	private transient MetaStorage metaStorage;
 
 	public void add(Namespace ns) {
 		datasets.put(ns.getStorage().getDataset().getId(), ns);

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/Namespaces.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/Namespaces.java
@@ -31,7 +31,7 @@ public class Namespaces extends NamespaceCollection implements Closeable {
 	@NotNull
 	@Getter
 	@Setter
-	private IdMap<WorkerId, WorkerInformation> workers = new IdMap<>();
+	private IdMap<WorkerId, WorkerInformation> workers = new IdMap<>(); // TODO remove this and take it from Namespaces.datasets
 	@Getter
 	@JsonIgnore
 	private transient ConcurrentMap<SocketAddress, SlaveInformation> slaves = new ConcurrentHashMap<>();

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/Namespaces.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/Namespaces.java
@@ -34,7 +34,7 @@ public class Namespaces extends NamespaceCollection implements Closeable {
 	private IdMap<WorkerId, WorkerInformation> workers = new IdMap<>(); // TODO remove this and take it from Namespaces.datasets
 	@Getter
 	@JsonIgnore
-	private transient ConcurrentMap<SocketAddress, SlaveInformation> shardNodes = new ConcurrentHashMap<>();
+	private transient ConcurrentMap<SocketAddress, ShardNodeInformation> shardNodes = new ConcurrentHashMap<>();
 	@Getter @Setter @JsonIgnore
 	private transient MetaStorage metaStorage;
 
@@ -78,14 +78,14 @@ public class Namespaces extends NamespaceCollection implements Closeable {
 		return metaStorage.getCentralRegistry();
 	}
 
-	public synchronized void register(SlaveInformation slave, WorkerInformation info) {
+	public synchronized void register(ShardNodeInformation node, WorkerInformation info) {
 		WorkerInformation old = workers.getOptional(info.getId()).orElse(null);
 		if (old != null) {
 			old.setIncludedBuckets(info.getIncludedBuckets());
-			old.setConnectedShardNode(slave);
+			old.setConnectedShardNode(node);
 		}
 		else {
-			info.setConnectedShardNode(slave);
+			info.setConnectedShardNode(node);
 			workers.add(info);
 		}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/ShardNodeInformation.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/ShardNodeInformation.java
@@ -3,17 +3,17 @@ package com.bakdata.conquery.models.worker;
 import com.bakdata.conquery.io.mina.MessageSender;
 import com.bakdata.conquery.io.mina.NetworkSession;
 import com.bakdata.conquery.models.jobs.JobManagerStatus;
-import com.bakdata.conquery.models.messages.network.SlaveMessage;
+import com.bakdata.conquery.models.messages.network.MessageToShardNode;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 
-public class SlaveInformation extends MessageSender.Simple<SlaveMessage> {
+public class ShardNodeInformation extends MessageSender.Simple<MessageToShardNode> {
 	@JsonIgnore @Getter
 	private transient JobManagerStatus jobManagerStatus = new JobManagerStatus();
 	@JsonIgnore
 	private final transient Object jobManagerSync = new Object();
 	
-	public SlaveInformation(NetworkSession session) {
+	public ShardNodeInformation(NetworkSession session) {
 		super(session);
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/SingletonNamespaceCollection.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/SingletonNamespaceCollection.java
@@ -5,7 +5,7 @@ import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class SingletonNamespaceCollection extends NamespaceCollection {
+public class SingletonNamespaceCollection extends IdResolveContext {
 	private final CentralRegistry registry;
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/Worker.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/Worker.java
@@ -17,7 +17,7 @@ import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.events.BucketManager;
 import com.bakdata.conquery.models.jobs.JobManager;
 import com.bakdata.conquery.models.messages.namespaces.NamespaceMessage;
-import com.bakdata.conquery.models.messages.network.MasterMessage;
+import com.bakdata.conquery.models.messages.network.MessageToManagerNode;
 import com.bakdata.conquery.models.messages.network.NetworkMessage;
 import com.bakdata.conquery.models.messages.network.specific.ForwardToNamespace;
 import com.bakdata.conquery.models.query.QueryExecutor;
@@ -101,7 +101,7 @@ public class Worker implements MessageSender.Transforming<NamespaceMessage, Netw
 	}
 
 	@Override
-	public MasterMessage transform(NamespaceMessage message) {
+	public MessageToManagerNode transform(NamespaceMessage message) {
 		return new ForwardToNamespace(getInfo().getDataset(), message);
 	}
 	

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/Worker.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/Worker.java
@@ -21,7 +21,6 @@ import com.bakdata.conquery.models.messages.network.MasterMessage;
 import com.bakdata.conquery.models.messages.network.NetworkMessage;
 import com.bakdata.conquery.models.messages.network.specific.ForwardToNamespace;
 import com.bakdata.conquery.models.query.QueryExecutor;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -54,7 +53,7 @@ public class Worker implements MessageSender.Transforming<NamespaceMessage, Netw
 		this.queryExecutor = new QueryExecutor(queryThreadPoolDefinition.createService("QueryExecutor %d"));
 		this.executorService = executorService;
 		
-		storage.setBucketManager(new BucketManager(this.jobManager, this.storage, getInfo()));
+		storage.setBucketManager(new BucketManager(this));
 		
 	}
 	
@@ -82,7 +81,6 @@ public class Worker implements MessageSender.Transforming<NamespaceMessage, Netw
 
 		WorkerInformation info = new WorkerInformation();
 		info.setDataset(dataset.getId());
-		info.setIncludedBuckets(new IntArrayList());
 		info.setName(directory.getName());
 		
 		workerStorage = new WorkerStorageImpl(validator, config, directory);

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/WorkerInformation.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/WorkerInformation.java
@@ -21,7 +21,7 @@ public class WorkerInformation extends NamedImpl<WorkerId> implements MessageSen
 	@NotNull
 	private IntHashSet includedBuckets = new IntHashSet();
 	@JsonIgnore
-	private transient SlaveInformation connectedSlave;
+	private transient SlaveInformation connectedShardNode;
 
 	@Override
 	public WorkerId createId() {
@@ -41,7 +41,7 @@ public class WorkerInformation extends NamedImpl<WorkerId> implements MessageSen
 
 	@Override
 	public SlaveInformation getMessageParent() {
-		return connectedSlave;
+		return connectedShardNode;
 	}
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/WorkerInformation.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/WorkerInformation.java
@@ -7,7 +7,7 @@ import com.bakdata.conquery.models.identifiable.NamedImpl;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.identifiable.ids.specific.WorkerId;
 import com.bakdata.conquery.models.messages.namespaces.WorkerMessage;
-import com.bakdata.conquery.models.messages.network.SlaveMessage;
+import com.bakdata.conquery.models.messages.network.MessageToShardNode;
 import com.bakdata.conquery.models.messages.network.specific.ForwardToWorker;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jetbrains.exodus.core.dataStructures.hash.IntHashSet;
@@ -15,13 +15,13 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Getter @Setter
-public class WorkerInformation extends NamedImpl<WorkerId> implements MessageSender.Transforming<WorkerMessage, SlaveMessage> {
+public class WorkerInformation extends NamedImpl<WorkerId> implements MessageSender.Transforming<WorkerMessage, MessageToShardNode> {
 	@NotNull
 	private DatasetId dataset;
 	@NotNull
 	private IntHashSet includedBuckets = new IntHashSet();
 	@JsonIgnore
-	private transient SlaveInformation connectedShardNode;
+	private transient ShardNodeInformation connectedShardNode;
 
 	@Override
 	public WorkerId createId() {
@@ -40,12 +40,12 @@ public class WorkerInformation extends NamedImpl<WorkerId> implements MessageSen
 	}
 
 	@Override
-	public SlaveInformation getMessageParent() {
+	public ShardNodeInformation getMessageParent() {
 		return connectedShardNode;
 	}
 
 	@Override
-	public SlaveMessage transform(WorkerMessage message) {
+	public MessageToShardNode transform(WorkerMessage message) {
 		return new ForwardToWorker(getId(), message);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/WorkerInformation.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/WorkerInformation.java
@@ -10,7 +10,7 @@ import com.bakdata.conquery.models.messages.namespaces.WorkerMessage;
 import com.bakdata.conquery.models.messages.network.SlaveMessage;
 import com.bakdata.conquery.models.messages.network.specific.ForwardToWorker;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
+import jetbrains.exodus.core.dataStructures.hash.IntHashSet;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -19,7 +19,7 @@ public class WorkerInformation extends NamedImpl<WorkerId> implements MessageSen
 	@NotNull
 	private DatasetId dataset;
 	@NotNull
-	private IntArrayList includedBuckets = new IntArrayList();
+	private IntHashSet includedBuckets = new IntHashSet();
 	@JsonIgnore
 	private transient SlaveInformation connectedSlave;
 
@@ -31,9 +31,9 @@ public class WorkerInformation extends NamedImpl<WorkerId> implements MessageSen
 	@JsonIgnore
 	public int findLargestEntityId() {
 		int max = -1;
-		for(int i=includedBuckets.size() - 1; i>=0; i--) {
-			if(includedBuckets.getInt(i) > max) {
-				max = includedBuckets.getInt(i);
+		for(Integer bucket : includedBuckets) {			
+			if(bucket > max) {
+				max = bucket;
 			}
 		}
 		return max;

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/Workers.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/Workers.java
@@ -28,7 +28,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class Workers extends NamespaceCollection {
+public class Workers extends IdResolveContext {
 	@Getter @Setter
 	private AtomicInteger nextWorker = new AtomicInteger(0);
 	@Getter

--- a/backend/src/main/java/com/bakdata/conquery/resources/ResourcesProvider.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/ResourcesProvider.java
@@ -3,13 +3,13 @@ package com.bakdata.conquery.resources;
 import java.io.Closeable;
 import java.io.IOException;
 
-import com.bakdata.conquery.commands.MasterCommand;
+import com.bakdata.conquery.commands.ManagerNode;
 import com.bakdata.conquery.io.cps.CPSBase;
 
 @CPSBase
 public interface ResourcesProvider extends Closeable {
 
-	void registerResources(MasterCommand master);
+	void registerResources(ManagerNode manager);
 	
 	@Override
 	default void close() throws IOException {}

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/AdminServlet.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/AdminServlet.java
@@ -70,7 +70,7 @@ public class AdminServlet {
 		adminProcessor = new AdminProcessor(
 			manager.getConfig(),
 			manager.getStorage(),
-			manager.getNamespaces(),
+			manager.getDatasetRegistry(),
 			manager.getJobManager(),
 			manager.getMaintenanceService(),
 			manager.getValidator());

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/AdminServlet.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/AdminServlet.java
@@ -2,7 +2,7 @@ package com.bakdata.conquery.resources.admin;
 
 import java.util.Collections;
 
-import com.bakdata.conquery.commands.MasterCommand;
+import com.bakdata.conquery.commands.ManagerNode;
 import com.bakdata.conquery.io.cps.CPSBase;
 import com.bakdata.conquery.io.freemarker.Freemarker;
 import com.bakdata.conquery.io.jersey.IdParamConverter;
@@ -55,25 +55,25 @@ public class AdminServlet {
 	private AdminProcessor adminProcessor;
 	private DropwizardResourceConfig jerseyConfig;
 
-	public void register(MasterCommand masterCommand) {
-		jerseyConfig = new DropwizardResourceConfig(masterCommand.getEnvironment().metrics());
+	public void register(ManagerNode manager) {
+		jerseyConfig = new DropwizardResourceConfig(manager.getEnvironment().metrics());
 		jerseyConfig.setUrlPattern("/admin");
 
-		RESTServer.configure(masterCommand.getConfig(), jerseyConfig);
+		RESTServer.configure(manager.getConfig(), jerseyConfig);
 
-		masterCommand.getEnvironment().admin().addServlet("admin", new ServletContainer(jerseyConfig)).addMapping("/admin/*");
+		manager.getEnvironment().admin().addServlet("admin", new ServletContainer(jerseyConfig)).addMapping("/admin/*");
 
-		jerseyConfig.register(new JacksonMessageBodyProvider(masterCommand.getEnvironment().getObjectMapper()));
+		jerseyConfig.register(new JacksonMessageBodyProvider(manager.getEnvironment().getObjectMapper()));
 		// freemarker support
-		jerseyConfig.register(new ViewMessageBodyWriter(masterCommand.getEnvironment().metrics(), Collections.singleton(Freemarker.HTML_RENDERER)));
+		jerseyConfig.register(new ViewMessageBodyWriter(manager.getEnvironment().metrics(), Collections.singleton(Freemarker.HTML_RENDERER)));
 
 		adminProcessor = new AdminProcessor(
-			masterCommand.getConfig(),
-			masterCommand.getStorage(),
-			masterCommand.getNamespaces(),
-			masterCommand.getJobManager(),
-			masterCommand.getMaintenanceService(),
-			masterCommand.getValidator());
+			manager.getConfig(),
+			manager.getStorage(),
+			manager.getNamespaces(),
+			manager.getJobManager(),
+			manager.getMaintenanceService(),
+			manager.getValidator());
 
 		// inject required services
 		jerseyConfig.register(new AbstractBinder() {
@@ -105,7 +105,7 @@ public class AdminServlet {
 			.register(AuthOverviewResource.class);
 
 		// Scan classpath for Admin side plugins and register them.
-		for ( Realm realm : masterCommand.getAuthController().getRealms()) {
+		for ( Realm realm : manager.getAuthController().getRealms()) {
 			if(realm instanceof AuthAdminResourceProvider) {
 				((AuthAdminResourceProvider)realm).registerAuthenticationAdminResources(jerseyConfig);
 			}
@@ -114,7 +114,7 @@ public class AdminServlet {
 		// register features
 		jerseyConfig
 			.register(new MultiPartFeature())
-			.register(masterCommand.getAuthController().getAuthenticationFilter())
+			.register(manager.getAuthController().getAuthenticationFilter())
 			.register(IdParamConverter.Provider.INSTANCE)
 			.register(AuthCookieFilter.class);
 	}

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminConceptsResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminConceptsResource.java
@@ -39,7 +39,7 @@ public class AdminConceptsResource extends HAdmin {
 	@Override
 	public void init() {
 		super.init();
-		this.namespace = processor.getNamespaces().get(datasetId);
+		this.namespace = processor.getDatasetRegistry().get(datasetId);
 		this.concept = namespace.getStorage().getConcept(conceptId);
 		if (this.concept == null) {
 			throw new WebApplicationException("Could not find concept " + conceptId, Status.NOT_FOUND);

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminDatasetResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminDatasetResource.java
@@ -63,7 +63,7 @@ public class AdminDatasetResource extends HAdmin {
 	@Override
 	public void init() {
 		super.init();
-		this.namespace = processor.getNamespaces().get(datasetId);
+		this.namespace = processor.getDatasetRegistry().get(datasetId);
 		if (namespace == null) {
 			throw new WebApplicationException("Could not find dataset " + datasetId, Status.NOT_FOUND);
 		}
@@ -88,7 +88,7 @@ public class AdminDatasetResource extends HAdmin {
 	@Path("tables")
 	@Consumes(MediaType.MULTIPART_FORM_DATA)
 	public void addTable(@FormDataParam("table_schema") FormDataBodyPart schemas) throws IOException, JSONException {
-		ObjectMapper mapper = processor.getNamespaces().injectInto(Jackson.MAPPER);
+		ObjectMapper mapper = processor.getDatasetRegistry().injectInto(Jackson.MAPPER);
 		for (BodyPart part : schemas.getParent().getBodyParts()) {
 			try (InputStream is = part.getEntityAs(InputStream.class)) {
 				Table t = mapper.readValue(is, Table.class);

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
@@ -532,6 +532,7 @@ public class AdminProcessor {
 	}
 
 	public void deleteImport(ImportId importId) {
+		// TODO explain when the includedBucket Information is updated/cleared in the WorkerInformation
 
 		final Namespace namespace = namespaces.get(importId.getDataset());
 

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
@@ -68,8 +68,8 @@ import com.bakdata.conquery.models.messages.namespaces.specific.UpdateMatchingSt
 import com.bakdata.conquery.models.messages.network.specific.AddWorker;
 import com.bakdata.conquery.models.messages.network.specific.RemoveWorker;
 import com.bakdata.conquery.models.preproc.PreprocessedHeader;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.models.worker.Namespace;
-import com.bakdata.conquery.models.worker.Namespaces;
 import com.bakdata.conquery.models.worker.ShardNodeInformation;
 import com.bakdata.conquery.resources.admin.ui.model.FEAuthOverview;
 import com.bakdata.conquery.resources.admin.ui.model.FEAuthOverview.OverviewRow;
@@ -101,7 +101,7 @@ public class AdminProcessor {
 
 	private final ConqueryConfig config;
 	private final MetaStorage storage;
-	private final Namespaces namespaces;
+	private final DatasetRegistry datasetRegistry;
 	private final JobManager jobManager;
 	private final ScheduledExecutorService maintenanceService;
 	private final Validator validator;
@@ -124,8 +124,8 @@ public class AdminProcessor {
 		table.getPrimaryColumn().setPosition(Column.PRIMARY_POSITION);
 
 		dataset.getTables().add(table);
-		namespaces.get(dataset.getId()).getStorage().updateDataset(dataset);
-		namespaces.get(dataset.getId()).sendToAll(new UpdateDataset(dataset));
+		datasetRegistry.get(dataset.getId()).getStorage().updateDataset(dataset);
+		datasetRegistry.get(dataset.getId()).sendToAll(new UpdateDataset(dataset));
 		// see #143 check duplicate names
 	}
 
@@ -133,15 +133,15 @@ public class AdminProcessor {
 		concept.setDataset(dataset.getId());
 		ValidatorHelper.failOnError(log, validator.validate(concept));
 		// Register the Concept in the ManagerNode and Workers
-		if (namespaces.get(dataset.getId()).getStorage().hasConcept(concept.getId())) {
+		if (datasetRegistry.get(dataset.getId()).getStorage().hasConcept(concept.getId())) {
 			throw new WebApplicationException("Can't replace already existing concept " + concept.getId(), Status.CONFLICT);
 		}
 
-		namespaces.get(dataset.getId()).getJobManager()
-			.addSlowJob(new SimpleJob("Adding concept " + concept.getId(), () -> namespaces.get(dataset.getId()).getStorage().updateConcept(concept)));
+		datasetRegistry.get(dataset.getId()).getJobManager()
+			.addSlowJob(new SimpleJob("Adding concept " + concept.getId(), () -> datasetRegistry.get(dataset.getId()).getStorage().updateConcept(concept)));
 
-		namespaces.get(dataset.getId()).getJobManager()
-			.addSlowJob(new SimpleJob("sendToAll " + concept.getId(), () -> namespaces.get(dataset.getId()).sendToAll(new UpdateConcept(concept))));
+		datasetRegistry.get(dataset.getId()).getJobManager()
+			.addSlowJob(new SimpleJob("sendToAll " + concept.getId(), () -> datasetRegistry.get(dataset.getId()).sendToAll(new UpdateConcept(concept))));
 		// see #144 check duplicate names
 	}
 
@@ -162,10 +162,10 @@ public class AdminProcessor {
 		Namespace ns = new Namespace(datasetStorage);
 		ns.initMaintenance(maintenanceService);
 
-		namespaces.add(ns);
+		datasetRegistry.add(ns);
 
 		// for now we just add one worker to every ShardNode
-		for (ShardNodeInformation node : namespaces.getShardNodes().values()) {
+		for (ShardNodeInformation node : datasetRegistry.getShardNodes().values()) {
 			addWorker(node, dataset);
 		}
 
@@ -181,14 +181,14 @@ public class AdminProcessor {
 
 			final ImportId importId = new ImportId(table.getId(), header.getName());
 
-			if(namespaces.get(dataset.getId()).getStorage().getImport(importId) != null){
+			if(datasetRegistry.get(dataset.getId()).getStorage().getImport(importId) != null){
 				throw new IllegalArgumentException(String.format("Import[%s] is already present.", importId));
 			}
 
 			log.info("Importing {}", selectedFile.getAbsolutePath());
 
-			namespaces.get(dataset.getId()).getJobManager()
-					  .addSlowJob(new ImportJob(namespaces.get(dataset.getId()), table.getId(), selectedFile));
+			datasetRegistry.get(dataset.getId()).getJobManager()
+					  .addSlowJob(new ImportJob(datasetRegistry.get(dataset.getId()), table.getId(), selectedFile));
 		}
 	}
 
@@ -208,7 +208,7 @@ public class AdminProcessor {
 	}
 
 	public void setStructure(Dataset dataset, StructureNode[] structure) throws JSONException {
-		namespaces.get(dataset.getId()).getStorage().updateStructure(structure);
+		datasetRegistry.get(dataset.getId()).getStorage().updateStructure(structure);
 	}
 
 	public synchronized void addRole(Role role) throws JSONException {
@@ -329,7 +329,7 @@ public class AdminProcessor {
 	}
 
 	public UIContext getUIContext() {
-		return new UIContext(namespaces);
+		return new UIContext(datasetRegistry);
 	}
 
 	public TreeSet<User> getAllUsers() {
@@ -534,7 +534,7 @@ public class AdminProcessor {
 	public void deleteImport(ImportId importId) {
 		// TODO explain when the includedBucket Information is updated/cleared in the WorkerInformation
 
-		final Namespace namespace = namespaces.get(importId.getDataset());
+		final Namespace namespace = datasetRegistry.get(importId.getDataset());
 
 		jobManager.addSlowJob(new SimpleJob(
 				"Delete Import" + importId,
@@ -552,7 +552,7 @@ public class AdminProcessor {
 	}
 
 	public void deleteTable(TableId tableId)  {
-		final Namespace namespace = namespaces.get(tableId.getDataset());
+		final Namespace namespace = datasetRegistry.get(tableId.getDataset());
 		final Dataset dataset = namespace.getDataset();
 
 		final List<? extends Connector> connectors = namespace.getStorage().getAllConcepts().stream().flatMap(c -> c.getConnectors().stream())
@@ -572,20 +572,20 @@ public class AdminProcessor {
 							 .forEach(this::deleteImport);
 
 					dataset.getTables().remove(tableId);
-					namespaces.get(dataset.getId()).getStorage().updateDataset(dataset);
+					datasetRegistry.get(dataset.getId()).getStorage().updateDataset(dataset);
 				}));
 
 		getJobManager()
 				.addSlowJob(new SimpleJob(
 						"Removing table " + tableId,
 						() -> {
-							namespaces.get(dataset.getId()).sendToAll(new UpdateDataset(dataset));
+							datasetRegistry.get(dataset.getId()).sendToAll(new UpdateDataset(dataset));
 						}
 				));
 	}
 
 	public void deleteConcept(ConceptId conceptId) {
-		final Namespace namespace = namespaces.get(conceptId.getDataset());
+		final Namespace namespace = datasetRegistry.get(conceptId.getDataset());
 
 		getJobManager()
 				.addSlowJob(new SimpleJob("Removing concept " + conceptId, () -> namespace.getStorage().removeConcept(conceptId)));
@@ -594,28 +594,28 @@ public class AdminProcessor {
 	}
 
 	public void deleteDataset(DatasetId datasetId) {
-		final Namespace namespace = namespaces.get(datasetId);
+		final Namespace namespace = datasetRegistry.get(datasetId);
 
 		if(!namespace.getDataset().getTables().isEmpty()){
 			throw new IllegalArgumentException(String.format("Cannot delete dataset `%s`, because it still has tables: `%s`", datasetId, namespace.getDataset().getTables().values()));
 		}
 
 		getJobManager()
-				.addSlowJob(new SimpleJob("Removing dataset " + datasetId, () -> namespaces.removeNamespace(datasetId)));
+				.addSlowJob(new SimpleJob("Removing dataset " + datasetId, () -> datasetRegistry.removeNamespace(datasetId)));
 		getJobManager()
 				.addSlowJob(new SimpleJob("sendToAll: remove " + datasetId,
-										  () -> namespaces.getShardNodes().values().forEach( shardNode -> shardNode.send(new RemoveWorker(datasetId))))
+										  () -> datasetRegistry.getShardNodes().values().forEach( shardNode -> shardNode.send(new RemoveWorker(datasetId))))
 				);
 
 	}
 
 	public void updateMatchingStats(DatasetId datasetId) {
-		final Namespace ns = getNamespaces().get(datasetId);
+		final Namespace ns = getDatasetRegistry().get(datasetId);
 
 		ns.getJobManager().addSlowJob(new SimpleJob("Start Update Matching Stats", () -> {
 			ns.sendToAll(new UpdateMatchingStatsMessage());
 		}));
 
-		FilterSearch.updateSearch(getNamespaces(), Collections.singleton(ns.getDataset()), getJobManager());
+		FilterSearch.updateSearch(getDatasetRegistry(), Collections.singleton(ns.getDataset()), getJobManager());
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
@@ -132,7 +132,7 @@ public class AdminProcessor {
 	public void addConcept(@NonNull Dataset dataset, @NonNull Concept<?> concept) throws JSONException {
 		concept.setDataset(dataset.getId());
 		ValidatorHelper.failOnError(log, validator.validate(concept));
-		// Register the Concept in the Master and Workers
+		// Register the Concept in the ManagerNode and Workers
 		if (namespaces.get(dataset.getId()).getStorage().hasConcept(concept.getId())) {
 			throw new WebApplicationException("Can't replace already existing concept " + concept.getId(), Status.CONFLICT);
 		}

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
@@ -26,7 +26,7 @@ import com.bakdata.conquery.io.HCFile;
 import com.bakdata.conquery.io.cps.CPSTypeIdResolver;
 import com.bakdata.conquery.io.csv.CsvIo;
 import com.bakdata.conquery.io.jackson.Jackson;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.io.xodus.NamespaceStorage;
 import com.bakdata.conquery.io.xodus.NamespaceStorageImpl;
 import com.bakdata.conquery.models.auth.AuthorizationHelper;
@@ -100,7 +100,7 @@ import org.apache.shiro.authz.Permission;
 public class AdminProcessor {
 
 	private final ConqueryConfig config;
-	private final MasterMetaStorage storage;
+	private final MetaStorage storage;
 	private final Namespaces namespaces;
 	private final JobManager jobManager;
 	private final ScheduledExecutorService maintenanceService;
@@ -517,7 +517,7 @@ public class AdminProcessor {
 	/**
 	 * Writes the given {@link User}s (one perline) with their effective permission to the specified CSV writer.
 	 */
-	private static void writeAuthOverviewUser(CsvWriter writer, List<String> scope, User user, MasterMetaStorage storage) {
+	private static void writeAuthOverviewUser(CsvWriter writer, List<String> scope, User user, MetaStorage storage) {
 		// Print the user in the first column
 		writer.addValue(String.format("%s %s", user.getLabel(), ConqueryEscape.unescape(user.getName())));
 

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
@@ -165,7 +165,7 @@ public class AdminProcessor {
 		namespaces.add(ns);
 
 		// for now we just add one worker to every slave
-		for (SlaveInformation slave : namespaces.getSlaves().values()) {
+		for (SlaveInformation slave : namespaces.getShardNodes().values()) {
 			addWorker(slave, dataset);
 		}
 
@@ -604,7 +604,7 @@ public class AdminProcessor {
 				.addSlowJob(new SimpleJob("Removing dataset " + datasetId, () -> namespaces.removeNamespace(datasetId)));
 		getJobManager()
 				.addSlowJob(new SimpleJob("sendToAll: remove " + datasetId,
-										  () -> namespaces.getSlaves().forEach((__, slave) -> slave.send(new RemoveWorker(datasetId))))
+										  () -> namespaces.getShardNodes().values().forEach( shardNode -> shardNode.send(new RemoveWorker(datasetId))))
 				);
 
 	}

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
@@ -70,7 +70,7 @@ import com.bakdata.conquery.models.messages.network.specific.RemoveWorker;
 import com.bakdata.conquery.models.preproc.PreprocessedHeader;
 import com.bakdata.conquery.models.worker.Namespace;
 import com.bakdata.conquery.models.worker.Namespaces;
-import com.bakdata.conquery.models.worker.SlaveInformation;
+import com.bakdata.conquery.models.worker.ShardNodeInformation;
 import com.bakdata.conquery.resources.admin.ui.model.FEAuthOverview;
 import com.bakdata.conquery.resources.admin.ui.model.FEAuthOverview.OverviewRow;
 import com.bakdata.conquery.resources.admin.ui.model.FEGroupContent;
@@ -164,9 +164,9 @@ public class AdminProcessor {
 
 		namespaces.add(ns);
 
-		// for now we just add one worker to every slave
-		for (SlaveInformation slave : namespaces.getShardNodes().values()) {
-			addWorker(slave, dataset);
+		// for now we just add one worker to every ShardNode
+		for (ShardNodeInformation node : namespaces.getShardNodes().values()) {
+			addWorker(node, dataset);
 		}
 
 		return dataset;
@@ -192,8 +192,8 @@ public class AdminProcessor {
 		}
 	}
 
-	public void addWorker(SlaveInformation slave, Dataset dataset) {
-		slave.send(new AddWorker(dataset));
+	public void addWorker(ShardNodeInformation node, Dataset dataset) {
+		node.send(new AddWorker(dataset));
 	}
 
 	public void setIdMapping(InputStream data, Namespace namespace) throws JSONException, IOException {

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminResource.java
@@ -50,6 +50,6 @@ public class AdminResource extends HAdmin {
 	@GET
 	@Path("datasets")
 	public List<DatasetId> listDatasets() {
-		return processor.getNamespaces().getAllDatasets().stream().map(Dataset::getId).collect(Collectors.toList());
+		return processor.getDatasetRegistry().getAllDatasets().stream().map(Dataset::getId).collect(Collectors.toList());
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminTablesResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminTablesResource.java
@@ -1,6 +1,8 @@
 package com.bakdata.conquery.resources.admin.rest;
 
-import static com.bakdata.conquery.resources.ResourceConstants.*;
+import static com.bakdata.conquery.resources.ResourceConstants.DATASET;
+import static com.bakdata.conquery.resources.ResourceConstants.IMPORT_ID;
+import static com.bakdata.conquery.resources.ResourceConstants.TABLE;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -45,7 +47,7 @@ public class AdminTablesResource extends HAdmin {
 	@Override
 	public void init() {
 		super.init();
-		this.namespace = processor.getNamespaces().get(datasetId);
+		this.namespace = processor.getDatasetRegistry().get(datasetId);
 		this.table = namespace.getDataset().getTables().getOrFail(tableId);
 		if (this.table == null) {
 			throw new WebApplicationException("Could not find table " + tableId, Status.NOT_FOUND);

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/AdminUIResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/AdminUIResource.java
@@ -3,7 +3,6 @@ package com.bakdata.conquery.resources.admin.ui;
 import static com.bakdata.conquery.resources.ResourceConstants.DATASET;
 import static com.bakdata.conquery.resources.ResourceConstants.JOB_ID;
 
-import java.net.SocketAddress;
 import java.time.LocalDate;
 import java.util.Map;
 import java.util.Objects;
@@ -133,8 +132,7 @@ public class AdminUIResource extends HAdmin {
 
 		processor.getJobManager().cancelJob(jobId);
 
-		for (Map.Entry<SocketAddress, SlaveInformation> entry : processor.getNamespaces().getSlaves().entrySet()) {
-			SlaveInformation info = entry.getValue();
+		for (SlaveInformation info : processor.getNamespaces().getShardNodes().values()) {
 			info.send(new CancelJobMessage(jobId));
 		}
 
@@ -160,7 +158,7 @@ public class AdminUIResource extends HAdmin {
 						.putAll(
 								processor
 										.getNamespaces()
-										.getSlaves()
+										.getShardNodes()
 										.values()
 										.stream()
 										.collect(Collectors.toMap(

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/AdminUIResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/AdminUIResource.java
@@ -31,7 +31,7 @@ import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.jobs.Job;
 import com.bakdata.conquery.models.jobs.JobManagerStatus;
 import com.bakdata.conquery.models.messages.network.specific.CancelJobMessage;
-import com.bakdata.conquery.models.worker.SlaveInformation;
+import com.bakdata.conquery.models.worker.ShardNodeInformation;
 import com.bakdata.conquery.resources.admin.rest.AdminProcessor;
 import com.bakdata.conquery.resources.admin.ui.model.UIView;
 import com.bakdata.conquery.resources.hierarchies.HAdmin;
@@ -132,7 +132,7 @@ public class AdminUIResource extends HAdmin {
 
 		processor.getJobManager().cancelJob(jobId);
 
-		for (SlaveInformation info : processor.getNamespaces().getShardNodes().values()) {
+		for (ShardNodeInformation info : processor.getNamespaces().getShardNodes().values()) {
 			info.send(new CancelJobMessage(jobId));
 		}
 
@@ -163,7 +163,7 @@ public class AdminUIResource extends HAdmin {
 										.stream()
 										.collect(Collectors.toMap(
 												si -> Objects.toString(si.getRemoteAddress()),
-												SlaveInformation::getJobManagerStatus
+												ShardNodeInformation::getJobManagerStatus
 										))
 						)
 						.build();

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/AdminUIResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/AdminUIResource.java
@@ -102,7 +102,7 @@ public class AdminUIResource extends HAdmin {
 		CompilerConfiguration config = new CompilerConfiguration();
 		config.addCompilationCustomizers(new ImportCustomizer().addImports(AUTO_IMPORTS));
 		GroovyShell groovy = new GroovyShell(config);
-		groovy.setProperty("namespaces", processor.getNamespaces());
+		groovy.setProperty("datasetRegistry", processor.getDatasetRegistry());
 		groovy.setProperty("jobManager", processor.getJobManager());
 
 		try {
@@ -117,7 +117,7 @@ public class AdminUIResource extends HAdmin {
 	@GET
 	@Path("datasets")
 	public View getDatasets() {
-		return new UIView<>("datasets.html.ftl", processor.getUIContext(), processor.getNamespaces().getAllDatasets());
+		return new UIView<>("datasets.html.ftl", processor.getUIContext(), processor.getDatasetRegistry().getAllDatasets());
 	}
 
 	@POST @Path("/update-matching-stats/{"+ DATASET +"}") @Consumes(MediaType.MULTIPART_FORM_DATA)
@@ -132,7 +132,7 @@ public class AdminUIResource extends HAdmin {
 
 		processor.getJobManager().cancelJob(jobId);
 
-		for (ShardNodeInformation info : processor.getNamespaces().getShardNodes().values()) {
+		for (ShardNodeInformation info : processor.getDatasetRegistry().getShardNodes().values()) {
 			info.send(new CancelJobMessage(jobId));
 		}
 
@@ -149,7 +149,7 @@ public class AdminUIResource extends HAdmin {
 						.put("ManagerNode", processor.getJobManager().reportStatus())
 						// Namespace JobManagers on ManagerNode
 						.putAll(
-								processor.getNamespaces().getNamespaces().stream()
+								processor.getDatasetRegistry().getDatasets().stream()
 										 .collect(Collectors.toMap(
 												 ns -> String.format("ManagerNode::%s", ns.getDataset().getId()),
 												 ns -> ns.getJobManager().reportStatus()
@@ -157,7 +157,7 @@ public class AdminUIResource extends HAdmin {
 						// Remote Worker JobManagers
 						.putAll(
 								processor
-										.getNamespaces()
+										.getDatasetRegistry()
 										.getShardNodes()
 										.values()
 										.stream()

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/AdminUIResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/AdminUIResource.java
@@ -148,12 +148,12 @@ public class AdminUIResource extends HAdmin {
 	public View getJobs() {
 		Map<String, JobManagerStatus> status =
 				ImmutableMap.<String, JobManagerStatus>builder()
-						.put("Master", processor.getJobManager().reportStatus())
-						// Namespace JobManagers on Master
+						.put("ManagerNode", processor.getJobManager().reportStatus())
+						// Namespace JobManagers on ManagerNode
 						.putAll(
 								processor.getNamespaces().getNamespaces().stream()
 										 .collect(Collectors.toMap(
-												 ns -> String.format("Master::%s", ns.getDataset().getId()),
+												 ns -> String.format("ManagerNode::%s", ns.getDataset().getId()),
 												 ns -> ns.getJobManager().reportStatus()
 										 )))
 						// Remote Worker JobManagers

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/ConceptsUIResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/ConceptsUIResource.java
@@ -42,7 +42,7 @@ public class ConceptsUIResource extends HAdmin {
 	@Override
 	public void init() {
 		super.init();
-		this.namespace = processor.getNamespaces().get(datasetId);
+		this.namespace = processor.getDatasetRegistry().get(datasetId);
 		this.concept = namespace.getStorage().getConcept(conceptId);
 		if (this.concept == null) {
 			throw new WebApplicationException("Could not find concept " + conceptId, Status.NOT_FOUND);

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/DatasetsUIResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/DatasetsUIResource.java
@@ -55,7 +55,7 @@ public class DatasetsUIResource extends HAdmin {
 	@Override
 	public void init() {
 		super.init();
-		this.namespace = processor.getNamespaces().get(datasetId);
+		this.namespace = processor.getDatasetRegistry().get(datasetId);
 		if (namespace == null) {
 			throw new WebApplicationException("Could not find dataset " + datasetId, Status.NOT_FOUND);
 		}

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/TablesUIResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/TablesUIResource.java
@@ -1,6 +1,8 @@
 package com.bakdata.conquery.resources.admin.ui;
 
-import static com.bakdata.conquery.resources.ResourceConstants.*;
+import static com.bakdata.conquery.resources.ResourceConstants.DATASET;
+import static com.bakdata.conquery.resources.ResourceConstants.IMPORT_ID;
+import static com.bakdata.conquery.resources.ResourceConstants.TABLE;
 
 import java.util.Arrays;
 import java.util.List;
@@ -50,7 +52,7 @@ public class TablesUIResource extends HAdmin {
 	@Override
 	public void init() {
 		super.init();
-		this.namespace = processor.getNamespaces().get(datasetId);
+		this.namespace = processor.getDatasetRegistry().get(datasetId);
 		this.table = namespace
 			.getStorage()
 			.getDataset()

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/model/UIContext.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/model/UIContext.java
@@ -2,7 +2,7 @@ package com.bakdata.conquery.resources.admin.ui.model;
 
 import java.util.Collection;
 
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.models.worker.WorkerInformation;
 import com.bakdata.conquery.resources.ResourceConstants;
 import freemarker.template.TemplateModel;
@@ -15,7 +15,7 @@ public class UIContext {
 	private static final TemplateModel STAIC_URI_ELEMENTS = ResourceConstants.getAsTemplateModel();
 
 	@Getter
-	private final Namespaces namespaces;
+	private final DatasetRegistry namespaces;
 
 	@Getter
 	public final TemplateModel staticUriElem = STAIC_URI_ELEMENTS;

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/model/UIContext.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/model/UIContext.java
@@ -21,7 +21,7 @@ public class UIContext {
 	public final TemplateModel staticUriElem = STAIC_URI_ELEMENTS;
 
 	public boolean[] getWorkerStatuses() {
-		boolean[] result = new boolean[namespaces.getSlaves().values().size()];
+		boolean[] result = new boolean[namespaces.getShardNodes().values().size()];
 		int id = 0;
 		for(WorkerInformation wi:namespaces.getWorkers().values()) {
 			result[id++] = wi.isConnected();

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java
@@ -34,7 +34,7 @@ import com.bakdata.conquery.models.exceptions.ConceptConfigurationException;
 import com.bakdata.conquery.models.identifiable.ids.specific.ConceptElementId;
 import com.bakdata.conquery.models.identifiable.ids.specific.ConnectorId;
 import com.bakdata.conquery.models.identifiable.ids.specific.FilterId;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.util.CalculatedValue;
 import com.bakdata.conquery.util.search.QuickSearch;
 import com.bakdata.conquery.util.search.SearchScorer;
@@ -54,7 +54,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ConceptsProcessor {
 	
-	private final Namespaces namespaces;
+	private final DatasetRegistry namespaces;
 	private final LoadingCache<Concept<?>, FEList> nodeCache = CacheBuilder.newBuilder()
 		.softValues()
 		.expireAfterWrite(10, TimeUnit.MINUTES)

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/FormResourceProvider.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/FormResourceProvider.java
@@ -1,6 +1,6 @@
 package com.bakdata.conquery.resources.api;
 
-import com.bakdata.conquery.commands.MasterCommand;
+import com.bakdata.conquery.commands.ManagerNode;
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.models.forms.frontendconfiguration.FormProcessor;
 import com.bakdata.conquery.resources.ResourcesProvider;
@@ -12,8 +12,8 @@ public class FormResourceProvider implements ResourcesProvider {
 	private FormProcessor processor;
 	
 	@Override
-	public void registerResources(MasterCommand master) {
-		JerseyEnvironment environment = master.getEnvironment().jersey();
+	public void registerResources(ManagerNode manager) {
+		JerseyEnvironment environment = manager.getEnvironment().jersey();
 		processor = new FormProcessor();
 
 		environment.register(new FormResource(processor));

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/QueryResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/QueryResource.java
@@ -50,12 +50,12 @@ public class QueryResource {
 	@Inject
 	public QueryResource(QueryProcessor processor) {
 		this.processor= processor;
-		dsUtil = new ResourceUtil(processor.getNamespaces());
+		dsUtil = new ResourceUtil(processor.getDatasetRegistry());
 	}
 
 	@POST
 	public Response postQuery(@Auth User user, @PathParam(DATASET) DatasetId datasetId, @NotNull @Valid QueryDescription query, @Context HttpServletRequest req) {
-		query.resolve(new QueryResolveContext(datasetId, processor.getNamespaces()));
+		query.resolve(new QueryResolveContext(datasetId, processor.getDatasetRegistry()));
 		log.info("Query posted on dataset {} by user {} ({}).", datasetId, user.getId(), user.getName());
 
 		return Response.ok(

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/ResultCSVResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/ResultCSVResource.java
@@ -32,7 +32,7 @@ import com.bakdata.conquery.models.identifiable.mapping.IdMappingState;
 import com.bakdata.conquery.models.query.ManagedQuery;
 import com.bakdata.conquery.models.query.PrintSettings;
 import com.bakdata.conquery.models.query.QueryToCSVRenderer;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import io.dropwizard.auth.Auth;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,7 +46,7 @@ public class ResultCSVResource {
 
 	public static final URLBuilderPath GET_CSV_PATH = new URLBuilderPath(
 		ResultCSVResource.class, "getAsCsv");
-	private final Namespaces namespaces;
+	private final DatasetRegistry namespaces;
 	private final ConqueryConfig config;
 
 	@GET

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/StoredQueriesResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/StoredQueriesResource.java
@@ -7,6 +7,7 @@ import static com.bakdata.conquery.resources.ResourceConstants.QUERY;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -23,13 +24,11 @@ import com.bakdata.conquery.apiv1.MetaDataPatch;
 import com.bakdata.conquery.apiv1.StoredQueriesProcessor;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.auth.permissions.Ability;
-import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.exceptions.JSONException;
 import com.bakdata.conquery.models.execution.ExecutionStatus;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
-import com.bakdata.conquery.models.worker.DatasetRegistry;
-import com.bakdata.conquery.util.ResourceUtil;
+import com.bakdata.conquery.resources.hierarchies.HDatasets;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.jersey.PATCH;
 
@@ -37,30 +36,24 @@ import io.dropwizard.jersey.PATCH;
 @Consumes(AdditionalMediaTypes.JSON)
 @Produces(AdditionalMediaTypes.JSON)
 
-public class StoredQueriesResource {
+public class StoredQueriesResource extends HDatasets {
 
-	private final StoredQueriesProcessor processor;
-	private final ResourceUtil dsUtil;
-
-	public StoredQueriesResource(DatasetRegistry namespaces) {
-		this.processor = new StoredQueriesProcessor(namespaces);
-		this.dsUtil = new ResourceUtil(namespaces);
-	}
+	@Inject
+	private StoredQueriesProcessor processor;
 
 	@GET
-	public List<ExecutionStatus> getAllQueries(@Auth User user, @PathParam(DATASET) DatasetId datasetId, @Context HttpServletRequest req) {
-		return processor.getAllQueries(dsUtil.getDataset(datasetId), req, user)
+	public List<ExecutionStatus> getAllQueries(@Auth User user, DatasetId datasetId, @Context HttpServletRequest req) {
+		return processor.getAllQueries(namespace, req, user)
 			.collect(Collectors.toList());
 	}
 
 	@GET
 	@Path("{" + QUERY + "}")
-	public ExecutionStatus getQueryWithSource(@Auth User user, @PathParam(DATASET) DatasetId datasetId, @PathParam(QUERY) ManagedExecutionId queryId) {
-		Dataset dataset = dsUtil.getDataset(datasetId);
+	public ExecutionStatus getQueryWithSource(@Auth User user, @PathParam(QUERY) ManagedExecutionId queryId) {
 		authorize(user, datasetId, Ability.READ);
 		authorize(user, queryId, Ability.READ);
 
-		ExecutionStatus status = processor.getQueryWithSource(dataset, queryId, user);
+		ExecutionStatus status = processor.getQueryWithSource(queryId, user);
 		if (status == null) {
 			throw new WebApplicationException("Unknown query " + queryId, Status.NOT_FOUND);
 		}
@@ -69,19 +62,19 @@ public class StoredQueriesResource {
 
 	@PATCH
 	@Path("{" + QUERY + "}")
-	public ExecutionStatus patchQuery(@Auth User user, @PathParam(DATASET) DatasetId datasetId, @PathParam(QUERY) ManagedExecutionId queryId, MetaDataPatch patch) throws JSONException {
+	public ExecutionStatus patchQuery(@Auth User user, @PathParam(QUERY) ManagedExecutionId queryId, MetaDataPatch patch) throws JSONException {
 		authorize(user, datasetId, Ability.READ);
 		processor.patchQuery(user, queryId, patch);
 		
-		return getQueryWithSource(user, datasetId, queryId);
+		return getQueryWithSource(user, queryId);
 	}
 
 	@DELETE
 	@Path("{" + QUERY + "}")
-	public void deleteQuery(@Auth User user, @PathParam(DATASET) DatasetId datasetId, @PathParam(QUERY) ManagedExecutionId queryId) {
+	public void deleteQuery(@Auth User user, @PathParam(QUERY) ManagedExecutionId queryId) {
 		authorize(user, datasetId, Ability.READ);
 		authorize(user, queryId, Ability.DELETE);
 
-		processor.deleteQuery(dsUtil.getDataset(datasetId), dsUtil.getManagedQuery(queryId));
+		processor.deleteQuery(namespace, queryId);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/StoredQueriesResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/StoredQueriesResource.java
@@ -28,7 +28,7 @@ import com.bakdata.conquery.models.exceptions.JSONException;
 import com.bakdata.conquery.models.execution.ExecutionStatus;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.util.ResourceUtil;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.jersey.PATCH;
@@ -42,7 +42,7 @@ public class StoredQueriesResource {
 	private final StoredQueriesProcessor processor;
 	private final ResourceUtil dsUtil;
 
-	public StoredQueriesResource(Namespaces namespaces) {
+	public StoredQueriesResource(DatasetRegistry namespaces) {
 		this.processor = new StoredQueriesProcessor(namespaces);
 		this.dsUtil = new ResourceUtil(namespaces);
 	}

--- a/backend/src/main/java/com/bakdata/conquery/resources/hierarchies/HDatasets.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/hierarchies/HDatasets.java
@@ -33,7 +33,7 @@ public abstract class HDatasets extends HAuthorized {
 	public void init() {
 		super.init();
 		authorize(user, datasetId, Ability.READ);
-		this.namespace = processor.getNamespaces().get(datasetId);
+		this.namespace = processor.getDatasetRegistry().get(datasetId);
 		if(namespace == null) {
 			throw new WebApplicationException("Could not find dataset "+datasetId, Status.NOT_FOUND);
 		}

--- a/backend/src/main/java/com/bakdata/conquery/tasks/QueryCleanupTask.java
+++ b/backend/src/main/java/com/bakdata/conquery/tasks/QueryCleanupTask.java
@@ -13,7 +13,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.PermissionOwner;
 import com.bakdata.conquery.models.auth.permissions.QueryPermission;
 import com.bakdata.conquery.models.auth.permissions.WildcardPermission;
@@ -42,10 +42,10 @@ public class QueryCleanupTask extends Task {
     public static final String EXPIRATION_PARAM = "expiration";
     private static final Predicate<String> UUID_PATTERN = Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$").asPredicate();
 
-    private final MasterMetaStorage storage;
+    private final MetaStorage storage;
     private Duration queryExpiration;
 
-    public QueryCleanupTask(MasterMetaStorage storage, Duration queryExpiration) {
+    public QueryCleanupTask(MetaStorage storage, Duration queryExpiration) {
 		super("cleanup");
 		this.storage = storage;
 		this.queryExpiration = queryExpiration;
@@ -146,7 +146,7 @@ public class QueryCleanupTask extends Task {
 	 * 
 	 * @return The number of deleted permissions.
 	 */
-	public static int deleteQueryPermissionsWithMissingRef(MasterMetaStorage storage, Iterable<? extends PermissionOwner<?>> owners) {
+	public static int deleteQueryPermissionsWithMissingRef(MetaStorage storage, Iterable<? extends PermissionOwner<?>> owners) {
 		int countDeleted = 0;
 		// Do the loop-di-loop
 		for (PermissionOwner<?> owner : owners) {

--- a/backend/src/main/java/com/bakdata/conquery/util/ResourceUtil.java
+++ b/backend/src/main/java/com/bakdata/conquery/util/ResourceUtil.java
@@ -5,13 +5,13 @@ import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.execution.ManagedExecution;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 
 public class ResourceUtil {
 
-	private final Namespaces namespaces;
+	private final DatasetRegistry namespaces;
 
-	public ResourceUtil(Namespaces namespaces) {
+	public ResourceUtil(DatasetRegistry namespaces) {
 		this.namespaces = namespaces;
 	}
 

--- a/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/index.html.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/index.html.ftl
@@ -2,8 +2,8 @@
 <@layout.layout>
 	<div class="row">
 		<div class="col">
-			<#list ctx.namespaces.slaves as key,slave>
-				<span class="badge badge-pill <#if slave.connected??>badge-success<#else>badge-danger</#if>">${key}</span>
+			<#list ctx.namespaces.shardNodes as key,shardNode>
+				<span class="badge badge-pill <#if shardNode.connected??>badge-success<#else>badge-danger</#if>">${key}</span>
 			</#list>
 		</div>
 	</div>

--- a/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/templates/template.html.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/templates/template.html.ftl
@@ -75,10 +75,10 @@
 			</div>
 		  </li>
 		</ul>
-		<!-- Status of the slaves -->
+		<!-- Status of the shardNodes -->
 		<div>
-			<#list ctx.namespaces.slaves as key,slave>
-				<i class="fas fa-circle <#if slave.connected>text-success<#else>text-danger</#if>"></i>
+			<#list ctx.namespaces.shardNodes as key,shardNode>
+				<i class="fas fa-circle <#if shardNode.connected>text-success<#else>text-danger</#if>"></i>
 			</#list>
 		</div>
 	  </div>

--- a/backend/src/test/java/com/bakdata/conquery/api/form/config/FormConfigTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/api/form/config/FormConfigTest.java
@@ -43,7 +43,7 @@ import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
 import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
 import com.bakdata.conquery.models.query.concept.specific.CQConcept;
 import com.bakdata.conquery.models.worker.Namespace;
-import com.bakdata.conquery.models.worker.NamespaceCollection;
+import com.bakdata.conquery.models.worker.IdResolveContext;
 import com.bakdata.conquery.models.worker.Namespaces;
 import com.codahale.metrics.SharedMetricRegistries;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -187,7 +187,7 @@ public class FormConfigTest {
 		
 
 		((MutableInjectableValues)FormConfigProcessor.getMAPPER().getInjectableValues())
-		.add(NamespaceCollection.class, namespacesMock);
+		.add(IdResolveContext.class, namespacesMock);
 		processor = new FormConfigProcessor(validator, storageMock);
 		controller = new AuthorizationController(new DevelopmentAuthorizationConfig(), Collections.emptyList(), storageMock);
 		controller.init();

--- a/backend/src/test/java/com/bakdata/conquery/api/form/config/FormConfigTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/api/form/config/FormConfigTest.java
@@ -42,9 +42,9 @@ import com.bakdata.conquery.models.identifiable.ids.specific.GroupId;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
 import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
 import com.bakdata.conquery.models.query.concept.specific.CQConcept;
-import com.bakdata.conquery.models.worker.Namespace;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.models.worker.IdResolveContext;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.Namespace;
 import com.codahale.metrics.SharedMetricRegistries;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -68,7 +68,7 @@ import org.mockito.Mockito;
 public class FormConfigTest {
 	
 	private MetaStorage storageMock;
-	private Namespaces namespacesMock;
+	private DatasetRegistry namespacesMock;
 	
 	private Map<FormConfigId, FormConfig> configs = new ConcurrentHashMap<>();
 	private Map<UserId, User> users = new HashedMap<>();
@@ -161,8 +161,8 @@ public class FormConfigTest {
 		}).when(storageMock).removeGroup(any());
 		when(storageMock.getAllGroups()).thenReturn(groups.values());
 		
-		// Mock namespaces for translation
-		namespacesMock = Mockito.mock(Namespaces.class);
+		// Mock DatasetRegistry for translation
+		namespacesMock = Mockito.mock(DatasetRegistry.class);
 		doAnswer(invocation -> {
 			throw new UnsupportedOperationException("Not yet implemented");
 		}).when(namespacesMock).getOptional(any());
@@ -183,7 +183,7 @@ public class FormConfigTest {
 		when(namespacesMock.getAllDatasets()).thenReturn(List.of(dataset,dataset1));
 		when(namespacesMock.injectInto(any(ObjectMapper.class))).thenCallRealMethod();
 		when(namespacesMock.inject(any(MutableInjectableValues.class))).thenCallRealMethod();
-		when(storageMock.getNamespaces()).thenReturn(namespacesMock);
+		when(storageMock.getDatasetRegistry()).thenReturn(namespacesMock);
 		
 
 		((MutableInjectableValues)FormConfigProcessor.getMAPPER().getInjectableValues())

--- a/backend/src/test/java/com/bakdata/conquery/api/form/config/FormConfigTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/api/form/config/FormConfigTest.java
@@ -22,7 +22,7 @@ import com.bakdata.conquery.apiv1.forms.export_form.ExportForm;
 import com.bakdata.conquery.apiv1.forms.export_form.RelativeMode;
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.io.jackson.MutableInjectableValues;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.AuthorizationController;
 import com.bakdata.conquery.models.auth.develop.DevelopmentAuthorizationConfig;
 import com.bakdata.conquery.models.auth.entities.Group;
@@ -67,7 +67,7 @@ import org.mockito.Mockito;
 @TestInstance(Lifecycle.PER_CLASS)
 public class FormConfigTest {
 	
-	private MasterMetaStorage storageMock;
+	private MetaStorage storageMock;
 	private Namespaces namespacesMock;
 	
 	private Map<FormConfigId, FormConfig> configs = new ConcurrentHashMap<>();
@@ -87,7 +87,7 @@ public class FormConfigTest {
 	@BeforeAll
 	public void setupTestClass() throws Exception{
 		SharedMetricRegistries.setDefault(FormConfigTest.class.getName());
-		storageMock = Mockito.mock(MasterMetaStorage.class);
+		storageMock = Mockito.mock(MetaStorage.class);
 
 		dataset.setName("test");
 		dataset1.setName("test1");

--- a/backend/src/test/java/com/bakdata/conquery/integration/common/IntegrationUtils.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/common/IntegrationUtils.java
@@ -42,7 +42,7 @@ public class IntegrationUtils {
 
 
 	public static void clearAuthStorage(MetaStorage storage, Role[] roles, RequiredUser[] rUsers) {
-		// Clear MasterStorage
+		// Clear MetaStorage
 		for (Role mandator : roles) {
 			storage.removeRole(mandator.getId());
 		}

--- a/backend/src/test/java/com/bakdata/conquery/integration/common/IntegrationUtils.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/common/IntegrationUtils.java
@@ -3,7 +3,7 @@ package com.bakdata.conquery.integration.common;
 import java.io.IOException;
 
 import com.bakdata.conquery.integration.json.ConqueryTestSpec;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.Role;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.exceptions.JSONException;
@@ -22,7 +22,7 @@ public class IntegrationUtils {
 	/**
 	 * Load the constellation of roles, users and permissions into the provided storage.
 	 */
-	public static void importPermissionConstellation(MasterMetaStorage storage, Role[] roles,  RequiredUser[] rUsers) {
+	public static void importPermissionConstellation(MetaStorage storage, Role[] roles,  RequiredUser[] rUsers) {
 
 		for (Role role : roles) {
 			storage.addRole(role);
@@ -41,7 +41,7 @@ public class IntegrationUtils {
 	}
 
 
-	public static void clearAuthStorage(MasterMetaStorage storage, Role[] roles, RequiredUser[] rUsers) {
+	public static void clearAuthStorage(MetaStorage storage, Role[] roles, RequiredUser[] rUsers) {
 		// Clear MasterStorage
 		for (Role mandator : roles) {
 			storage.removeRole(mandator.getId());

--- a/backend/src/test/java/com/bakdata/conquery/integration/common/LoadingUtil.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/common/LoadingUtil.java
@@ -59,7 +59,7 @@ public class LoadingUtil {
 			ConceptQuery q = new ConceptQuery(new CQExternal(Arrays.asList(FormatColumn.ID, FormatColumn.DATE_SET), data)).resolve(new QueryResolveContext(support.getDataset().getId(), support.getNamespace().getNamespaces()));
 
 			ManagedExecution<?> managed = ExecutionManager.createQuery(support.getNamespace().getNamespaces(),q, queryId, user.getId(), support.getNamespace().getDataset().getId());
-			user.addPermission(support.getMasterMetaStorage(), QueryPermission.onInstance(AbilitySets.QUERY_CREATOR, managed.getId()));
+			user.addPermission(support.getMetaStorage(), QueryPermission.onInstance(AbilitySets.QUERY_CREATOR, managed.getId()));
 			managed.awaitDone(1, TimeUnit.DAYS);
 
 			if (managed.getState() == ExecutionState.FAILED) {

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/AbstractQueryEngineTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/AbstractQueryEngineTest.java
@@ -24,7 +24,7 @@ import com.bakdata.conquery.models.query.QueryToCSVRenderer;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfoCollector;
 import com.bakdata.conquery.models.query.results.ContainedEntityResult;
 import com.bakdata.conquery.models.query.results.MultilineContainedEntityResult;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.util.support.StandaloneSupport;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.github.powerlibraries.io.In;
@@ -43,7 +43,7 @@ public abstract class AbstractQueryEngineTest extends ConqueryTestSpec {
 
 	@Override
 	public void executeTest(StandaloneSupport standaloneSupport) throws IOException, JSONException {
-		Namespaces namespaces = standaloneSupport.getNamespace().getNamespaces();
+		DatasetRegistry namespaces = standaloneSupport.getNamespace().getNamespaces();
 		MetaStorage storage = standaloneSupport.getNamespace().getStorage().getMetaStorage();
 		UserId userId = standaloneSupport.getTestUser().getId();
 		DatasetId dataset = standaloneSupport.getNamespace().getDataset().getId();

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/AbstractQueryEngineTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/AbstractQueryEngineTest.java
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import com.bakdata.conquery.integration.common.ResourceFile;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.exceptions.JSONException;
 import com.bakdata.conquery.models.execution.ExecutionState;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
@@ -44,7 +44,7 @@ public abstract class AbstractQueryEngineTest extends ConqueryTestSpec {
 	@Override
 	public void executeTest(StandaloneSupport standaloneSupport) throws IOException, JSONException {
 		Namespaces namespaces = standaloneSupport.getNamespace().getNamespaces();
-		MasterMetaStorage storage = standaloneSupport.getNamespace().getStorage().getMetaStorage();
+		MetaStorage storage = standaloneSupport.getNamespace().getStorage().getMetaStorage();
 		UserId userId = standaloneSupport.getTestUser().getId();
 		DatasetId dataset = standaloneSupport.getNamespace().getDataset().getId();
 		

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/FormTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/FormTest.java
@@ -34,7 +34,7 @@ import com.bakdata.conquery.models.query.ManagedQuery;
 import com.bakdata.conquery.models.query.PrintSettings;
 import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.QueryToCSVRenderer;
-import com.bakdata.conquery.models.worker.Namespaces;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.util.support.StandaloneSupport;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -104,7 +104,7 @@ public class FormTest extends ConqueryTestSpec {
 
 	@Override
 	public void executeTest(StandaloneSupport support) throws Exception {
-		Namespaces namespaces = support.getNamespace().getNamespaces();
+		DatasetRegistry namespaces = support.getNamespace().getNamespaces();
 		UserId userId = support.getTestUser().getId();
 		DatasetId dataset = support.getNamespace().getDataset().getId();
 		

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/JsonIntegrationTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/JsonIntegrationTest.java
@@ -35,8 +35,8 @@ public class JsonIntegrationTest extends IntegrationTest.Simple {
 		test.importRequiredData(conquery);
 
 		//ensure the metadata is collected
-		for(ShardNode slave : conquery.getShardNodes()) {
-			slave.getWorkers().getWorkers().values().forEach(worker -> {
+		for(ShardNode node : conquery.getShardNodes()) {
+			node.getWorkers().getWorkers().values().forEach(worker -> {
 				worker.getJobManager().addSlowJob(new UpdateMatchingStats(worker));
 			});
 		}

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/JsonIntegrationTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/JsonIntegrationTest.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 
 import javax.validation.Validator;
 
-import com.bakdata.conquery.commands.SlaveCommand;
+import com.bakdata.conquery.commands.ShardNode;
 import com.bakdata.conquery.integration.IntegrationTest;
 import com.bakdata.conquery.io.jackson.Jackson;
 import com.bakdata.conquery.models.datasets.Dataset;
@@ -35,7 +35,7 @@ public class JsonIntegrationTest extends IntegrationTest.Simple {
 		test.importRequiredData(conquery);
 
 		//ensure the metadata is collected
-		for(SlaveCommand slave : conquery.getSlaves()) {
+		for(ShardNode slave : conquery.getShardNodes()) {
 			slave.getWorkers().getWorkers().values().forEach(worker -> {
 				worker.getJobManager().addSlowJob(new UpdateMatchingStats(worker));
 			});

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/auth/PermissionStorageSerializationTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/auth/PermissionStorageSerializationTest.java
@@ -53,7 +53,7 @@ public class PermissionStorageSerializationTest extends ConqueryTestSpec {
 	public void importRequiredData(StandaloneSupport support) throws Exception {
 		Validator validator = support.getValidator();
 		StorageConfig config = support.getConfig().getStorage();
-		CentralRegistry registry = support.getMasterMetaStorage().getCentralRegistry();
+		CentralRegistry registry = support.getMetaStorage().getCentralRegistry();
 		directory = new File(config.getDirectory(), STORE_SUFFIX);
 		directory.deleteOnExit();
 		Environment env = Environments.newInstance(directory, config.getXodus().createConfig());

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/AdminEndpointTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/AdminEndpointTest.java
@@ -8,7 +8,6 @@ import java.util.List;
 import com.bakdata.conquery.integration.tests.EndpointTestHelper.EndPoint;
 import com.bakdata.conquery.util.support.TestConquery;
 import com.github.powerlibraries.io.In;
-
 import io.dropwizard.jersey.DropwizardResourceConfig;
 
 /**
@@ -21,7 +20,7 @@ public class AdminEndpointTest implements ProgrammaticIntegrationTest {
 	public void execute(String name, TestConquery testConquery) throws Exception {
 		List<EndPoint> expectedEndpoints = READER.readValue(In.resource("/tests/endpoints/adminEndpointInfo.json").asStream());
 
-		DropwizardResourceConfig jerseyConfig = testConquery.getStandaloneCommand().getMaster().getAdmin().getJerseyConfig();
+		DropwizardResourceConfig jerseyConfig = testConquery.getStandaloneCommand().getManager().getAdmin().getJerseyConfig();
 
 		List<EndPoint> resources = EndpointTestHelper.collectEndpoints(jerseyConfig);
 

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/ConceptPermissionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/ConceptPermissionTest.java
@@ -13,7 +13,7 @@ import com.bakdata.conquery.integration.common.IntegrationUtils;
 import com.bakdata.conquery.integration.common.LoadingUtil;
 import com.bakdata.conquery.integration.json.JsonIntegrationTest;
 import com.bakdata.conquery.integration.json.QueryTest;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.auth.permissions.Ability;
 import com.bakdata.conquery.models.auth.permissions.ConceptPermission;
@@ -33,7 +33,7 @@ public class ConceptPermissionTest extends IntegrationTest.Simple implements Pro
 
 	@Override
 	public void execute(StandaloneSupport conquery) throws Exception {
-		final MasterMetaStorage storage = conquery.getMasterMetaStorage();
+		final MetaStorage storage = conquery.getMetaStorage();
 		final Dataset dataset = conquery.getDataset();
 		final String testJson = In.resource("/tests/query/SIMPLE_TREECONCEPT_QUERY/SIMPLE_TREECONCEPT_Query.test.json").withUTF8().readAll();
 		final QueryTest test = (QueryTest) JsonIntegrationTest.readJson(dataset.getId(), testJson);
@@ -82,7 +82,7 @@ public class ConceptPermissionTest extends IntegrationTest.Simple implements Pro
 		}
 	}
 	
-	public static void executeAndWaitUntilFinish(QueryProcessor processor, Dataset dataset, QueryDescription query, User user, MasterMetaStorage storage ) {
+	public static void executeAndWaitUntilFinish(QueryProcessor processor, Dataset dataset, QueryDescription query, User user, MetaStorage storage ) {
 		ExecutionStatus status = processor.postQuery(dataset, query, null, user);
 		Objects.requireNonNull(storage.getExecution(status.getId()), "Execution was not found in storage, even though it was startet")
 			.awaitDone(2, TimeUnit.MINUTES);

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/ConceptPermissionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/ConceptPermissionTest.java
@@ -38,7 +38,7 @@ public class ConceptPermissionTest extends IntegrationTest.Simple implements Pro
 		final String testJson = In.resource("/tests/query/SIMPLE_TREECONCEPT_QUERY/SIMPLE_TREECONCEPT_Query.test.json").withUTF8().readAll();
 		final QueryTest test = (QueryTest) JsonIntegrationTest.readJson(dataset.getId(), testJson);
 		final IQuery query = IntegrationUtils.parseQuery(conquery, test.getRawQuery());
-		final QueryProcessor processor = new QueryProcessor(storage.getNamespaces(), storage);
+		final QueryProcessor processor = new QueryProcessor(storage.getDatasetRegistry(), storage);
 		final User user  = new User("testUser", "testUserLabel");
 
 		// Manually import data, so we can do our own work.

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/GroupHandlingTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/GroupHandlingTest.java
@@ -3,7 +3,7 @@ package com.bakdata.conquery.integration.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.bakdata.conquery.integration.IntegrationTest;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.Group;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.util.support.StandaloneSupport;
@@ -22,7 +22,7 @@ public class GroupHandlingTest extends IntegrationTest.Simple implements Program
 
 	@Override
 	public void execute(StandaloneSupport conquery) throws Exception {
-		MasterMetaStorage storage = conquery.getMasterMetaStorage();
+		MetaStorage storage = conquery.getMetaStorage();
 		
 		try {
 			storage.addGroup(group1);

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/PermissionGroupHandlingTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/PermissionGroupHandlingTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.UUID;
 
 import com.bakdata.conquery.integration.IntegrationTest;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.Group;
 import com.bakdata.conquery.models.auth.entities.Role;
 import com.bakdata.conquery.models.auth.entities.User;
@@ -27,7 +27,7 @@ public class PermissionGroupHandlingTest extends IntegrationTest.Simple implemen
 	 */
 	@Override
 	public void execute(StandaloneSupport conquery) throws Exception {
-		MasterMetaStorage storage = conquery.getMasterMetaStorage();
+		MetaStorage storage = conquery.getMetaStorage();
 		Dataset dataset1 = new Dataset();
 		dataset1.setLabel("dataset1");
 		ManagedExecutionId query1 = new ManagedExecutionId(dataset1.getId(), UUID.randomUUID());

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/PermissionRoleHandlingTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/PermissionRoleHandlingTest.java
@@ -3,7 +3,7 @@ package com.bakdata.conquery.integration.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.bakdata.conquery.integration.IntegrationTest;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.Role;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.auth.permissions.Ability;
@@ -22,7 +22,7 @@ public class PermissionRoleHandlingTest extends IntegrationTest.Simple implement
 	 */
 	@Override
 	public void execute(StandaloneSupport conquery) throws Exception {
-		MasterMetaStorage storage = conquery.getMasterMetaStorage();
+		MetaStorage storage = conquery.getMetaStorage();
 		Dataset dataset1 = new Dataset();
 		dataset1.setLabel("dataset1");
 		

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/RestartTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/RestartTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.validation.Validator;
 
-import com.bakdata.conquery.commands.MasterCommand;
+import com.bakdata.conquery.commands.ManagerNode;
 import com.bakdata.conquery.integration.json.ConqueryTestSpec;
 import com.bakdata.conquery.integration.json.JsonIntegrationTest;
 import com.bakdata.conquery.io.xodus.MasterMetaStorage;
@@ -47,15 +47,15 @@ public class RestartTest implements ProgrammaticIntegrationTest {
 		PersistentIdMap persistentIdMap = IdMapSerialisationTest
 												  .createTestPersistentMap();
 
-		MasterCommand master = testConquery.getStandaloneCommand().getMaster();
+		ManagerNode manager = testConquery.getStandaloneCommand().getManager();
 		AdminProcessor adminProcessor = new AdminProcessor(
 
-				master.getConfig(),
-				master.getStorage(),
-				master.getNamespaces(),
-				master.getJobManager(),
-				master.getMaintenanceService(),
-				master.getValidator()
+				manager.getConfig(),
+				manager.getStorage(),
+				manager.getNamespaces(),
+				manager.getJobManager(),
+				manager.getMaintenanceService(),
+				manager.getValidator()
 		);
 
 

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/RestartTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/RestartTest.java
@@ -52,7 +52,7 @@ public class RestartTest implements ProgrammaticIntegrationTest {
 
 				manager.getConfig(),
 				manager.getStorage(),
-				manager.getNamespaces(),
+				manager.getDatasetRegistry(),
 				manager.getJobManager(),
 				manager.getMaintenanceService(),
 				manager.getValidator()

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/RestartTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/RestartTest.java
@@ -7,7 +7,7 @@ import javax.validation.Validator;
 import com.bakdata.conquery.commands.ManagerNode;
 import com.bakdata.conquery.integration.json.ConqueryTestSpec;
 import com.bakdata.conquery.integration.json.JsonIntegrationTest;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.io.xodus.NamespaceStorage;
 import com.bakdata.conquery.models.auth.entities.Group;
 import com.bakdata.conquery.models.auth.entities.Role;
@@ -131,7 +131,7 @@ public class RestartTest implements ProgrammaticIntegrationTest {
 
 		assertThat(entityBucketSizeBeforeRestart).isEqualTo(ConqueryConfig.getInstance().getCluster().getEntityBucketSize());
 
-		MasterMetaStorage storage = conquery.getMasterMetaStorage();
+		MetaStorage storage = conquery.getMetaStorage();
 
 		{// Auth actual tests
 			User userStored = storage.getUser(user.getId());

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/RoleHandlingOnGroupTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/RoleHandlingOnGroupTest.java
@@ -3,7 +3,7 @@ package com.bakdata.conquery.integration.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.bakdata.conquery.integration.IntegrationTest;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.Group;
 import com.bakdata.conquery.models.auth.entities.Role;
 import com.bakdata.conquery.models.auth.entities.User;
@@ -28,7 +28,7 @@ public class RoleHandlingOnGroupTest extends IntegrationTest.Simple implements P
 	public void execute(StandaloneSupport conquery) throws Exception {
 		Dataset dataset1 = new Dataset();
 		dataset1.setLabel("dataset1");
-		MasterMetaStorage storage = conquery.getMasterMetaStorage();
+		MetaStorage storage = conquery.getMetaStorage();
 		
 		try {
 			storage.addRole(role);

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/RoleHandlingTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/RoleHandlingTest.java
@@ -3,7 +3,7 @@ package com.bakdata.conquery.integration.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.bakdata.conquery.integration.IntegrationTest;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.Role;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.datasets.Dataset;
@@ -25,7 +25,7 @@ public class RoleHandlingTest extends IntegrationTest.Simple implements Programm
 	public void execute(StandaloneSupport conquery) throws Exception {
 		Dataset dataset1 = new Dataset();
 		dataset1.setLabel("dataset1");
-		MasterMetaStorage storage = conquery.getMasterMetaStorage();
+		MetaStorage storage = conquery.getMetaStorage();
 		
 		try {
 			storage.addRole(mandator1);

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/RoleUITest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/RoleUITest.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import javax.ws.rs.core.Response;
 
 import com.bakdata.conquery.integration.IntegrationTest;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.Role;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.auth.permissions.Ability;
@@ -32,7 +32,7 @@ import com.bakdata.conquery.util.support.StandaloneSupport;
 public class RoleUITest extends IntegrationTest.Simple implements ProgrammaticIntegrationTest {
 
 
-	private MasterMetaStorage storage;
+	private MetaStorage storage;
 	private Role mandator = new Role("testMandatorName", "testMandatorLabel");
 	private RoleId mandatorId = mandator.getId();
 	private User user = new User("testUser@test.de", "testUserName");
@@ -43,7 +43,7 @@ public class RoleUITest extends IntegrationTest.Simple implements ProgrammaticIn
 	public void execute(StandaloneSupport conquery) throws Exception {
 		try {
 	
-			storage = conquery.getMasterMetaStorage();
+			storage = conquery.getMetaStorage();
 			storage.addRole(mandator);
 			storage.addUser(user);
 			// override permission object, because it might have changed by the subject

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/SuperPermissionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/SuperPermissionTest.java
@@ -3,7 +3,7 @@ package com.bakdata.conquery.integration.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.bakdata.conquery.integration.IntegrationTest;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.Role;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.auth.permissions.Ability;
@@ -22,7 +22,7 @@ public class SuperPermissionTest extends IntegrationTest.Simple implements Progr
 	public void execute(StandaloneSupport conquery) throws Exception {
 		Dataset dataset1 = new Dataset();
 		dataset1.setLabel("dataset1");
-		MasterMetaStorage storage = conquery.getMasterMetaStorage();
+		MetaStorage storage = conquery.getMetaStorage();
 		
 		try {
 			user1.addRole(storage, mandator1);

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/ConceptUpdateAndDeletionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/ConceptUpdateAndDeletionTest.java
@@ -22,8 +22,8 @@ import com.bakdata.conquery.models.messages.namespaces.specific.RemoveConcept;
 import com.bakdata.conquery.models.query.ExecutionManager;
 import com.bakdata.conquery.models.query.IQuery;
 import com.bakdata.conquery.models.query.ManagedQuery;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.models.worker.Namespace;
-import com.bakdata.conquery.models.worker.Namespaces;
 import com.bakdata.conquery.models.worker.Worker;
 import com.bakdata.conquery.models.worker.WorkerInformation;
 import com.bakdata.conquery.util.support.StandaloneSupport;
@@ -51,7 +51,7 @@ public class ConceptUpdateAndDeletionTest implements ProgrammaticIntegrationTest
 		final String testJson2 = In.resource("/tests/query/UPDATE_CONCEPT_TESTS/SIMPLE_TREECONCEPT_2_Query.json").withUTF8().readAll();
 
 		final Dataset dataset = conquery.getDataset();
-		final Namespace namespace = storage.getNamespaces().get(dataset.getId());
+		final Namespace namespace = storage.getDatasetRegistry().get(dataset.getId());
 
 		final ConceptId conceptId = ConceptId.Parser.INSTANCE.parse(dataset.getName(), "test_tree");
 
@@ -255,7 +255,7 @@ public class ConceptUpdateAndDeletionTest implements ProgrammaticIntegrationTest
 	 * Send a query onto the conquery instance and assert the result's size.
 	 */
 	public static void assertQueryResult(StandaloneSupport conquery, IQuery query, long size, ExecutionState state) {
-		Namespaces namespaces = conquery.getNamespace().getNamespaces();
+		DatasetRegistry namespaces = conquery.getNamespace().getNamespaces();
 		MetaStorage storage = conquery.getNamespace().getStorage().getMetaStorage();
 		UserId userId = conquery.getTestUser().getId();
 		DatasetId dataset = conquery.getNamespace().getDataset().getId();

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/ConceptUpdateAndDeletionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/ConceptUpdateAndDeletionTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.TimeUnit;
 
-import com.bakdata.conquery.commands.SlaveCommand;
+import com.bakdata.conquery.commands.ShardNode;
 import com.bakdata.conquery.integration.common.IntegrationUtils;
 import com.bakdata.conquery.integration.common.LoadingUtil;
 import com.bakdata.conquery.integration.json.JsonIntegrationTest;
@@ -87,7 +87,7 @@ public class ConceptUpdateAndDeletionTest implements ProgrammaticIntegrationTest
 			assertThat(namespace.getStorage().getCentralRegistry().getOptional(conceptId))
 					.isNotEmpty();
 
-			for (SlaveCommand slave : conquery.getSlaves()) {
+			for (ShardNode slave : conquery.getShardNodes()) {
 				for (Worker value : slave.getWorkers().getWorkers().values()) {
 					if (!value.getInfo().getDataset().equals(dataset)) {
 						continue;
@@ -136,7 +136,7 @@ public class ConceptUpdateAndDeletionTest implements ProgrammaticIntegrationTest
 			assertThat(namespace.getStorage().getCentralRegistry().getOptional(conceptId))
 					.isEmpty();
 
-			for (SlaveCommand slave : conquery.getSlaves()) {
+			for (ShardNode slave : conquery.getShardNodes()) {
 				for (Worker value : slave.getWorkers().getWorkers().values()) {
 					if (!value.getInfo().getDataset().equals(dataset)) {
 						continue;
@@ -182,7 +182,7 @@ public class ConceptUpdateAndDeletionTest implements ProgrammaticIntegrationTest
 			assertThat(namespace.getStorage().getCentralRegistry().getOptional(conceptId))
 					.isNotEmpty();
 
-			for (SlaveCommand slave : conquery.getSlaves()) {
+			for (ShardNode slave : conquery.getShardNodes()) {
 				for (Worker value : slave.getWorkers().getWorkers().values()) {
 					if (!value.getInfo().getDataset().equals(dataset)) {
 						continue;
@@ -226,7 +226,7 @@ public class ConceptUpdateAndDeletionTest implements ProgrammaticIntegrationTest
 				assertThat(namespace.getStorage().getCentralRegistry().getOptional(conceptId))
 						.isNotEmpty();
 
-				for (SlaveCommand slave : conquery2.getSlaves()) {
+				for (ShardNode slave : conquery2.getShardNodes()) {
 					for (Worker value : slave.getWorkers().getWorkers().values()) {
 						if (!value.getInfo().getDataset().equals(dataset)) {
 							continue;

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/ConceptUpdateAndDeletionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/ConceptUpdateAndDeletionTest.java
@@ -87,9 +87,9 @@ public class ConceptUpdateAndDeletionTest implements ProgrammaticIntegrationTest
 			assertThat(namespace.getStorage().getCentralRegistry().getOptional(conceptId))
 					.isNotEmpty();
 
-			for (ShardNode slave : conquery.getShardNodes()) {
-				for (Worker value : slave.getWorkers().getWorkers().values()) {
-					if (!value.getInfo().getDataset().equals(dataset)) {
+			for (ShardNode node : conquery.getShardNodes()) {
+				for (Worker value : node.getWorkers().getWorkers().values()) {
+					if (!value.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
 					}
 
@@ -136,9 +136,9 @@ public class ConceptUpdateAndDeletionTest implements ProgrammaticIntegrationTest
 			assertThat(namespace.getStorage().getCentralRegistry().getOptional(conceptId))
 					.isEmpty();
 
-			for (ShardNode slave : conquery.getShardNodes()) {
-				for (Worker value : slave.getWorkers().getWorkers().values()) {
-					if (!value.getInfo().getDataset().equals(dataset)) {
+			for (ShardNode node : conquery.getShardNodes()) {
+				for (Worker value : node.getWorkers().getWorkers().values()) {
+					if (!value.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
 					}
 
@@ -182,9 +182,9 @@ public class ConceptUpdateAndDeletionTest implements ProgrammaticIntegrationTest
 			assertThat(namespace.getStorage().getCentralRegistry().getOptional(conceptId))
 					.isNotEmpty();
 
-			for (ShardNode slave : conquery.getShardNodes()) {
-				for (Worker value : slave.getWorkers().getWorkers().values()) {
-					if (!value.getInfo().getDataset().equals(dataset)) {
+			for (ShardNode node : conquery.getShardNodes()) {
+				for (Worker value : node.getWorkers().getWorkers().values()) {
+					if (!value.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
 					}
 
@@ -226,9 +226,9 @@ public class ConceptUpdateAndDeletionTest implements ProgrammaticIntegrationTest
 				assertThat(namespace.getStorage().getCentralRegistry().getOptional(conceptId))
 						.isNotEmpty();
 
-				for (ShardNode slave : conquery2.getShardNodes()) {
-					for (Worker value : slave.getWorkers().getWorkers().values()) {
-						if (!value.getInfo().getDataset().equals(dataset)) {
+				for (ShardNode node : conquery2.getShardNodes()) {
+					for (Worker value : node.getWorkers().getWorkers().values()) {
+						if (!value.getInfo().getDataset().equals(dataset.getId())) {
 							continue;
 						}
 

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/ConceptUpdateAndDeletionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/ConceptUpdateAndDeletionTest.java
@@ -10,7 +10,7 @@ import com.bakdata.conquery.integration.common.LoadingUtil;
 import com.bakdata.conquery.integration.json.JsonIntegrationTest;
 import com.bakdata.conquery.integration.json.QueryTest;
 import com.bakdata.conquery.integration.tests.ProgrammaticIntegrationTest;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.io.xodus.WorkerStorage;
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.exceptions.ValidatorHelper;
@@ -44,7 +44,7 @@ public class ConceptUpdateAndDeletionTest implements ProgrammaticIntegrationTest
 
 		final StandaloneSupport conquery = testConquery.getSupport(name);
 
-		final MasterMetaStorage storage = conquery.getMasterMetaStorage();
+		final MetaStorage storage = conquery.getMetaStorage();
 
 		// Read two JSONs with different Trees
 		final String testJson = In.resource("/tests/query/UPDATE_CONCEPT_TESTS/SIMPLE_TREECONCEPT_Query.json").withUTF8().readAll();
@@ -256,7 +256,7 @@ public class ConceptUpdateAndDeletionTest implements ProgrammaticIntegrationTest
 	 */
 	public static void assertQueryResult(StandaloneSupport conquery, IQuery query, long size, ExecutionState state) {
 		Namespaces namespaces = conquery.getNamespace().getNamespaces();
-		MasterMetaStorage storage = conquery.getNamespace().getStorage().getMetaStorage();
+		MetaStorage storage = conquery.getNamespace().getStorage().getMetaStorage();
 		UserId userId = conquery.getTestUser().getId();
 		DatasetId dataset = conquery.getNamespace().getDataset().getId();
 		

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/DatasetDeletionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/DatasetDeletionTest.java
@@ -11,7 +11,7 @@ import com.bakdata.conquery.integration.json.JsonIntegrationTest;
 import com.bakdata.conquery.integration.json.QueryTest;
 import com.bakdata.conquery.integration.tests.ProgrammaticIntegrationTest;
 import com.bakdata.conquery.io.jackson.Jackson;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.io.xodus.WorkerStorage;
 import com.bakdata.conquery.models.concepts.Concept;
 import com.bakdata.conquery.models.datasets.Dataset;
@@ -39,7 +39,7 @@ public class DatasetDeletionTest implements ProgrammaticIntegrationTest {
 	public void execute(String name, TestConquery testConquery) throws Exception {
 
 		StandaloneSupport conquery = testConquery.getSupport(name);
-		final MasterMetaStorage storage = conquery.getMasterMetaStorage();
+		final MetaStorage storage = conquery.getMetaStorage();
 		final Dataset dataset = conquery.getDataset();
 		Namespace namespace = storage.getNamespaces().get(dataset.getId());
 		final String testJson = In.resource("/tests/query/DELETE_IMPORT_TESTS/SIMPLE_TREECONCEPT_Query.test.json").withUTF8().readAll();

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/DatasetDeletionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/DatasetDeletionTest.java
@@ -41,7 +41,7 @@ public class DatasetDeletionTest implements ProgrammaticIntegrationTest {
 		StandaloneSupport conquery = testConquery.getSupport(name);
 		final MetaStorage storage = conquery.getMetaStorage();
 		final Dataset dataset = conquery.getDataset();
-		Namespace namespace = storage.getNamespaces().get(dataset.getId());
+		Namespace namespace = storage.getDatasetRegistry().get(dataset.getId());
 		final String testJson = In.resource("/tests/query/DELETE_IMPORT_TESTS/SIMPLE_TREECONCEPT_Query.test.json").withUTF8().readAll();
 		final QueryTest test = (QueryTest) JsonIntegrationTest.readJson(dataset, testJson);
 		final IQuery query = IntegrationUtils.parseQuery(conquery, test.getRawQuery());
@@ -179,7 +179,7 @@ public class DatasetDeletionTest implements ProgrammaticIntegrationTest {
 			final StandaloneSupport conquery2 =
 					new StandaloneSupport(
 							testConquery,
-							storage.getNamespaces()
+							storage.getDatasetRegistry()
 								   .get(dataset.getId()),
 							newDataset,
 							conquery.getTmpDir(),
@@ -189,7 +189,7 @@ public class DatasetDeletionTest implements ProgrammaticIntegrationTest {
 					);
 
 
-			namespace = storage.getNamespaces().get(dataset.getId());
+			namespace = storage.getDatasetRegistry().get(dataset.getId());
 
 			// only import the deleted import/table
 			for (RequiredTable table : test.getContent().getTables()) {
@@ -206,7 +206,7 @@ public class DatasetDeletionTest implements ProgrammaticIntegrationTest {
 			LoadingUtil.importConcepts(conquery2, test.getRawConcepts());
 			conquery.waitUntilWorkDone();
 
-			assertThat(conquery2.getDatasetsProcessor().getNamespaces().get(dataset.getId()))
+			assertThat(conquery2.getDatasetsProcessor().getDatasetRegistry().get(dataset.getId()))
 					.describedAs("Dataset after re-import.")
 					.isNotNull();
 

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/DatasetDeletionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/DatasetDeletionTest.java
@@ -3,7 +3,7 @@ package com.bakdata.conquery.integration.tests.deletion;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.bakdata.conquery.commands.SlaveCommand;
+import com.bakdata.conquery.commands.ShardNode;
 import com.bakdata.conquery.integration.common.IntegrationUtils;
 import com.bakdata.conquery.integration.common.LoadingUtil;
 import com.bakdata.conquery.integration.common.RequiredTable;
@@ -71,7 +71,7 @@ public class DatasetDeletionTest implements ProgrammaticIntegrationTest {
 			assertThat(namespace.getStorage().getCentralRegistry().getOptional(dataset.getId()))
 					.isNotEmpty();
 
-			for (SlaveCommand slave : conquery.getSlaves()) {
+			for (ShardNode slave : conquery.getShardNodes()) {
 				for (Worker value : slave.getWorkers().getWorkers().values()) {
 					if (!value.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
@@ -136,7 +136,7 @@ public class DatasetDeletionTest implements ProgrammaticIntegrationTest {
 					.filteredOn(imp -> imp.getId().getTable().getDataset().equals(dataset.getId()))
 					.isEmpty();
 
-			for (SlaveCommand slave : conquery.getSlaves()) {
+			for (ShardNode slave : conquery.getShardNodes()) {
 				for (Worker value : slave.getWorkers().getWorkers().values()) {
 					if (!value.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
@@ -212,10 +212,10 @@ public class DatasetDeletionTest implements ProgrammaticIntegrationTest {
 
 			assertThat(namespace.getStorage().getAllImports().size()).isEqualTo(nImports);
 
-			for (SlaveCommand slave : conquery.getSlaves()) {
+			for (ShardNode slave : conquery.getShardNodes()) {
 				assertThat(slave.getWorkers().getWorkers().values())
 						.filteredOn(w -> w.getInfo().getDataset().equals(dataset.getId()))
-						.describedAs("Workers for slave {}", slave.getLabel())
+						.describedAs("Workers for slave {}", slave.getName())
 						.isNotEmpty();
 			}
 
@@ -238,7 +238,7 @@ public class DatasetDeletionTest implements ProgrammaticIntegrationTest {
 
 				assertThat(namespace.getStorage().getAllImports().size()).isEqualTo(2);
 
-				for (SlaveCommand slave : conquery2.getSlaves()) {
+				for (ShardNode slave : conquery2.getShardNodes()) {
 					for (Worker value : slave.getWorkers().getWorkers().values()) {
 						if (!value.getInfo().getDataset().equals(dataset.getId())) {
 							continue;

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/DatasetDeletionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/DatasetDeletionTest.java
@@ -71,8 +71,8 @@ public class DatasetDeletionTest implements ProgrammaticIntegrationTest {
 			assertThat(namespace.getStorage().getCentralRegistry().getOptional(dataset.getId()))
 					.isNotEmpty();
 
-			for (ShardNode slave : conquery.getShardNodes()) {
-				for (Worker value : slave.getWorkers().getWorkers().values()) {
+			for (ShardNode node : conquery.getShardNodes()) {
+				for (Worker value : node.getWorkers().getWorkers().values()) {
 					if (!value.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
 					}
@@ -136,8 +136,8 @@ public class DatasetDeletionTest implements ProgrammaticIntegrationTest {
 					.filteredOn(imp -> imp.getId().getTable().getDataset().equals(dataset.getId()))
 					.isEmpty();
 
-			for (ShardNode slave : conquery.getShardNodes()) {
-				for (Worker value : slave.getWorkers().getWorkers().values()) {
+			for (ShardNode node : conquery.getShardNodes()) {
+				for (Worker value : node.getWorkers().getWorkers().values()) {
 					if (!value.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
 					}
@@ -212,10 +212,10 @@ public class DatasetDeletionTest implements ProgrammaticIntegrationTest {
 
 			assertThat(namespace.getStorage().getAllImports().size()).isEqualTo(nImports);
 
-			for (ShardNode slave : conquery.getShardNodes()) {
-				assertThat(slave.getWorkers().getWorkers().values())
+			for (ShardNode node : conquery.getShardNodes()) {
+				assertThat(node.getWorkers().getWorkers().values())
 						.filteredOn(w -> w.getInfo().getDataset().equals(dataset.getId()))
-						.describedAs("Workers for slave {}", slave.getName())
+						.describedAs("Workers for node {}", node.getName())
 						.isNotEmpty();
 			}
 
@@ -238,8 +238,8 @@ public class DatasetDeletionTest implements ProgrammaticIntegrationTest {
 
 				assertThat(namespace.getStorage().getAllImports().size()).isEqualTo(2);
 
-				for (ShardNode slave : conquery2.getShardNodes()) {
-					for (Worker value : slave.getWorkers().getWorkers().values()) {
+				for (ShardNode node : conquery2.getShardNodes()) {
+					for (Worker value : node.getWorkers().getWorkers().values()) {
 						if (!value.getInfo().getDataset().equals(dataset.getId())) {
 							continue;
 						}

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/ImportDeletionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/ImportDeletionTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 
-import com.bakdata.conquery.commands.SlaveCommand;
+import com.bakdata.conquery.commands.ShardNode;
 import com.bakdata.conquery.integration.common.IntegrationUtils;
 import com.bakdata.conquery.integration.common.LoadingUtil;
 import com.bakdata.conquery.integration.common.RequiredTable;
@@ -84,7 +84,7 @@ public class ImportDeletionTest implements ProgrammaticIntegrationTest {
 			assertThat(namespace.getStorage().getCentralRegistry().getOptional(importId))
 					.isNotEmpty();
 
-			for (SlaveCommand slave : conquery.getSlaves()) {
+			for (ShardNode slave : conquery.getShardNodes()) {
 				for (Worker worker : slave.getWorkers().getWorkers().values()) {
 					if (!worker.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
@@ -130,7 +130,7 @@ public class ImportDeletionTest implements ProgrammaticIntegrationTest {
 					.filteredOn(imp -> imp.getId().equals(importId))
 					.isEmpty();
 
-			for (SlaveCommand slave : conquery.getSlaves()) {
+			for (ShardNode slave : conquery.getShardNodes()) {
 				for (Worker worker : slave.getWorkers().getWorkers().values()) {
 					if (!worker.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
@@ -209,7 +209,7 @@ public class ImportDeletionTest implements ProgrammaticIntegrationTest {
 
 			assertThat(namespace.getStorage().getAllImports().size()).isEqualTo(nImports);
 
-			for (SlaveCommand slave : conquery.getSlaves()) {
+			for (ShardNode slave : conquery.getShardNodes()) {
 				for (Worker worker : slave.getWorkers().getWorkers().values()) {
 					if (!worker.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
@@ -245,7 +245,7 @@ public class ImportDeletionTest implements ProgrammaticIntegrationTest {
 			{
 				assertThat(namespace.getStorage().getAllImports().size()).isEqualTo(2);
 
-				for (SlaveCommand slave : conquery2.getSlaves()) {
+				for (ShardNode slave : conquery2.getShardNodes()) {
 					for (Worker worker : slave.getWorkers().getWorkers().values()) {
 
 						if (!worker.getInfo().getDataset().equals(dataset.getId()))

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/ImportDeletionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/ImportDeletionTest.java
@@ -84,8 +84,8 @@ public class ImportDeletionTest implements ProgrammaticIntegrationTest {
 			assertThat(namespace.getStorage().getCentralRegistry().getOptional(importId))
 					.isNotEmpty();
 
-			for (ShardNode slave : conquery.getShardNodes()) {
-				for (Worker worker : slave.getWorkers().getWorkers().values()) {
+			for (ShardNode node : conquery.getShardNodes()) {
+				for (Worker worker : node.getWorkers().getWorkers().values()) {
 					if (!worker.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
 					}
@@ -130,8 +130,8 @@ public class ImportDeletionTest implements ProgrammaticIntegrationTest {
 					.filteredOn(imp -> imp.getId().equals(importId))
 					.isEmpty();
 
-			for (ShardNode slave : conquery.getShardNodes()) {
-				for (Worker worker : slave.getWorkers().getWorkers().values()) {
+			for (ShardNode node : conquery.getShardNodes()) {
+				for (Worker worker : node.getWorkers().getWorkers().values()) {
 					if (!worker.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
 					}
@@ -209,8 +209,8 @@ public class ImportDeletionTest implements ProgrammaticIntegrationTest {
 
 			assertThat(namespace.getStorage().getAllImports().size()).isEqualTo(nImports);
 
-			for (ShardNode slave : conquery.getShardNodes()) {
-				for (Worker worker : slave.getWorkers().getWorkers().values()) {
+			for (ShardNode node : conquery.getShardNodes()) {
+				for (Worker worker : node.getWorkers().getWorkers().values()) {
 					if (!worker.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
 					}
@@ -245,8 +245,8 @@ public class ImportDeletionTest implements ProgrammaticIntegrationTest {
 			{
 				assertThat(namespace.getStorage().getAllImports().size()).isEqualTo(2);
 
-				for (ShardNode slave : conquery2.getShardNodes()) {
-					for (Worker worker : slave.getWorkers().getWorkers().values()) {
+				for (ShardNode node : conquery2.getShardNodes()) {
+					for (Worker worker : node.getWorkers().getWorkers().values()) {
 
 						if (!worker.getInfo().getDataset().equals(dataset.getId()))
 							continue;

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/ImportDeletionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/ImportDeletionTest.java
@@ -12,7 +12,7 @@ import com.bakdata.conquery.integration.json.JsonIntegrationTest;
 import com.bakdata.conquery.integration.json.QueryTest;
 import com.bakdata.conquery.integration.tests.ProgrammaticIntegrationTest;
 import com.bakdata.conquery.io.jackson.Jackson;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.io.xodus.WorkerStorage;
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.exceptions.ValidatorHelper;
@@ -43,7 +43,7 @@ public class ImportDeletionTest implements ProgrammaticIntegrationTest {
 
 
 		final StandaloneSupport conquery = testConquery.getSupport(name);
-		MasterMetaStorage storage = conquery.getMasterMetaStorage();
+		MetaStorage storage = conquery.getMetaStorage();
 
 		final String testJson = In.resource("/tests/query/DELETE_IMPORT_TESTS/SIMPLE_TREECONCEPT_Query.test.json").withUTF8().readAll();
 

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/ImportDeletionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/ImportDeletionTest.java
@@ -86,7 +86,7 @@ public class ImportDeletionTest implements ProgrammaticIntegrationTest {
 
 			for (SlaveCommand slave : conquery.getSlaves()) {
 				for (Worker worker : slave.getWorkers().getWorkers().values()) {
-					if (!worker.getInfo().getDataset().equals(dataset)) {
+					if (!worker.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
 					}
 
@@ -132,7 +132,7 @@ public class ImportDeletionTest implements ProgrammaticIntegrationTest {
 
 			for (SlaveCommand slave : conquery.getSlaves()) {
 				for (Worker worker : slave.getWorkers().getWorkers().values()) {
-					if (!worker.getInfo().getDataset().equals(dataset)) {
+					if (!worker.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
 					}
 
@@ -211,7 +211,7 @@ public class ImportDeletionTest implements ProgrammaticIntegrationTest {
 
 			for (SlaveCommand slave : conquery.getSlaves()) {
 				for (Worker worker : slave.getWorkers().getWorkers().values()) {
-					if (!worker.getInfo().getDataset().equals(dataset)) {
+					if (!worker.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
 					}
 
@@ -248,7 +248,7 @@ public class ImportDeletionTest implements ProgrammaticIntegrationTest {
 				for (SlaveCommand slave : conquery2.getSlaves()) {
 					for (Worker worker : slave.getWorkers().getWorkers().values()) {
 
-						if (!worker.getInfo().getDataset().equals(dataset))
+						if (!worker.getInfo().getDataset().equals(dataset.getId()))
 							continue;
 
 						final WorkerStorage workerStorage = worker.getStorage();

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/ImportDeletionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/ImportDeletionTest.java
@@ -48,7 +48,7 @@ public class ImportDeletionTest implements ProgrammaticIntegrationTest {
 		final String testJson = In.resource("/tests/query/DELETE_IMPORT_TESTS/SIMPLE_TREECONCEPT_Query.test.json").withUTF8().readAll();
 
 		final Dataset dataset = conquery.getDataset();
-		final Namespace namespace = storage.getNamespaces().get(dataset.getId());
+		final Namespace namespace = storage.getDatasetRegistry().get(dataset.getId());
 
 		final ImportId importId = ImportId.Parser.INSTANCE.parse(dataset.getName(), "test_table2", "test_table2_import");
 

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/TableDeletionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/TableDeletionTest.java
@@ -12,7 +12,7 @@ import com.bakdata.conquery.integration.common.RequiredTable;
 import com.bakdata.conquery.integration.json.JsonIntegrationTest;
 import com.bakdata.conquery.integration.json.QueryTest;
 import com.bakdata.conquery.integration.tests.ProgrammaticIntegrationTest;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.io.xodus.WorkerStorage;
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.exceptions.ValidatorHelper;
@@ -37,7 +37,7 @@ public class TableDeletionTest implements ProgrammaticIntegrationTest {
 
 		final StandaloneSupport conquery = testConquery.getSupport(name);
 
-		final MasterMetaStorage storage = conquery.getMasterMetaStorage();
+		final MetaStorage storage = conquery.getMetaStorage();
 
 		final String testJson = In.resource("/tests/query/DELETE_IMPORT_TESTS/SIMPLE_TREECONCEPT_Query.test.json").withUTF8().readAll();
 

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/TableDeletionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/TableDeletionTest.java
@@ -42,7 +42,7 @@ public class TableDeletionTest implements ProgrammaticIntegrationTest {
 		final String testJson = In.resource("/tests/query/DELETE_IMPORT_TESTS/SIMPLE_TREECONCEPT_Query.test.json").withUTF8().readAll();
 
 		final Dataset dataset = conquery.getDataset();
-		final Namespace namespace = storage.getNamespaces().get(dataset.getId());
+		final Namespace namespace = storage.getDatasetRegistry().get(dataset.getId());
 
 		final TableId tableId = TableId.Parser.INSTANCE.parse(dataset.getName(), "test_table2");
 

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/TableDeletionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/TableDeletionTest.java
@@ -73,8 +73,8 @@ public class TableDeletionTest implements ProgrammaticIntegrationTest {
 			assertThat(namespace.getStorage().getCentralRegistry().getOptional(tableId))
 					.isNotEmpty();
 
-			for (ShardNode slave : conquery.getShardNodes()) {
-				for (Worker value : slave.getWorkers().getWorkers().values()) {
+			for (ShardNode node : conquery.getShardNodes()) {
+				for (Worker value : node.getWorkers().getWorkers().values()) {
 					if (!value.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
 					}
@@ -127,8 +127,8 @@ public class TableDeletionTest implements ProgrammaticIntegrationTest {
 					.filteredOn(imp -> imp.getId().getTable().equals(tableId))
 					.isEmpty();
 
-			for (ShardNode slave : conquery.getShardNodes()) {
-				for (Worker value : slave.getWorkers().getWorkers().values()) {
+			for (ShardNode node : conquery.getShardNodes()) {
+				for (Worker value : node.getWorkers().getWorkers().values()) {
 					if (!value.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
 					}
@@ -177,13 +177,11 @@ public class TableDeletionTest implements ProgrammaticIntegrationTest {
 					.describedAs("Table after re-import.")
 					.isPresent();
 
-			for (ShardNode slave : conquery.getShardNodes()) {
-				for (Worker value : slave.getWorkers().getWorkers().values()) {
+			for (ShardNode node : conquery.getShardNodes()) {
+				for (Worker value : node.getWorkers().getWorkers().values()) {
 					if (!value.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
 					}
-
-					final WorkerStorage workerStorage = value.getStorage();
 
 					assertThat(value.getStorage().getCentralRegistry().resolve(tableId))
 							.describedAs("Table in worker storage.")
@@ -197,8 +195,8 @@ public class TableDeletionTest implements ProgrammaticIntegrationTest {
 			log.info("Checking state after re-import");
 			assertThat(namespace.getStorage().getAllImports().size()).isEqualTo(nImports);
 
-			for (ShardNode slave : conquery.getShardNodes()) {
-				for (Worker value : slave.getWorkers().getWorkers().values()) {
+			for (ShardNode node : conquery.getShardNodes()) {
+				for (Worker value : node.getWorkers().getWorkers().values()) {
 					if (!value.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
 					}
@@ -232,8 +230,8 @@ public class TableDeletionTest implements ProgrammaticIntegrationTest {
 			{
 				assertThat(namespace.getStorage().getAllImports().size()).isEqualTo(2);
 
-				for (ShardNode slave : conquery2.getShardNodes()) {
-					for (Worker value : slave.getWorkers().getWorkers().values()) {
+				for (ShardNode node : conquery2.getShardNodes()) {
+					for (Worker value : node.getWorkers().getWorkers().values()) {
 						if (!value.getInfo().getDataset().equals(dataset.getId())) {
 							continue;
 						}

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/TableDeletionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/TableDeletionTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.stream.Collectors;
 
-import com.bakdata.conquery.commands.SlaveCommand;
+import com.bakdata.conquery.commands.ShardNode;
 import com.bakdata.conquery.integration.common.IntegrationUtils;
 import com.bakdata.conquery.integration.common.LoadingUtil;
 import com.bakdata.conquery.integration.common.RequiredTable;
@@ -73,7 +73,7 @@ public class TableDeletionTest implements ProgrammaticIntegrationTest {
 			assertThat(namespace.getStorage().getCentralRegistry().getOptional(tableId))
 					.isNotEmpty();
 
-			for (SlaveCommand slave : conquery.getSlaves()) {
+			for (ShardNode slave : conquery.getShardNodes()) {
 				for (Worker value : slave.getWorkers().getWorkers().values()) {
 					if (!value.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
@@ -127,7 +127,7 @@ public class TableDeletionTest implements ProgrammaticIntegrationTest {
 					.filteredOn(imp -> imp.getId().getTable().equals(tableId))
 					.isEmpty();
 
-			for (SlaveCommand slave : conquery.getSlaves()) {
+			for (ShardNode slave : conquery.getShardNodes()) {
 				for (Worker value : slave.getWorkers().getWorkers().values()) {
 					if (!value.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
@@ -177,7 +177,7 @@ public class TableDeletionTest implements ProgrammaticIntegrationTest {
 					.describedAs("Table after re-import.")
 					.isPresent();
 
-			for (SlaveCommand slave : conquery.getSlaves()) {
+			for (ShardNode slave : conquery.getShardNodes()) {
 				for (Worker value : slave.getWorkers().getWorkers().values()) {
 					if (!value.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
@@ -197,7 +197,7 @@ public class TableDeletionTest implements ProgrammaticIntegrationTest {
 			log.info("Checking state after re-import");
 			assertThat(namespace.getStorage().getAllImports().size()).isEqualTo(nImports);
 
-			for (SlaveCommand slave : conquery.getSlaves()) {
+			for (ShardNode slave : conquery.getShardNodes()) {
 				for (Worker value : slave.getWorkers().getWorkers().values()) {
 					if (!value.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
@@ -232,7 +232,7 @@ public class TableDeletionTest implements ProgrammaticIntegrationTest {
 			{
 				assertThat(namespace.getStorage().getAllImports().size()).isEqualTo(2);
 
-				for (SlaveCommand slave : conquery2.getSlaves()) {
+				for (ShardNode slave : conquery2.getShardNodes()) {
 					for (Worker value : slave.getWorkers().getWorkers().values()) {
 						if (!value.getInfo().getDataset().equals(dataset.getId())) {
 							continue;

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/TableDeletionTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/deletion/TableDeletionTest.java
@@ -75,7 +75,7 @@ public class TableDeletionTest implements ProgrammaticIntegrationTest {
 
 			for (SlaveCommand slave : conquery.getSlaves()) {
 				for (Worker value : slave.getWorkers().getWorkers().values()) {
-					if (!value.getInfo().getDataset().equals(dataset)) {
+					if (!value.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
 					}
 
@@ -129,7 +129,7 @@ public class TableDeletionTest implements ProgrammaticIntegrationTest {
 
 			for (SlaveCommand slave : conquery.getSlaves()) {
 				for (Worker value : slave.getWorkers().getWorkers().values()) {
-					if (!value.getInfo().getDataset().equals(dataset)) {
+					if (!value.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
 					}
 
@@ -179,7 +179,7 @@ public class TableDeletionTest implements ProgrammaticIntegrationTest {
 
 			for (SlaveCommand slave : conquery.getSlaves()) {
 				for (Worker value : slave.getWorkers().getWorkers().values()) {
-					if (!value.getInfo().getDataset().equals(dataset)) {
+					if (!value.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
 					}
 
@@ -199,7 +199,7 @@ public class TableDeletionTest implements ProgrammaticIntegrationTest {
 
 			for (SlaveCommand slave : conquery.getSlaves()) {
 				for (Worker value : slave.getWorkers().getWorkers().values()) {
-					if (!value.getInfo().getDataset().equals(dataset)) {
+					if (!value.getInfo().getDataset().equals(dataset.getId())) {
 						continue;
 					}
 
@@ -234,7 +234,7 @@ public class TableDeletionTest implements ProgrammaticIntegrationTest {
 
 				for (SlaveCommand slave : conquery2.getSlaves()) {
 					for (Worker value : slave.getWorkers().getWorkers().values()) {
-						if (!value.getInfo().getDataset().equals(dataset)) {
+						if (!value.getInfo().getDataset().equals(dataset.getId())) {
 							continue;
 						}
 

--- a/backend/src/test/java/com/bakdata/conquery/models/SerializationTests.java
+++ b/backend/src/test/java/com/bakdata/conquery/models/SerializationTests.java
@@ -10,7 +10,7 @@ import com.bakdata.conquery.apiv1.forms.export_form.AbsoluteMode;
 import com.bakdata.conquery.apiv1.forms.export_form.ExportForm;
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.io.jackson.serializer.SerializationTestUtil;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.Group;
 import com.bakdata.conquery.models.auth.entities.Role;
 import com.bakdata.conquery.models.auth.entities.User;
@@ -76,7 +76,7 @@ public class SerializationTests {
 	 */
 	@Test
 	public void user() throws IOException, JSONException{
-		MasterMetaStorage storage = mock(MasterMetaStorage.class);
+		MetaStorage storage = mock(MetaStorage.class);
 		User user = new User("user", "user");
 		user.addPermission(storage, DatasetPermission.onInstance(Ability.READ, new DatasetId("test")));
 		user
@@ -97,7 +97,7 @@ public class SerializationTests {
 	
 	@Test
 	public void group() throws IOException, JSONException {
-		MasterMetaStorage storage = mock(MasterMetaStorage.class);
+		MetaStorage storage = mock(MetaStorage.class);
 		Group group = new Group("group", "group");
 		group.addPermission(storage, DatasetPermission.onInstance(Ability.READ, new DatasetId("test")));
 		group

--- a/backend/src/test/java/com/bakdata/conquery/models/auth/LocalAuthRealmTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/models/auth/LocalAuthRealmTest.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 import com.auth0.jwt.JWT;
 import com.bakdata.conquery.apiv1.auth.PasswordCredential;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.basic.LocalAuthenticationConfig;
 import com.bakdata.conquery.models.auth.basic.LocalAuthenticationRealm;
 import com.bakdata.conquery.models.auth.basic.TokenHandler.JwtToken;
@@ -42,14 +42,14 @@ public class LocalAuthRealmTest {
 	private File tmpDir;
 	private AuthorizationController controller;
 	private LocalAuthenticationRealm realm;
-	private MasterMetaStorage storage;
+	private MetaStorage storage;
 	private User user1;
 
 	@BeforeAll
 	public void setupAll() throws Exception {
 		LocalAuthenticationConfig config = new LocalAuthenticationConfig();
 
-		storage = mock(MasterMetaStorage.class);
+		storage = mock(MetaStorage.class);
 		File tmpDir = Files.createTempDir();
 
 		tmpDir.mkdir();

--- a/backend/src/test/java/com/bakdata/conquery/models/auth/PermissionCheckTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/models/auth/PermissionCheckTest.java
@@ -61,7 +61,7 @@ public class PermissionCheckTest extends ConqueryTestSpec  {
 	public void importRequiredData(StandaloneSupport support) throws Exception {
 		storage = support.getMetaStorage();
 
-		// Clear MasterStorage
+		// Clear MetaStorage
 		clearAuthStorage(storage, roles, rUsers);
 		
 		importPermissionConstellation(storage, roles, rUsers);
@@ -136,7 +136,7 @@ public class PermissionCheckTest extends ConqueryTestSpec  {
 		assertThat(getGrantedElementwiseCheck()).as("permissions individually checked on users").containsAllEntriesOf(getExpected());
 		assertThat(getGrantedListedCheck()).as("list of permission checked on user").containsAnyElementsOf(getExpectedAllGranted());
 
-		// Clear MasterStorage
+		// Clear MetaStorage
 		clearAuthStorage(storage, roles, rUsers);
 	}
 }

--- a/backend/src/test/java/com/bakdata/conquery/models/auth/PermissionCheckTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/models/auth/PermissionCheckTest.java
@@ -20,7 +20,7 @@ import com.bakdata.conquery.integration.common.PermissionToCheck;
 import com.bakdata.conquery.integration.common.RequiredUser;
 import com.bakdata.conquery.integration.json.ConqueryTestSpec;
 import com.bakdata.conquery.io.cps.CPSType;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.Role;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.auth.permissions.ConqueryPermission;
@@ -55,11 +55,11 @@ public class PermissionCheckTest extends ConqueryTestSpec  {
 	private HashMultimap<ConqueryPermission, UserId> expectedPermitts = HashMultimap.create();
 	
 	@JsonIgnore
-	private MasterMetaStorage storage = null;
+	private MetaStorage storage = null;
 
 	@Override
 	public void importRequiredData(StandaloneSupport support) throws Exception {
-		storage = support.getMasterMetaStorage();
+		storage = support.getMetaStorage();
 
 		// Clear MasterStorage
 		clearAuthStorage(storage, roles, rUsers);

--- a/backend/src/test/java/com/bakdata/conquery/tasks/QueryCleanupTaskTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/tasks/QueryCleanupTaskTest.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.auth.permissions.Ability;
 import com.bakdata.conquery.models.auth.permissions.AbilitySets;
@@ -56,13 +56,13 @@ class QueryCleanupTaskTest {
 		return managedQuery;
 	}
 
-	private MasterMetaStorage storageMock;
+	private MetaStorage storageMock;
 	private Map<ManagedExecutionId, ? super ManagedExecution<?>> executions;
 	private Map<UserId,User> users;
 
 	@BeforeAll
 	void setUpAllTests() {
-		storageMock = Mockito.mock(MasterMetaStorage.class);
+		storageMock = Mockito.mock(MetaStorage.class);
 
 		executions = new HashMap<>();
 		users = new HashMap<>();

--- a/backend/src/test/java/com/bakdata/conquery/util/support/StandaloneSupport.java
+++ b/backend/src/test/java/com/bakdata/conquery/util/support/StandaloneSupport.java
@@ -9,7 +9,7 @@ import javax.ws.rs.client.Client;
 
 import com.bakdata.conquery.Conquery;
 import com.bakdata.conquery.commands.PreprocessorCommand;
-import com.bakdata.conquery.commands.SlaveCommand;
+import com.bakdata.conquery.commands.ShardNode;
 import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.io.xodus.NamespaceStorage;
 import com.bakdata.conquery.models.auth.entities.User;
@@ -71,8 +71,8 @@ public class StandaloneSupport implements Closeable {
 		return testConquery.getStandaloneCommand().getManager().getNamespaces().get(dataset.getId()).getStorage();
 	}
 
-	public List<SlaveCommand> getSlaves() {
-		return testConquery.getStandaloneCommand().getSlaves();
+	public List<ShardNode> getShardNodes() {
+		return testConquery.getStandaloneCommand().getShardNodes();
 	}
 	
 	/**

--- a/backend/src/test/java/com/bakdata/conquery/util/support/StandaloneSupport.java
+++ b/backend/src/test/java/com/bakdata/conquery/util/support/StandaloneSupport.java
@@ -60,15 +60,15 @@ public class StandaloneSupport implements Closeable {
 	}
 
 	public Validator getValidator() {
-		return testConquery.getStandaloneCommand().getMaster().getValidator();
+		return testConquery.getStandaloneCommand().getManager().getValidator();
 	}
 
 	public MasterMetaStorage getMasterMetaStorage() {
-		return testConquery.getStandaloneCommand().getMaster().getStorage();
+		return testConquery.getStandaloneCommand().getManager().getStorage();
 	}
 
 	public NamespaceStorage getNamespaceStorage() {
-		return testConquery.getStandaloneCommand().getMaster().getNamespaces().get(dataset.getId()).getStorage();
+		return testConquery.getStandaloneCommand().getManager().getNamespaces().get(dataset.getId()).getStorage();
 	}
 
 	public List<SlaveCommand> getSlaves() {

--- a/backend/src/test/java/com/bakdata/conquery/util/support/StandaloneSupport.java
+++ b/backend/src/test/java/com/bakdata/conquery/util/support/StandaloneSupport.java
@@ -68,7 +68,7 @@ public class StandaloneSupport implements Closeable {
 	}
 
 	public NamespaceStorage getNamespaceStorage() {
-		return testConquery.getStandaloneCommand().getManager().getNamespaces().get(dataset.getId()).getStorage();
+		return testConquery.getStandaloneCommand().getManager().getDatasetRegistry().get(dataset.getId()).getStorage();
 	}
 
 	public List<ShardNode> getShardNodes() {

--- a/backend/src/test/java/com/bakdata/conquery/util/support/StandaloneSupport.java
+++ b/backend/src/test/java/com/bakdata/conquery/util/support/StandaloneSupport.java
@@ -10,7 +10,7 @@ import javax.ws.rs.client.Client;
 import com.bakdata.conquery.Conquery;
 import com.bakdata.conquery.commands.PreprocessorCommand;
 import com.bakdata.conquery.commands.SlaveCommand;
-import com.bakdata.conquery.io.xodus.MasterMetaStorage;
+import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.io.xodus.NamespaceStorage;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.config.ConqueryConfig;
@@ -63,7 +63,7 @@ public class StandaloneSupport implements Closeable {
 		return testConquery.getStandaloneCommand().getManager().getValidator();
 	}
 
-	public MasterMetaStorage getMasterMetaStorage() {
+	public MetaStorage getMetaStorage() {
 		return testConquery.getStandaloneCommand().getManager().getStorage();
 	}
 

--- a/backend/src/test/java/com/bakdata/conquery/util/support/TestConquery.java
+++ b/backend/src/test/java/com/bakdata/conquery/util/support/TestConquery.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 import javax.validation.Validator;
 import javax.ws.rs.client.Client;
 
-import com.bakdata.conquery.commands.SlaveCommand;
+import com.bakdata.conquery.commands.ShardNode;
 import com.bakdata.conquery.commands.StandaloneCommand;
 import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.config.PreprocessingDirectories;
@@ -106,7 +106,7 @@ public class TestConquery implements Extension, BeforeAllCallback, AfterAllCallb
 		Namespaces namespaces = standaloneCommand.getManager().getNamespaces();
 		Namespace ns = namespaces.get(datasetId);
 
-		assertThat(namespaces.getSlaves()).hasSize(2);
+		assertThat(namespaces.getShardNodes()).hasSize(2);
 
 		// make tmp subdir and change cfg accordingly
 		File localTmpDir = new File(tmpDir, "tmp_" + name);
@@ -126,7 +126,7 @@ public class TestConquery implements Extension, BeforeAllCallback, AfterAllCallb
 			// Getting the User from AuthorizationConfig
 			standaloneCommand.getManager().getConfig().getAuthorization().getInitialUsers().get(0).getUser());
 
-		Wait.builder().attempts(100).stepTime(50).build().until(() -> ns.getWorkers().size() == ns.getNamespaces().getSlaves().size());
+		Wait.builder().attempts(100).stepTime(50).build().until(() -> ns.getWorkers().size() == ns.getNamespaces().getShardNodes().size());
 
 		support.waitUntilWorkDone();
 		openSupports.add(support);
@@ -154,7 +154,7 @@ public class TestConquery implements Extension, BeforeAllCallback, AfterAllCallb
 
 		config.getPreprocessor().setDirectories(new PreprocessingDirectories[] { new PreprocessingDirectories(tmpDir, tmpDir, tmpDir) });
 		config.getStorage().setDirectory(tmpDir);
-		config.getStandalone().setNumberOfSlaves(2);
+		config.getStandalone().setNumberOfShardNodes(2);
 		// configure logging
 		config.setLoggingFactory(new TestLoggingFactory());
 
@@ -224,7 +224,7 @@ public class TestConquery implements Extension, BeforeAllCallback, AfterAllCallb
 
 			log.info("Tearing down dataset");
 			DatasetId dataset = openSupport.getDataset().getId();
-			standaloneCommand.getManager().getNamespaces().getSlaves().values().forEach(s -> s.send(new RemoveWorker(dataset)));
+			standaloneCommand.getManager().getNamespaces().getShardNodes().values().forEach(s -> s.send(new RemoveWorker(dataset)));
 			standaloneCommand.getManager().getNamespaces().removeNamespace(dataset);
 			it.remove();
 		}
@@ -252,7 +252,7 @@ public class TestConquery implements Extension, BeforeAllCallback, AfterAllCallb
 					busy |= namespace.getJobManager().isSlowWorkerBusy();
 				}
 
-				for (SlaveCommand slave : standaloneCommand.getSlaves())
+				for (ShardNode slave : standaloneCommand.getShardNodes())
 					busy |= slave.isBusy();
 
 				Uninterruptibles.sleepUninterruptibly(5, TimeUnit.MILLISECONDS);
@@ -267,7 +267,7 @@ public class TestConquery implements Extension, BeforeAllCallback, AfterAllCallb
 	}
 	
 	public void closeNamespace(DatasetId dataset) {
-		standaloneCommand.getManager().getNamespaces().getSlaves().values().forEach(s -> s.send(new RemoveWorker(dataset)));
+		standaloneCommand.getManager().getNamespaces().getShardNodes().values().forEach(s -> s.send(new RemoveWorker(dataset)));
 		standaloneCommand.getManager().getNamespaces().removeNamespace(dataset);
 	}
 }

--- a/docs/Config JSON.md
+++ b/docs/Config JSON.md
@@ -389,7 +389,7 @@ Supported Fields:
 
 |  | Field | Type | Default | Example | Description |
 | --- | --- | --- | --- | --- | --- |
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/config/StandaloneConfig.java#L8) | numberOfSlaves | `int` | `2` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/config/StandaloneConfig.java#L8) | numberOfShardNodes | `int` | `2` |  |  | 
 </p></details>
 
 ### Type StorageConfig<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/config/StorageConfig.java#L16)</sup></sub></sup>

--- a/docs/Config JSON.md
+++ b/docs/Config JSON.md
@@ -226,7 +226,7 @@ Supported Fields:
 |  | Field | Type | Default | Example | Description |
 | --- | --- | --- | --- | --- | --- |
 | [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/config/ClusterConfig.java#L22) | entityBucketSize | `int` | `1000` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/config/ClusterConfig.java#L18) | masterURL | `InetAddress` | `"localhost"` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/config/ClusterConfig.java#L18) | managerURL | `InetAddress` | `"localhost"` |  |  | 
 | [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/config/ClusterConfig.java#L20) | mina | [MinaConfig](#Type-MinaConfig) |  |  |  | 
 | [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/config/ClusterConfig.java#L16) | port | `int` | `16170` |  |  | 
 </p></details>

--- a/docs/REST API JSONs.md
+++ b/docs/REST API JSONs.md
@@ -156,7 +156,7 @@ Returns: `Response`
 
 </p></details>
 
-### GET datasets/{dataset}/stored-queries<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/StoredQueriesResource.java#L50)</sup></sub></sup>
+### GET datasets/{dataset}/stored-queries<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/StoredQueriesResource.java#L44)</sup></sub></sup>
 
 
 <details><summary>Details</summary><p>
@@ -165,11 +165,12 @@ Java Type: `com.bakdata.conquery.resources.api.StoredQueriesResource`
 
 Method: `getAllQueries`
 
+Expects: ID of `Dataset`
 Returns: list of [ExecutionStatus](#Type-ExecutionStatus)
 
 </p></details>
 
-### GET datasets/{dataset}/stored-queries<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/StoredQueriesResource.java#L56)</sup></sub></sup>
+### GET datasets/{dataset}/stored-queries<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/StoredQueriesResource.java#L50)</sup></sub></sup>
 
 
 <details><summary>Details</summary><p>
@@ -182,7 +183,7 @@ Returns: [ExecutionStatus](#Type-ExecutionStatus)
 
 </p></details>
 
-### PATCH datasets/{dataset}/stored-queries<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/StoredQueriesResource.java#L70)</sup></sub></sup>
+### PATCH datasets/{dataset}/stored-queries<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/StoredQueriesResource.java#L63)</sup></sub></sup>
 
 
 <details><summary>Details</summary><p>
@@ -196,7 +197,7 @@ Returns: [ExecutionStatus](#Type-ExecutionStatus)
 
 </p></details>
 
-### DELETE datasets/{dataset}/stored-queries<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/StoredQueriesResource.java#L79)</sup></sub></sup>
+### DELETE datasets/{dataset}/stored-queries<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/StoredQueriesResource.java#L72)</sup></sub></sup>
 
 
 <details><summary>Details</summary><p>


### PR DESCRIPTION
| aktuell              | Vorschlag                  | Funktion                                             |
|----------------------|----------------------------|------------------------------------------------------|
| MasterCommand        |  ManagerNode               | Hostet den Webserver und alle delegierende Funktionen  |
| MasterMetaStorage    |  MetaStorage               | Inhalte über  Nutzer und Nuntzungspezifische Inhalte |
| SlaveCommand         |  ShardNode                 | Hostet Worker und delegiert nur Nachrichten          |
| Slave                |  ShardNetworkContext       | Context, der Informationen über den Shard enthält für die Verwendung in eingehenden Nachrichten |
| NamespaceCollection  |  IdResolveContext        | (abstract) Context für Jackson Deserializierer um ID zu Identifiables zu mappen|
| Namespaces           |  DatasetRegistry           | Verwaltet alle Datasets und ShardNodes auf der ManagerNode |