### PR TITLE
use concept tree child labels in column name

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
@@ -150,8 +150,8 @@ public class QueryProcessor {
 		}
 	}
 
-	public ExecutionStatus getStatus(Dataset dataset, ManagedExecution<?> query, UriBuilder urlb, User user) {
-		return query.buildStatus(storage, urlb, user, CreationFlag.WITH_COLUMN_DESCIPTION);
+	public ExecutionStatus getStatus(ManagedExecution<?> query, UriBuilder urlb, User user) {
+		return query.buildStatus(storage, urlb, user, CreationFlag.WITH_COLUMN_DESCIPTION, datasetRegistry);
 	}
 
 	public ExecutionStatus cancel(Dataset dataset, ManagedExecution<?> query, UriBuilder urlb) {

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
@@ -102,7 +102,7 @@ public class QueryProcessor {
 
 				final ManagedExecution<?> mq = ExecutionManager.execute( datasetRegistry, storage.getExecution(executionId));
 
-				return getStatus(dataset, mq, urlb, user);
+				return getStatus(mq, urlb, user);
 			}
 
 		}
@@ -118,7 +118,7 @@ public class QueryProcessor {
 		}
 
 		// return status
-		return getStatus(dataset, mq, urlb, user);
+		return getStatus(mq, urlb, user);
 	}
 
 	private void translateToOtherDatasets(Dataset dataset, QueryDescription query, User user, ManagedExecution<?> mq) {

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesProcessor.java
@@ -32,11 +32,11 @@ import lombok.extern.slf4j.Slf4j;
 public class StoredQueriesProcessor {
 
 	@Getter
-	private final DatasetRegistry datasets;
+	private final DatasetRegistry datasetRegistry;
 	private final MetaStorage storage;
 
 	public StoredQueriesProcessor(DatasetRegistry datasets) {
-		this.datasets = datasets;
+		this.datasetRegistry = datasets;
 		this.storage = datasets.getMetaStorage();
 	}
 
@@ -88,8 +88,8 @@ public class StoredQueriesProcessor {
 		storage.updateExecution(execution);
 		
 		// Patch this query in other datasets
-		List<Dataset> remainingDatasets = datasets.getAllDatasets(() -> new ArrayList<>());
-		remainingDatasets.remove(datasets.get(executionId.getDataset()).getDataset());
+		List<Dataset> remainingDatasets = datasetRegistry.getAllDatasets(() -> new ArrayList<>());
+		remainingDatasets.remove(datasetRegistry.get(executionId.getDataset()).getDataset());
 		for(Dataset dataset : remainingDatasets) {
 			ManagedExecutionId id = new ManagedExecutionId(dataset.getId(),executionId.getExecution());
 			execution = storage.getExecution(id);

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesProcessor.java
@@ -55,7 +55,8 @@ public class StoredQueriesProcessor {
 						mq.buildStatus(
 							storage,
 							RequestAwareUriBuilder.fromRequest(req),
-							user));
+							user,
+							datasetRegistry));
 				}
 				catch (Exception e) {
 					log.warn("Could not build status of " + mq, e);

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
@@ -229,14 +229,14 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 	@Nullable
 	protected abstract URL getDownloadURLInternal(UriBuilder url) throws MalformedURLException, IllegalArgumentException, UriBuilderException;
 
-	public ExecutionStatus buildStatus(@NonNull MetaStorage storage, UriBuilder url, User user) {
-		return buildStatus(storage, url, user, EnumSet.noneOf(ExecutionStatus.CreationFlag.class));
+	public ExecutionStatus buildStatus(@NonNull MetaStorage storage, UriBuilder url, User user, DatasetRegistry datasetRegistry) {
+		return buildStatus(storage, url, user, EnumSet.noneOf(ExecutionStatus.CreationFlag.class), datasetRegistry);
 	}
-	public ExecutionStatus buildStatus(@NonNull MetaStorage storage, UriBuilder url, User user, @NonNull ExecutionStatus.CreationFlag creationFlag) {
-		return buildStatus(storage, url, user, EnumSet.of(creationFlag));
+	public ExecutionStatus buildStatus(@NonNull MetaStorage storage, UriBuilder url, User user, @NonNull ExecutionStatus.CreationFlag creationFlag, DatasetRegistry datasetRegistry) {
+		return buildStatus(storage, url, user, EnumSet.of(creationFlag), datasetRegistry);
 	}
 	
-	public ExecutionStatus buildStatus(@NonNull MetaStorage storage, UriBuilder url, User user, @NonNull EnumSet<ExecutionStatus.CreationFlag> creationFlags) {
+	public ExecutionStatus buildStatus(@NonNull MetaStorage storage, UriBuilder url, User user, @NonNull EnumSet<ExecutionStatus.CreationFlag> creationFlags, DatasetRegistry datasetRegistry) {
 		ExecutionStatus status = new ExecutionStatus();
 		setStatusBase(storage, url, user, status);
 		for(CreationFlag flag : creationFlags) {
@@ -255,7 +255,7 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 		
 	}
 
-	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MetaStorage storage, UriBuilder url, User user, ExecutionStatus status) {
+	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MetaStorage storage, UriBuilder url, User user, ExecutionStatus status, DatasetRegistry datasetRegistry) {
 		// Implementation specific
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
@@ -242,7 +242,7 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 		for(CreationFlag flag : creationFlags) {
 			switch (flag) {
 				case WITH_COLUMN_DESCIPTION:
-					setAdditionalFieldsForStatusWithColumnDescription(storage, url, user, status);
+					setAdditionalFieldsForStatusWithColumnDescription(storage, url, user, status,  datasetRegistry);
 					break;
 				case WITH_SOURCE:
 					setAdditionalFieldsForStatusWithSource(storage, url, user, status);

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ResultProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ResultProcessor.java
@@ -32,13 +32,13 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ResultProcessor {
 	
-	public static ResponseBuilder getResult(User user, DatasetId datasetId, ManagedExecutionId queryId, String userAgent, String queryCharset, DatasetRegistry namespaces, ConqueryConfig config) {
+	public static ResponseBuilder getResult(User user, DatasetId datasetId, ManagedExecutionId queryId, String userAgent, String queryCharset, DatasetRegistry datasetRegistry, ConqueryConfig config) {
 		ConqueryMDC.setLocation(user.getName());
 		log.info("Downloading results for {} on dataset {}", queryId, datasetId);
 		authorize(user, datasetId, Ability.READ);
 		authorize(user, queryId, Ability.READ);
 
-		ManagedExecution<?> exec = namespaces.getMetaStorage().getExecution(queryId);
+		ManagedExecution<?> exec = datasetRegistry.getMetaStorage().getExecution(queryId);
 		
 		// Check if user is permitted to download on all datasets that were referenced by the query
 		authorizeDownloadDatasets(user, exec);
@@ -46,7 +46,7 @@ public class ResultProcessor {
 		IdMappingState mappingState = config.getIdMapping().initToExternal(user, exec);
 		
 		// Get the locale extracted by the LocaleFilter
-		PrintSettings settings = new PrintSettings(true, I18n.LOCALE.get());
+		PrintSettings settings = new PrintSettings(true, I18n.LOCALE.get(), datasetRegistry);
 		Charset charset = determineCharset(userAgent, queryCharset);
 
 		try {

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
@@ -241,7 +241,7 @@ public class ManagedForm extends ManagedExecution<FormSharedResult> {
 				getSubmitted().getClass().getSimpleName());
 			return;
 		}
-		status.setColumnDescriptions(subQuery.get(0).generateColumnDescriptions());
+		status.setColumnDescriptions(subQuery.get(0).generateColumnDescriptions(datasetRegistry));
 	}
 
 

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
@@ -220,8 +220,8 @@ public class ManagedForm extends ManagedExecution<FormSharedResult> {
 	}
 	
 	@Override
-	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MetaStorage storage, UriBuilder url, User user, ExecutionStatus status) {
-		super.setAdditionalFieldsForStatusWithColumnDescription(storage, url, user, status);
+	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MetaStorage storage, UriBuilder url, User user, ExecutionStatus status, DatasetRegistry datasetRegistry) {
+		super.setAdditionalFieldsForStatusWithColumnDescription(storage, url, user, status, datasetRegistry);
 		// Set the ColumnDescription if the Form only consits of a single subquery
 		if(subQueries == null) {
 			// If subqueries was not set the Execution was not initialized

--- a/backend/src/main/java/com/bakdata/conquery/models/preproc/Preprocessed.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/preproc/Preprocessed.java
@@ -18,7 +18,7 @@ import com.bakdata.conquery.models.types.parser.specific.DateParser;
 import com.bakdata.conquery.models.types.parser.specific.DateRangeParser;
 import com.bakdata.conquery.models.types.parser.specific.string.StringParser;
 import com.esotericsoftware.kryo.io.Output;
-import io.dropwizard.util.Size;
+import io.dropwizard.util.DataSize;
 import it.unimi.dsi.fastutil.ints.Int2ObjectAVLTreeMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import lombok.Data;
@@ -38,7 +38,7 @@ public class Preprocessed {
 	private long writtenGroups = 0;
 	private Int2ObjectMap<List<Object[]>> entries = new Int2ObjectAVLTreeMap<>();
 	
-	private final Output buffer = new Output((int) Size.megabytes(50).toBytes());
+	private final Output buffer = new Output((int) DataSize.megabytes(50).toBytes());
 
 	public Preprocessed(TableImportDescriptor descriptor, ParserConfig parserConfig) throws IOException {
 		this.file = descriptor.getInputFile();

--- a/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
@@ -144,8 +144,8 @@ public class ManagedQuery extends ManagedExecution<ShardResult> {
 	}
 	
 	@Override
-	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MetaStorage storage, UriBuilder url, User user, ExecutionStatus status) {
-		super.setAdditionalFieldsForStatusWithColumnDescription(storage, url, user, status);
+	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MetaStorage storage, UriBuilder url, User user, ExecutionStatus status, DatasetRegistry datasetRegistry) {
+		super.setAdditionalFieldsForStatusWithColumnDescription(storage, url, user, status, datasetRegistry);
 		if (columnDescriptions == null) {
 			columnDescriptions = generateColumnDescriptions(datasetRegistry);
 		}

--- a/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
@@ -147,7 +147,7 @@ public class ManagedQuery extends ManagedExecution<ShardResult> {
 	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MetaStorage storage, UriBuilder url, User user, ExecutionStatus status) {
 		super.setAdditionalFieldsForStatusWithColumnDescription(storage, url, user, status);
 		if (columnDescriptions == null) {
-			columnDescriptions = generateColumnDescriptions();
+			columnDescriptions = generateColumnDescriptions(datasetRegistry);
 		}
 		status.setColumnDescriptions(columnDescriptions);
 	}
@@ -155,7 +155,7 @@ public class ManagedQuery extends ManagedExecution<ShardResult> {
 	/**
 	 * Generates a description of each column that will appear in the resulting csv.
 	 */
-	public List<ColumnDescriptor> generateColumnDescriptions() {
+	public List<ColumnDescriptor> generateColumnDescriptions(DatasetRegistry datasetRegistry) {
 		List<ColumnDescriptor> columnDescriptions = new ArrayList<>();
 		// First add the id columns to the descriptor list. The are the first columns
 		for (String header : ConqueryConfig.getInstance().getIdMapping().getPrintIdFields()) {
@@ -165,7 +165,7 @@ public class ManagedQuery extends ManagedExecution<ShardResult> {
 				.build());
 		}
 		// Then all columns that originate from selects and static aggregators
-		PrintSettings settings = new PrintSettings(true, I18n.LOCALE.get());
+		PrintSettings settings = new PrintSettings(true, I18n.LOCALE.get(), datasetRegistry);
 		collectResultInfos().getInfos().forEach(info -> columnDescriptions.add(info.asColumnDescriptor(settings)));
 		return columnDescriptions;
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
@@ -1,11 +1,14 @@
 package com.bakdata.conquery.models.query;
 
 import java.util.Locale;
-import java.util.function.Function;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
+import com.bakdata.conquery.models.concepts.ConceptElement;
 import com.bakdata.conquery.models.concepts.Connector;
 import com.bakdata.conquery.models.query.resultinfo.SelectNameExtractor;
 import com.bakdata.conquery.models.query.resultinfo.SelectResultInfo;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
@@ -17,9 +20,13 @@ public class PrintSettings implements SelectNameExtractor {
 
 	private final boolean prettyPrint;
 	private final Locale locale;
+	/**
+	 * Use the registry to resolve ids to objects/labels where this was not done yet, such as {@link CQConcept::getIds()}.
+	 */
+	private final DatasetRegistry datasetRegistry;
 	
 	@NonNull
-	private Function<SelectResultInfo, String> columnNamer = PrintSettings::defaultColumnName;
+	private BiFunction<SelectResultInfo, DatasetRegistry, String> columnNamer = PrintSettings::defaultColumnName;
 	
 
 	/**
@@ -31,11 +38,11 @@ public class PrintSettings implements SelectNameExtractor {
 			// Should never be reached
 			throw new IllegalStateException("No column namer was supplied");
 		}
-		return columnNamer.apply(columnInfo);
+		return columnNamer.apply(columnInfo, datasetRegistry);
 	}
 
 
-	private static String defaultColumnName(SelectResultInfo columnInfo) {
+	private static String defaultColumnName(SelectResultInfo columnInfo, DatasetRegistry datasetRegistry) {
 		StringBuilder sb = new StringBuilder();
 		String cqLabel = columnInfo.getCqConcept().getLabel();
 		String conceptLabel = columnInfo.getSelect().getHolder().findConcept().getLabel();
@@ -46,6 +53,20 @@ public class PrintSettings implements SelectNameExtractor {
 			// If these labels differ, the user might changed the label of the concept in the frontend, or a TreeChild was posted
 			sb.append(cqLabel);
 			sb.append(" - ");
+		}
+		else {
+			// When no Label was set within the query, get the labels of all ids that are in the CQConcept
+			String concatElementLabels = columnInfo.getCqConcept().getIds().stream()
+			.map(datasetRegistry::resolve)
+			.map(ConceptElement.class::cast)
+			.map(ConceptElement::getLabel)
+			.collect(Collectors.joining("+"));
+			
+			if(!concatElementLabels.equalsIgnoreCase(conceptLabel)) {
+				// Only add all child labels if they are different from the actual label of the concept
+				sb.append(concatElementLabels);
+				sb.append(" - ");
+			}
 		}
 		if (columnInfo.getSelect().getHolder() instanceof Connector && columnInfo.getSelect().getHolder().findConcept().getConnectors().size() > 1) {
 			// The select originates from a connector and the corresponding concept has more than one connector -> Print also the connector

--- a/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/PrintSettings.java
@@ -54,7 +54,7 @@ public class PrintSettings implements SelectNameExtractor {
 			sb.append(cqLabel);
 			sb.append(" - ");
 		}
-		else {
+		else if(columnInfo.getCqConcept().getIds().size() > 0) {
 			// When no Label was set within the query, get the labels of all ids that are in the CQConcept
 			String concatElementLabels = columnInfo.getCqConcept().getIds().stream()
 			.map(datasetRegistry::resolve)

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/QueryResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/QueryResource.java
@@ -88,7 +88,6 @@ public class QueryResource {
 		ManagedExecution<?> query = dsUtil.getManagedQuery(queryId);
 		query.awaitDone(10, TimeUnit.SECONDS);
 		return processor.getStatus(
-			dsUtil.getDataset(datasetId),
 			query,
 			RequestAwareUriBuilder.fromRequest(req),
 			user);

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/AbstractQueryEngineTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/AbstractQueryEngineTest.java
@@ -38,9 +38,6 @@ public abstract class AbstractQueryEngineTest extends ConqueryTestSpec {
 
 	protected abstract ResourceFile getExpectedCsv();
 
-	@JsonIgnore
-	private static final PrintSettings PRINT_SETTINGS = new PrintSettings(false,Locale.ENGLISH, columnInfo -> columnInfo.getSelect().getId().toStringWithoutDataset());
-
 	@Override
 	public void executeTest(StandaloneSupport standaloneSupport) throws IOException, JSONException {
 		DatasetRegistry namespaces = standaloneSupport.getNamespace().getNamespaces();
@@ -78,6 +75,7 @@ public abstract class AbstractQueryEngineTest extends ConqueryTestSpec {
 			assertThat(v).hasSameSizeAs(resultInfos.getInfos())
 		);
 
+		PrintSettings PRINT_SETTINGS = new PrintSettings(false,Locale.ENGLISH, standaloneSupport.getNamespace().getNamespaces(), (columnInfo, dr) -> columnInfo.getSelect().getId().toStringWithoutDataset());
 		List<String> actual = QueryToCSVRenderer
 			.toCSV(
 				PRINT_SETTINGS,

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/FormTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/FormTest.java
@@ -52,8 +52,6 @@ import lombok.extern.slf4j.Slf4j;
 @CPSType(id = "FORM_TEST", base = ConqueryTestSpec.class)
 public class FormTest extends ConqueryTestSpec {
 	
-	private static final PrintSettings PRINT_SETTINGS = new PrintSettings(true, Locale.ENGLISH);
-	
 	/*
 	 * parse form as json first, because it may contain namespaced ids, that can only be resolved after
 	 * concepts and tables have been imported.
@@ -125,10 +123,10 @@ public class FormTest extends ConqueryTestSpec {
 
 		log.info("{} QUERIES EXECUTED", getLabel());
 
-		checkResults((ManagedForm) managedForm, support.getTestUser());
+		checkResults(support, (ManagedForm) managedForm, support.getTestUser());
 	}
 
-	private void checkResults(ManagedForm managedForm, User user) throws IOException {
+	private void checkResults(StandaloneSupport standaloneSupport, ManagedForm managedForm, User user) throws IOException {
 		Map<String, List<ManagedQuery>> managedMapping = managedForm.getSubQueries();
 		IdMappingState mappingState = idMapping
 			.initToExternal(user, managedForm);
@@ -136,7 +134,7 @@ public class FormTest extends ConqueryTestSpec {
 			log.info("{} CSV TESTING: {}", getLabel(), managed.getKey());
 			List<String> actual = QueryToCSVRenderer
 				.toCSV(
-					PRINT_SETTINGS,
+					new PrintSettings(false,Locale.ENGLISH, standaloneSupport.getNamespace().getNamespaces(), (columnInfo, dr) -> columnInfo.getSelect().getId().toStringWithoutDataset()),
 					managed.getValue(),
 					mappingState)
 				.collect(Collectors.toList());

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/FormTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/FormTest.java
@@ -134,7 +134,7 @@ public class FormTest extends ConqueryTestSpec {
 			log.info("{} CSV TESTING: {}", getLabel(), managed.getKey());
 			List<String> actual = QueryToCSVRenderer
 				.toCSV(
-					new PrintSettings(false,Locale.ENGLISH, standaloneSupport.getNamespace().getNamespaces(), (columnInfo, dr) -> columnInfo.getSelect().getId().toStringWithoutDataset()),
+					new PrintSettings(false,Locale.ENGLISH, standaloneSupport.getNamespace().getNamespaces()),
 					managed.getValue(),
 					mappingState)
 				.collect(Collectors.toList());

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/FormTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/FormTest.java
@@ -134,7 +134,7 @@ public class FormTest extends ConqueryTestSpec {
 			log.info("{} CSV TESTING: {}", getLabel(), managed.getKey());
 			List<String> actual = QueryToCSVRenderer
 				.toCSV(
-					new PrintSettings(false,Locale.ENGLISH, standaloneSupport.getNamespace().getNamespaces()),
+					new PrintSettings(true,Locale.ENGLISH, standaloneSupport.getNamespace().getNamespaces()),
 					managed.getValue(),
 					mappingState)
 				.collect(Collectors.toList());

--- a/backend/src/test/java/com/bakdata/conquery/models/externalservice/ResultTypeTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/models/externalservice/ResultTypeTest.java
@@ -25,11 +25,10 @@ public class ResultTypeTest {
 		// Initialization of the internationalization
 		I18n.init();
 	}
-	
 
-	private static final PrintSettings PRETTY = new PrintSettings(true, Locale.ENGLISH);
-	private static final PrintSettings PRETTY_DE = new PrintSettings(true, Locale.GERMAN);
-	private static final PrintSettings PLAIN = new PrintSettings(false, Locale.ENGLISH);
+	private static final PrintSettings PRETTY = new PrintSettings(true, Locale.ENGLISH, null);
+	private static final PrintSettings PRETTY_DE = new PrintSettings(true, Locale.GERMAN, null);
+	private static final PrintSettings PLAIN = new PrintSettings(false, Locale.ENGLISH, null);
 	
 	public static Stream<Arguments> testData() {
 		//init global default config

--- a/backend/src/test/java/com/bakdata/conquery/models/query/DefaultColumnNameTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/models/query/DefaultColumnNameTest.java
@@ -1,0 +1,197 @@
+package com.bakdata.conquery.models.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import com.bakdata.conquery.models.concepts.SelectHolder;
+import com.bakdata.conquery.models.concepts.select.Select;
+import com.bakdata.conquery.models.concepts.select.concept.UniversalSelect;
+import com.bakdata.conquery.models.concepts.tree.ConceptTreeChild;
+import com.bakdata.conquery.models.concepts.tree.ConceptTreeConnector;
+import com.bakdata.conquery.models.concepts.tree.TreeConcept;
+import com.bakdata.conquery.models.identifiable.ids.specific.ConceptTreeChildId;
+import com.bakdata.conquery.models.query.concept.specific.CQConcept;
+import com.bakdata.conquery.models.query.queryplan.aggregators.Aggregator;
+import com.bakdata.conquery.models.query.resultinfo.SelectResultInfo;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class DefaultColumnNameTest {
+	private final static DatasetRegistry DATASET_REGISTRY = mock(DatasetRegistry.class);
+	private final static PrintSettings SETTINGS = new PrintSettings(false, Locale.ENGLISH, DATASET_REGISTRY);
+	
+	private final static Function<TestConcept,Select> FIRST_CONCEPT_SELECT_EXTRACTOR = (concept) -> concept.getSelects().get(0);
+	private final static Function<TestConcept,Select> FIRST_CONNCETOR_FIRST_SELECT_EXTRACTOR = (concept) -> concept.getConnectors().get(0).getSelects().get(0);
+	
+	@BeforeAll
+	static void before() {
+		doAnswer(invocation -> {
+			final ConceptTreeChildId id = invocation.getArgument(0);
+			ConceptTreeChild child = new ConceptTreeChild();
+			child.setLabel(id.getName());
+			return child;
+		}).when(DATASET_REGISTRY).resolve(any());
+	}
+	
+	private static Stream<Arguments> provideCombinations() {
+		return Stream.of(
+			// ConceptSelect, without CQLabel, one Id
+			Arguments.of(
+				TestConcept.create(1, FIRST_CONCEPT_SELECT_EXTRACTOR),
+				TestCQConcept.create(false, 1),
+				"TestConceptLabel - ID_0 - TestSelectLabel"),
+			// ConceptSelect without CQLabel, multiple Ids
+			Arguments.of(
+				TestConcept.create(1, FIRST_CONCEPT_SELECT_EXTRACTOR),
+				TestCQConcept.create(false, 3),
+				"TestConceptLabel - ID_0+ID_1+ID_2 - TestSelectLabel"),
+			// ConceptSelect with CQLabel, one Id
+			Arguments.of(
+				TestConcept.create(1, FIRST_CONCEPT_SELECT_EXTRACTOR),
+				TestCQConcept.create(true, 1),
+				"TestConceptLabel - TestCQLabel - TestSelectLabel"),
+			// ConceptSelect with CQLabel, multiple Ids
+			Arguments.of(
+				TestConcept.create(1, FIRST_CONCEPT_SELECT_EXTRACTOR),
+				TestCQConcept.create(true, 3),
+				"TestConceptLabel - TestCQLabel - TestSelectLabel"),
+			
+			// ConnectorSelect, without CQLabel, one Id, one Connector
+			Arguments.of(
+				TestConcept.create(1, FIRST_CONNCETOR_FIRST_SELECT_EXTRACTOR),
+				TestCQConcept.create(false, 1),
+				"TestConceptLabel - ID_0 - TestSelectLabel"),
+			// ConnectorSelect without CQLabel, multiple Ids, one Connector
+			Arguments.of(
+				TestConcept.create(1, FIRST_CONNCETOR_FIRST_SELECT_EXTRACTOR),
+				TestCQConcept.create(false, 3),
+				"TestConceptLabel - ID_0+ID_1+ID_2 - TestSelectLabel"),
+			// ConnectorSelect with CQLabel, one Id, one Connector
+			Arguments.of(
+				TestConcept.create(1, FIRST_CONNCETOR_FIRST_SELECT_EXTRACTOR),
+				TestCQConcept.create(true, 1),
+				"TestConceptLabel - TestCQLabel - TestSelectLabel"),
+			// ConnectorSelect with CQLabel, multiple Ids, one Connector
+			Arguments.of(
+				TestConcept.create(1, FIRST_CONNCETOR_FIRST_SELECT_EXTRACTOR),
+				TestCQConcept.create(true, 3),
+				"TestConceptLabel - TestCQLabel - TestSelectLabel"),
+			
+			// ConnectorSelect, without CQLabel, one Id, multiple Connectors
+			Arguments.of(
+				TestConcept.create(3, FIRST_CONNCETOR_FIRST_SELECT_EXTRACTOR),
+				TestCQConcept.create(false, 1),
+				"TestConceptLabel - ID_0 - TestConnectorLabel_0 TestSelectLabel"),
+			// ConnectorSelect without CQLabel, multiple Ids, multiple Connectors
+			Arguments.of(
+				TestConcept.create(3, FIRST_CONNCETOR_FIRST_SELECT_EXTRACTOR),
+				TestCQConcept.create(false, 3),
+				"TestConceptLabel - ID_0+ID_1+ID_2 - TestConnectorLabel_0 TestSelectLabel"),
+			// ConnectorSelect with CQLabel, one Id, multiple Connectors
+			Arguments.of(
+				TestConcept.create(3, FIRST_CONNCETOR_FIRST_SELECT_EXTRACTOR),
+				TestCQConcept.create(true, 1),
+				"TestConceptLabel - TestCQLabel - TestConnectorLabel_0 TestSelectLabel"),
+			// ConnectorSelect with CQLabel, multiple Ids, multiple Connectors
+			Arguments.of(
+				TestConcept.create(3, FIRST_CONNCETOR_FIRST_SELECT_EXTRACTOR),
+				TestCQConcept.create(true, 3),
+				"TestConceptLabel - TestCQLabel - TestConnectorLabel_0 TestSelectLabel")
+			);
+	}
+	
+	@ParameterizedTest
+	@MethodSource("provideCombinations")
+	void checkCombinations(TestConcept concept, CQConcept cqConcept, String expectedColumnName) {
+		
+		SelectResultInfo info = new SelectResultInfo(concept.extractSelect(), cqConcept);
+		
+		assertThat(SETTINGS.columnName(info)).isEqualTo(expectedColumnName);
+	}
+
+	
+	private static class TestCQConcept extends CQConcept {
+		private static CQConcept create(boolean withLabel, int countIds) {
+			CQConcept cqConcept = new CQConcept();
+			if(withLabel) {				
+				cqConcept.setLabel("TestCQLabel");
+			}
+			
+			cqConcept.setIds(IntStream.range(0, countIds)
+				.mapToObj(i -> new ConceptTreeChildId(null, "ID_" + i))
+				.collect(Collectors.toList())
+				);
+			
+			return cqConcept;
+		}
+	}
+	
+	private static class TestConcept extends TreeConcept {
+		
+		private final Function<TestConcept,Select> selectExtractor;
+		
+		private TestConcept(Function<TestConcept,Select> selectExtractor) {
+			this.selectExtractor = selectExtractor;
+			setName("TestConceptName");
+			setLabel("TestConceptLabel");
+			setSelects(List.of(new TestUniversalSelect(this)));
+		}
+		
+		public Select extractSelect(){
+			return selectExtractor.apply(this);
+		}
+		
+		public static TestConcept create(int countConnectors, Function<TestConcept,Select> selectExtractor) {
+			TestConcept concept = new TestConcept(selectExtractor);
+			ArrayList<ConceptTreeConnector> connectors = new ArrayList<>();
+			concept.setConnectors(connectors);
+			for (; countConnectors > 0; countConnectors--) {
+				connectors.add(new TestConnector(concept));
+			}
+			
+			return concept;
+		}
+		
+		@SuppressWarnings("serial")
+		private static class TestConnector extends ConceptTreeConnector {
+			
+			public TestConnector(TreeConcept concept) {
+				int presentConnectors = concept.getConnectors().size();
+				setName("TestConnectorName_"+presentConnectors);
+				setLabel("TestConnectorLabel_"+presentConnectors);
+				setConcept(concept);
+				setSelects(List.of(new TestUniversalSelect(this)));
+			}
+			
+		}
+
+		
+		private static class TestUniversalSelect extends UniversalSelect {
+			
+			public TestUniversalSelect(SelectHolder<?> holder) {
+				setName("TestSelectName");
+				setLabel("TestSelectLabel");
+				setHolder(holder);
+			}
+
+			@Override
+			public Aggregator<?> createAggregator() {
+				return null;
+			}
+		}
+		
+	}
+}


### PR DESCRIPTION
This adds more information to the default columnName if no label was set by the user.

Previously only the concept name was set, even if a concept child was chosen. Now both are displayed