### PR TITLE
adds parameter to request to control prettyprint (default pretty=true)

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ResultProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ResultProcessor.java
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ResultProcessor {
 	
-	public static ResponseBuilder getResult(User user, DatasetId datasetId, ManagedExecutionId queryId, String userAgent, String queryCharset, DatasetRegistry namespaces, ConqueryConfig config) {
+	public static ResponseBuilder getResult(User user, DatasetId datasetId, ManagedExecutionId queryId, String userAgent, String queryCharset, boolean pretty, DatasetRegistry namespaces, ConqueryConfig config) {
 		ConqueryMDC.setLocation(user.getName());
 		log.info("Downloading results for {} on dataset {}", queryId, datasetId);
 		authorize(user, datasetId, Ability.READ);
@@ -46,7 +46,7 @@ public class ResultProcessor {
 		IdMappingState mappingState = config.getIdMapping().initToExternal(user, exec);
 		
 		// Get the locale extracted by the LocaleFilter
-		PrintSettings settings = new PrintSettings(true, I18n.LOCALE.get());
+		PrintSettings settings = new PrintSettings(pretty, I18n.LOCALE.get());
 		Charset charset = determineCharset(userAgent, queryCharset);
 
 		try {

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ResultProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ResultProcessor.java
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ResultProcessor {
 	
-	public static ResponseBuilder getResult(User user, DatasetId datasetId, ManagedExecutionId queryId, String userAgent, String queryCharset, boolean pretty, DatasetRegistry namespaces, ConqueryConfig config) {
+	public static ResponseBuilder getResult(User user, DatasetId datasetId, ManagedExecutionId queryId, String userAgent, String queryCharset, boolean pretty, DatasetRegistry datasetRegistry, ConqueryConfig config) {
 		ConqueryMDC.setLocation(user.getName());
 		log.info("Downloading results for {} on dataset {}", queryId, datasetId);
 		authorize(user, datasetId, Ability.READ);

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/ResultCSVResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/ResultCSVResource.java
@@ -51,7 +51,7 @@ public class ResultCSVResource {
 	@GET
 	@Path("{" + QUERY + "}.csv")
 	@Produces(AdditionalMediaTypes.CSV)
-	public Response getAsCsv(@Auth User user, @PathParam(DATASET) DatasetId datasetId, @PathParam(QUERY) ManagedExecutionId queryId, @QueryParam("charset") String queryCharset, @HeaderParam("user-agent") String userAgent, @HeaderParam("pretty") Optional<Boolean> pretty) {
+	public Response getAsCsv(@Auth User user, @PathParam(DATASET) DatasetId datasetId, @PathParam(QUERY) ManagedExecutionId queryId,@HeaderParam("user-agent") String userAgent,  @QueryParam("charset") String queryCharset, @QueryParam("pretty") Optional<Boolean> pretty) {
 		log.info("Result for {} download on dataset {} by user {} ({}).", queryId, datasetId, user.getId(), user.getName());
 		return getResult(user, datasetId, queryId, userAgent, queryCharset, pretty.orElse(Boolean.TRUE), namespaces, config).build();
 	}

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/ResultCSVResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/ResultCSVResource.java
@@ -10,6 +10,7 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.ws.rs.GET;
@@ -50,9 +51,9 @@ public class ResultCSVResource {
 	@GET
 	@Path("{" + QUERY + "}.csv")
 	@Produces(AdditionalMediaTypes.CSV)
-	public Response getAsCsv(@Auth User user, @PathParam(DATASET) DatasetId datasetId, @PathParam(QUERY) ManagedExecutionId queryId, @QueryParam("charset") String queryCharset, @HeaderParam("user-agent") String userAgent) {
+	public Response getAsCsv(@Auth User user, @PathParam(DATASET) DatasetId datasetId, @PathParam(QUERY) ManagedExecutionId queryId, @QueryParam("charset") String queryCharset, @HeaderParam("user-agent") String userAgent, @HeaderParam("pretty") Optional<Boolean> pretty) {
 		log.info("Result for {} download on dataset {} by user {} ({}).", queryId, datasetId, user.getId(), user.getName());
-		return getResult(user, datasetId, queryId, userAgent, queryCharset, namespaces, config).build();
+		return getResult(user, datasetId, queryId, userAgent, queryCharset, pretty.orElse(Boolean.TRUE), namespaces, config).build();
 	}
 
 	public static StreamingOutput resultAsStreamingOutput(ManagedExecutionId id, PrintSettings settings, List<ManagedQuery> queries, IdMappingState state, Charset charset, String lineSeparator) {

--- a/docs/REST API JSONs.md
+++ b/docs/REST API JSONs.md
@@ -141,7 +141,7 @@ Returns: [ExecutionStatus](#Type-ExecutionStatus)
 
 </p></details>
 
-### GET datasets/{dataset}/result/<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ResultCSVResource.java#L50)</sup></sub></sup>
+### GET datasets/{dataset}/result/<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ResultCSVResource.java#L51)</sup></sub></sup>
 
 
 <details><summary>Details</summary><p>
@@ -152,6 +152,7 @@ Method: `getAsCsv`
 
 Expects: `String`
 Expects: `String`
+Expects: `Optional<Boolean>`
 Returns: `Response`
 
 </p></details>


### PR DESCRIPTION
@Kadrian for the preview feature
Adds prettyPrint QueryParameter to 
`datasets/{DATASET}/result/{QUERY}.csv?pretty=(true|false)` .
This influences the printed output for columns of type INTEGER, MONEY and NUMERIC.

**pretty=true:**
- INTEGER Locale en_US: 10,908,090
- NUMERIC  Locale en_US: 10,908,090.84...
- NUMERIC  Locale de_DE: 10.908.090,84...
- MONEY Locale de_DE (DOLLAR,EUR, ... two digits): 10.908.090,84

**pretty=false:**
- INTEGER: 10908090
- NUMERIC: 10908090.84...
- MONEY (cents): 1090809084