### PR TITLE
autocomplete result count

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/resources/ResourceConstants.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/ResourceConstants.java
@@ -14,7 +14,7 @@ public class ResourceConstants {
 	public static final String QUERY	=	"query";
 	public static final String FORM_CONFIG	=	"form-config";
 	public static final String FILENAME	=	"filename";
-	public static final String MAX_RESULT_COUNT	=	"max-result-count";
+	public static final String MAX_RESULT_COUNT	= "max-result-count";
 	public static final String API		=	"api";
 	public static final String IMPORT_ID = "importId";
 	public static final String JOB_ID = "jobId";

--- a/backend/src/main/java/com/bakdata/conquery/resources/ResourceConstants.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/ResourceConstants.java
@@ -14,6 +14,7 @@ public class ResourceConstants {
 	public static final String QUERY	=	"query";
 	public static final String FORM_CONFIG	=	"form-config";
 	public static final String FILENAME	=	"filename";
+	public static final String MAX_RESULT_COUNT	=	"max-result-count";
 	public static final String API		=	"api";
 	public static final String IMPORT_ID = "importId";
 	public static final String JOB_ID = "jobId";

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java
@@ -137,13 +137,14 @@ public class ConceptsProcessor {
 
 	/**
 	 * Autocompletion for search terms. For values of {@link AbstractSelectFilter<?>}.
+	 * @param maxResultNumber 
 	 */
-	public List<FEValue> autocompleteTextFilter(AbstractSelectFilter<?> filter, String text) {
+	public List<FEValue> autocompleteTextFilter(AbstractSelectFilter<?> filter, String text, OptionalInt maxResultNumber) {
 		List<FEValue> result = new LinkedList<>();
 
 		QuickSearch<FilterSearchItem> search = filter.getSourceSearch();
 		if (search != null) {
-			result = createSourceSearchResult(filter.getSourceSearch(), Collections.singletonList(text), OptionalInt.of(50), FilterSearch.FilterSearchType.CONTAINS::score);
+			result = createSourceSearchResult(filter.getSourceSearch(), Collections.singletonList(text), maxResultNumber, FilterSearch.FilterSearchType.CONTAINS::score);
 		}
 		
 		String value = filter.getValueFor(text);

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java
@@ -159,7 +159,7 @@ public class ConceptsProcessor {
 	 * Do a search with the supplied values.
 	 */
 	private List<FEValue> createSourceSearchResult(QuickSearch<FilterSearchItem> search, Collection<String> values, OptionalInt numberOfTopItems, SearchScorer scorer) {
-		if(search == null) {
+		if(search == null || (numberOfTopItems.isPresent() && numberOfTopItems.getAsInt() <= 0)) {
 			return Collections.emptyList();
 		}
 

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/FilterResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/FilterResource.java
@@ -1,18 +1,22 @@
 package com.bakdata.conquery.resources.api;
 
-import static com.bakdata.conquery.resources.ResourceConstants.*;
+import static com.bakdata.conquery.resources.ResourceConstants.CONCEPT;
+import static com.bakdata.conquery.resources.ResourceConstants.DATASET;
+import static com.bakdata.conquery.resources.ResourceConstants.FILTER;
+import static com.bakdata.conquery.resources.ResourceConstants.MAX_RESULT_COUNT;
+import static com.bakdata.conquery.resources.ResourceConstants.TABLE;
 
 import java.util.List;
+import java.util.OptionalInt;
 
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response.Status;
 
 import com.bakdata.conquery.io.jersey.ExtraMimeTypes;
@@ -41,7 +45,7 @@ public class FilterResource extends HFilters {
 	
 	@POST
 	@Path("autocomplete")
-	public List<FEValue> autocompleteTextFilter(@NotNull StringContainer text, @Context HttpServletRequest req) {
+	public List<FEValue> autocompleteTextFilter(@NotNull StringContainer text, @PathParam(MAX_RESULT_COUNT) OptionalInt maxResultNumber) {
 		if(StringUtils.isEmpty(text.getText())) {
 			throw new WebApplicationException("Too short text. Requires at least 1 characters.", Status.BAD_REQUEST);
 		}
@@ -50,7 +54,7 @@ public class FilterResource extends HFilters {
 		}
 		
 
-		return processor.autocompleteTextFilter((AbstractSelectFilter<?>) filter, text.getText());
+		return processor.autocompleteTextFilter((AbstractSelectFilter<?>) filter, text.getText(), maxResultNumber);
 	}
 	
 	@Data

--- a/docs/REST API JSONs.md
+++ b/docs/REST API JSONs.md
@@ -73,7 +73,7 @@ Returns: [ResolvedConceptsResult](#Type-ResolvedConceptsResult)
 
 </p></details>
 
-### POST datasets/{dataset}/concepts/{concept}/tables/{table}/filters/{filter}<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/FilterResource.java#L36)</sup></sub></sup>
+### POST datasets/{dataset}/concepts/{concept}/tables/{table}/filters/{filter}<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/FilterResource.java#L40)</sup></sub></sup>
 
 
 <details><summary>Details</summary><p>
@@ -87,7 +87,7 @@ Returns: [ResolvedConceptsResult](#Type-ResolvedConceptsResult)
 
 </p></details>
 
-### POST datasets/{dataset}/concepts/{concept}/tables/{table}/filters/{filter}<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/FilterResource.java#L42)</sup></sub></sup>
+### POST datasets/{dataset}/concepts/{concept}/tables/{table}/filters/{filter}<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/FilterResource.java#L46)</sup></sub></sup>
 
 
 <details><summary>Details</summary><p>
@@ -728,7 +728,7 @@ Supported Fields:
 | [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/api/description/FEValue.java#L16) | templateValues | map from `String` to `String` | ? |  |  | 
 </p></details>
 
-### Type FilterValues<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/FilterResource.java#L56)</sup></sub></sup>
+### Type FilterValues<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/FilterResource.java#L60)</sup></sub></sup>
 
 
 <details><summary>Details</summary><p>
@@ -739,7 +739,7 @@ Supported Fields:
 
 |  | Field | Type | Default | Example | Description |
 | --- | --- | --- | --- | --- | --- |
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/FilterResource.java#L58) | values | list of `String` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/FilterResource.java#L62) | values | list of `String` | `null` |  |  | 
 </p></details>
 
 ### Type FormConfig<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/forms/configs/FormConfig.java#L37)</sup></sub></sup>
@@ -833,7 +833,7 @@ Supported Fields:
 | [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/apiv1/MetaDataPatch.java#L33) | tags | list of `String` | `null` |  |  | 
 </p></details>
 
-### Type ResolvedConceptsResult<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L225)</sup></sub></sup>
+### Type ResolvedConceptsResult<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L226)</sup></sub></sup>
 
 
 <details><summary>Details</summary><p>
@@ -844,12 +844,12 @@ Supported Fields:
 
 |  | Field | Type | Default | Example | Description |
 | --- | --- | --- | --- | --- | --- |
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L230) | resolvedConcepts | list of ID of `ConceptElement` | ? |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L231) | resolvedFilter | [ResolvedFilterResult](#Type-ResolvedFilterResult) | ? |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L232) | unknownCodes | list of `String` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L231) | resolvedConcepts | list of ID of `ConceptElement` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L232) | resolvedFilter | [ResolvedFilterResult](#Type-ResolvedFilterResult) | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L233) | unknownCodes | list of `String` | ? |  |  | 
 </p></details>
 
-### Type ResolvedFilterResult<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L205)</sup></sub></sup>
+### Type ResolvedFilterResult<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L206)</sup></sub></sup>
 
 
 <details><summary>Details</summary><p>
@@ -860,12 +860,12 @@ Supported Fields:
 
 |  | Field | Type | Default | Example | Description |
 | --- | --- | --- | --- | --- | --- |
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L211) | filterId | ID of `Filter` | ? |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L210) | tableId | ID of `Connector` | ? |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L212) | value | list of [FEValue](#Type-FEValue) | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L212) | filterId | ID of `Filter` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L211) | tableId | ID of `Connector` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L213) | value | list of [FEValue](#Type-FEValue) | ? |  |  | 
 </p></details>
 
-### Type StringContainer<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/FilterResource.java#L61)</sup></sub></sup>
+### Type StringContainer<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/FilterResource.java#L65)</sup></sub></sup>
 
 
 <details><summary>Details</summary><p>
@@ -876,7 +876,7 @@ Supported Fields:
 
 |  | Field | Type | Default | Example | Description |
 | --- | --- | --- | --- | --- | --- |
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/FilterResource.java#L63) | text | `String` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/FilterResource.java#L67) | text | `String` | `null` |  |  | 
 </p></details>
 
 ### Type ValidityDateColumn<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/query/concept/filter/CQTable.java#L42)</sup></sub></sup>


### PR DESCRIPTION
allows a query parameter to be passed to set the maximum number of results returned

```
datasets/{DATASET}/concepts/{CONCEPT}/tables/{TABLE}/filters/{FILTER}/autocomplete?max-result-count={POSITIVE_NUMBER}
```

if `max-result-count` is not set, all results will be returned