### PR TITLE
call a private method instead of creating a lambda

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/models/types/parser/specific/string/StringParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/types/parser/specific/string/StringParser.java
@@ -62,7 +62,7 @@ public class StringParser extends Parser<Integer> {
 
 	@Override
 	protected Integer parseValue(String value) throws ParsingException {
-		return strings.computeIfAbsent(value, this::parseNewValue);
+		return strings.computeIfAbsent(value, this::processNewValue);
 	}
 	
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/types/parser/specific/string/StringParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/types/parser/specific/string/StringParser.java
@@ -49,19 +49,20 @@ public class StringParser extends Parser<Integer> {
 	public StringParser(ParserConfig config) {
 
 	}
+	
+	private int parseNewValue(String value) {
+
+		//set longest common prefix and suffix
+		prefix = Strings.commonPrefix(value, Objects.requireNonNullElse(prefix, value));
+		suffix = Strings.commonSuffix(value, Objects.requireNonNullElse(suffix, value));
+
+		//return next id
+		return strings.size();
+	}
 
 	@Override
 	protected Integer parseValue(String value) throws ParsingException {
-		return strings.computeIfAbsent(value, v-> {
-			//new values
-
-			//set longest common prefix and suffix
-			prefix = Strings.commonPrefix(v, Objects.requireNonNullElse(prefix, v));
-			suffix = Strings.commonSuffix(v, Objects.requireNonNullElse(suffix, v));
-
-			//return next id
-			return strings.size();
-		});
+		return strings.computeIfAbsent(value, this::parseNewValue);
 	}
 	
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/types/parser/specific/string/StringParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/types/parser/specific/string/StringParser.java
@@ -50,7 +50,7 @@ public class StringParser extends Parser<Integer> {
 
 	}
 	
-	private int parseNewValue(String value) {
+	private int processNewValue(String value) {
 
 		//set longest common prefix and suffix
 		prefix = Strings.commonPrefix(value, Objects.requireNonNullElse(prefix, value));


### PR DESCRIPTION
Reduce creation of lambda objects

```
 num     #instances         #bytes  class name (module)
-------------------------------------------------------
   1:     608625161    56831278992  [Ljava.lang.Object; (java.base@11.0.8)
....
com.bakdata.conquery.models.common.daterange.CDateRangeExactly
  19:      19069613      457670712  com.bakdata.conquery.models.types.parser.specific.string.StringParser$$Lambda$402/0x00007efe435ff0b0
  20:       7113683      227637856  it.unimi.dsi.fastutil.bytes.ByteArrayList
```