### PR TITLE
Improve several details about secondary IDs

### DIFF
--- a/frontend/mock-api/concepts.json
+++ b/frontend/mock-api/concepts.json
@@ -2,7 +2,7 @@
   "version": 1,
   "secondaryIds": [
     {
-      "description": "Toystory 2: Electric Treppenfahrstuhl Boogaloo",
+      "description": "Toystory 2: Electric Treppenfahrstuhl Boogaloo, weil das ganze eine sehr spannende Beschreibung ist, die relativ lange anmutet.",
       "label": "Secondary Fall",
       "id": "fun2_fall_id"
     },

--- a/frontend/mock-api/index.js
+++ b/frontend/mock-api/index.js
@@ -183,6 +183,12 @@ module.exports = function (app, port) {
             shared: Math.random() < 0.8,
             resultUrl: notExecuted ? null : `/api/results/results.csv`,
             ownerName: "System",
+            ...(Math.random() > 0.2
+              ? { queryType: "CONCEPT_QUERY" }
+              : {
+                  queryType: "SECONDARY_ID_QUERY",
+                  secondaryId: "fun_fall_id",
+                }),
           });
         }
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,7 +54,7 @@
     "react-router-redux": "5.0.0-alpha.8",
     "react-select": "^3.1.0",
     "react-split-pane": "^0.1.91",
-    "react-tippy": "^1.2.3",
+    "react-tippy": "^1.4.0",
     "redux": "^4.0.5",
     "redux-form": "^8.3.7",
     "redux-multi": "^0.1.12",

--- a/frontend/src/js/api/types.ts
+++ b/frontend/src/js/api/types.ts
@@ -303,6 +303,8 @@ export interface GetStoredQueryResponseT {
   requiredTime: number; // TODO: Not used
   tags?: string[];
   query: QueryT;
+  queryType: "CONCEPT_QUERY" | "SECONDARY_ID_QUERY";
+  secondaryId: string | null;
   owner: string; // TODO: Remove. Not used. And it's actually an ID
   status: "DONE" | "NEW"; // TODO: Remove. Not used here
   groups?: UserGroupIdT[];

--- a/frontend/src/js/form-components/DropzoneWithFileInput.tsx
+++ b/frontend/src/js/form-components/DropzoneWithFileInput.tsx
@@ -36,12 +36,12 @@ const TopRight = styled("p")`
 
 interface PropsT {
   children: (args: ChildArgs) => React.ReactNode;
-  acceptedDropTypes?: string[];
   onSelectFile: (file: File) => void;
+  onDrop: (props: any, monitor: DropTargetMonitor) => void;
+  acceptedDropTypes?: string[];
   disableClick?: boolean;
   showFileSelectButton?: boolean;
   isInitial?: boolean;
-  onDrop: (props: any, monitor: DropTargetMonitor) => void;
 }
 
 /*

--- a/frontend/src/js/form-components/ToggleButton.tsx
+++ b/frontend/src/js/form-components/ToggleButton.tsx
@@ -1,14 +1,46 @@
 import React, { FC } from "react";
 import styled from "@emotion/styled";
+import WithTooltip from "../tooltip/WithTooltip";
 
-const Root = styled("p")`
+const Root = styled("div")`
   margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+
+  > span {
+    &:first-child {
+      margin-left: 0;
+      border-top-left-radius: 2px;
+      border-bottom-left-radius: 2px;
+    }
+
+    &:last-child {
+      border-top-right-radius: 2px;
+      border-bottom-right-radius: 2px;
+    }
+  }
+  > div {
+    &:first-child {
+      span {
+        margin-left: 0;
+        border-top-left-radius: 2px;
+        border-bottom-left-radius: 2px;
+      }
+    }
+    &:last-child {
+      span {
+        border-top-right-radius: 2px;
+        border-bottom-right-radius: 2px;
+      }
+    }
+  }
 `;
 
 const Option = styled("span")<{ active?: boolean }>`
   font-size: ${({ theme }) => theme.font.xs};
   display: inline-block;
-  padding: 2px 8px;
+  padding: 4px 8px;
   cursor: pointer;
   transition: color ${({ theme }) => theme.transitionTime},
     background-color ${({ theme }) => theme.transitionTime};
@@ -19,17 +51,6 @@ const Option = styled("span")<{ active?: boolean }>`
 
   margin-left: -1px;
 
-  &:first-of-type {
-    margin-left: 0;
-    border-top-left-radius: 2px;
-    border-bottom-left-radius: 2px;
-  }
-
-  &:last-of-type {
-    border-top-right-radius: 2px;
-    border-bottom-right-radius: 2px;
-  }
-
   &:hover {
     background-color: ${({ theme, active }) =>
       active ? "white" : theme.col.graySuperLight};
@@ -39,6 +60,7 @@ const Option = styled("span")<{ active?: boolean }>`
 interface OptionsT {
   label: string;
   value: string;
+  description?: string;
 }
 
 interface PropsT {
@@ -52,16 +74,18 @@ interface PropsT {
 const ToggleButton: FC<PropsT> = ({ options, input }) => {
   return (
     <Root>
-      {options.map(({ value, label }, i) => (
-        <Option
-          key={i}
-          active={input.value === value}
-          onClick={() => {
-            if (value !== input.value) input.onChange(value);
-          }}
-        >
-          {label}
-        </Option>
+      {options.map(({ value, label, description }, i) => (
+        <WithTooltip text={description}>
+          <Option
+            key={i}
+            active={input.value === value}
+            onClick={() => {
+              if (value !== input.value) input.onChange(value);
+            }}
+          >
+            {label}
+          </Option>
+        </WithTooltip>
       ))}
     </Root>
   );

--- a/frontend/src/js/previous-queries/list/PreviousQuery.tsx
+++ b/frontend/src/js/previous-queries/list/PreviousQuery.tsx
@@ -29,7 +29,7 @@ import PreviousQueryTags from "./PreviousQueryTags";
 import { formatDateDistance } from "../../common/helpers";
 import { PreviousQueryT } from "./reducer";
 import PreviousQueriesLabel from "./PreviousQueriesLabel";
-import type { DatasetIdT } from "../../api/types";
+import type { DatasetIdT, SecondaryId } from "../../api/types";
 import type { StateT } from "app-types";
 import { useDeletePreviousQuery } from "./useDeletePreviousQuery";
 
@@ -113,6 +113,10 @@ const PreviousQuery = React.forwardRef<HTMLDivElement, PropsT>(
       canDownloadResult(state)
     );
 
+    const loadedSecondaryIds = useSelector<StateT, SecondaryId[]>(
+      (state) => state.conceptTrees.secondaryIds
+    );
+
     const dispatch = useDispatch();
 
     const onRenamePreviousQuery = (label: string) =>
@@ -145,6 +149,10 @@ const PreviousQuery = React.forwardRef<HTMLDivElement, PropsT>(
     );
     const label = query.label || query.id.toString();
     const mayEditQuery = query.own || query.shared;
+
+    const secondaryId = query.secondaryId
+      ? loadedSecondaryIds.find((secId) => query.secondaryId === secId.id)
+      : null;
 
     return (
       <Root
@@ -182,6 +190,15 @@ const PreviousQuery = React.forwardRef<HTMLDivElement, PropsT>(
                     />
                   </StyledWithTooltip>
                 )}
+              {secondaryId && query.queryType === "SECONDARY_ID_QUERY" && (
+                <StyledWithTooltip
+                  text={`${T.translate("queryEditor.secondaryId")}: ${
+                    secondaryId.label
+                  }`}
+                >
+                  <IconButton icon="microscope" bare onClick={() => {}} />
+                </StyledWithTooltip>
+              )}
               {query.own && !query.shared && (
                 <StyledWithTooltip text={T.translate("common.share")}>
                   <IconButton icon="upload" bare onClick={onIndicateShare} />

--- a/frontend/src/js/previous-queries/list/PreviousQueryDragContainer.tsx
+++ b/frontend/src/js/previous-queries/list/PreviousQueryDragContainer.tsx
@@ -15,22 +15,25 @@ interface PropsT {
   datasetId: DatasetIdT;
   onIndicateDeletion: () => void;
   onIndicateShare: () => void;
-  connectDragSource: () => void;
 }
 
 const PreviousQueryDragContainer: FC<PropsT> = ({ query, ...props }) => {
   const isNotEditing = !(query.editingLabel || query.editingTags);
   const ref = useRef<HTMLDivElement | null>(null);
+  const dragType =
+    query.queryType === "CONCEPT_QUERY" ? PREVIOUS_QUERY : "UNDROPPABLE";
   const item = {
     width: 0,
     height: 0,
-    type: PREVIOUS_QUERY,
+    type: dragType,
     id: query.id,
     label: query.label,
     isPreviousQuery: true,
   };
+
   const [, drag] = useDrag({
     item,
+    canDrag: dragType !== "UNDROPPABLE",
     begin: (): DraggedQueryType => ({
       ...item,
       ...getWidthAndHeight(ref),

--- a/frontend/src/js/previous-queries/list/reducer.ts
+++ b/frontend/src/js/previous-queries/list/reducer.ts
@@ -32,6 +32,8 @@ export interface PreviousQueryT {
   shared: boolean;
   isPristineLabel?: boolean;
   groups?: UserGroupIdT[];
+  queryType: "CONCEPT_QUERY" | "SECONDARY_ID_QUERY";
+  secondaryId?: string | null;
 }
 
 export interface PreviousQueriesStateT {

--- a/frontend/src/js/previous-queries/upload/CSVColumnPicker.tsx
+++ b/frontend/src/js/previous-queries/upload/CSVColumnPicker.tsx
@@ -11,10 +11,10 @@ import FaIcon from "../../icon/FaIcon";
 import ReactSelect from "../../form-components/ReactSelect";
 import InputSelect from "../../form-components/InputSelect";
 
-type ExternalQueryT = {
+export interface ExternalQueryT {
   format: string[];
   values: string[][];
-};
+}
 
 type PropsT = {
   file: File;
@@ -94,13 +94,13 @@ export default ({ file, loading, onUpload, onReset }: PropsT) => {
     { label: T.translate("csvColumnPicker.dateSet"), value: "DATE_SET" },
     { label: T.translate("csvColumnPicker.startDate"), value: "START_DATE" },
     { label: T.translate("csvColumnPicker.endDate"), value: "END_DATE" },
-    { label: T.translate("csvColumnPicker.ignore"), value: "IGNORE" }
+    { label: T.translate("csvColumnPicker.ignore"), value: "IGNORE" },
   ];
 
   const DELIMITER_OPTIONS = [
     { label: T.translate("csvColumnPicker.semicolon") + " ( ; )", value: ";" },
     { label: T.translate("csvColumnPicker.comma") + " ( , )", value: "," },
-    { label: T.translate("csvColumnPicker.colon") + " ( : )", value: ":" }
+    { label: T.translate("csvColumnPicker.colon") + " ( : )", value: ":" },
   ];
 
   React.useEffect(() => {
@@ -139,7 +139,7 @@ export default ({ file, loading, onUpload, onReset }: PropsT) => {
   function uploadQuery() {
     onUpload({
       format: csvHeader,
-      values: csv
+      values: csv,
     });
   }
 
@@ -156,7 +156,7 @@ export default ({ file, loading, onUpload, onReset }: PropsT) => {
             input={{
               onChange: setDelimiter,
               value: delimiter,
-              defaultValue: DELIMITER_OPTIONS[0]
+              defaultValue: DELIMITER_OPTIONS[0],
             }}
             options={DELIMITER_OPTIONS}
           />
@@ -178,14 +178,14 @@ export default ({ file, loading, onUpload, onReset }: PropsT) => {
                       small
                       options={SELECT_OPTIONS}
                       value={
-                        SELECT_OPTIONS.find(o => o.value === csvHeader[i]) ||
+                        SELECT_OPTIONS.find((o) => o.value === csvHeader[i]) ||
                         SELECT_OPTIONS[0]
                       }
-                      onChange={value =>
+                      onChange={(value) =>
                         setCSVHeader([
                           ...csvHeader.slice(0, i),
                           value.value,
-                          ...csvHeader.slice(i + 1)
+                          ...csvHeader.slice(i + 1),
                         ])
                       }
                     />

--- a/frontend/src/js/previous-queries/upload/UploadQueryResultsModal.tsx
+++ b/frontend/src/js/previous-queries/upload/UploadQueryResultsModal.tsx
@@ -10,7 +10,8 @@ import Modal from "../../modal/Modal";
 import ErrorMessage from "../../error-message/ErrorMessage";
 import FaIcon from "../../icon/FaIcon";
 
-import CSVColumnPicker from "./CSVColumnPicker";
+import CSVColumnPicker, { ExternalQueryT } from "./CSVColumnPicker";
+import { DropTargetMonitor } from "react-dnd";
 
 const Root = styled("div")`
   text-align: center;
@@ -46,18 +47,24 @@ const SxDropzoneWithFileInput = styled(DropzoneWithFileInput)`
   cursor: pointer;
 `;
 
-type PropsT = {
+interface PropsT {
   loading: boolean;
   success: Object | null;
   error: Object | null;
-  onClose: Function;
-  onUpload: Function;
-};
+  onClose: () => void;
+  onUpload: (query: ExternalQueryT) => void;
+}
 
-export default ({ loading, success, error, onClose, onUpload }: PropsT) => {
-  const [file, setFile] = React.useState(null);
+const UploadQueryResultsModal: React.FC<PropsT> = ({
+  loading,
+  success,
+  error,
+  onClose,
+  onUpload,
+}) => {
+  const [file, setFile] = React.useState<File | null>(null);
 
-  function onDrop(_, monitor) {
+  function onDrop(_: any, monitor: DropTargetMonitor) {
     const item = monitor.getItem();
 
     if (item.files) {
@@ -119,3 +126,5 @@ export default ({ loading, success, error, onClose, onUpload }: PropsT) => {
     </Modal>
   );
 };
+
+export default UploadQueryResultsModal;

--- a/frontend/src/js/standard-query-editor/SecondaryIdSelector.tsx
+++ b/frontend/src/js/standard-query-editor/SecondaryIdSelector.tsx
@@ -10,12 +10,20 @@ import { T } from "../localization";
 import { ConceptQueryNodeType, StandardQueryType } from "./types";
 import type { SelectedSecondaryIdStateT } from "./selectedSecondaryIdReducer";
 import { setSelectedSecondaryId } from "./actions";
-import { SecondaryId } from "js/api/types";
+import { SecondaryId } from "../api/types";
+import FaIcon from "../icon/FaIcon";
 
 const Headline = styled.h3<{ active?: boolean }>`
   font-size: ${({ theme }) => theme.font.sm};
   margin: 0;
   text-transform: uppercase;
+  transition: color ${({ theme }) => theme.transitionTime};
+  color: ${({ theme, active }) =>
+    active ? theme.col.blueGrayDark : theme.col.gray};
+`;
+
+const SxFaIcon = styled(FaIcon)<{ active?: boolean }>`
+  transition: color ${({ theme }) => theme.transitionTime};
   color: ${({ theme, active }) =>
     active ? theme.col.blueGrayDark : theme.col.gray};
 `;
@@ -72,12 +80,14 @@ const SecondaryIdSelector: FC = () => {
     ...availableSecondaryIds.map((id) => ({
       label: id.label,
       value: id.id,
+      description: id.description,
     })),
   ];
 
   return (
     <div>
       <Headline active={!!selectedSecondaryId}>
+        <SxFaIcon active={!!selectedSecondaryId} left icon="microscope" />
         {T.translate("queryEditor.secondaryId")}
       </Headline>
       <ToggleButton

--- a/frontend/src/js/tooltip/InfoTooltip.tsx
+++ b/frontend/src/js/tooltip/InfoTooltip.tsx
@@ -1,23 +1,22 @@
-import React from "react";
+import React, { FC } from "react";
 import styled from "@emotion/styled";
 
 import FaIcon from "../icon/FaIcon";
 
 import WithTooltip from "./WithTooltip";
 
-type PropsType = {
+interface PropsT {
   text: string;
   className?: string;
   noIcon?: boolean;
-  place?: string;
-};
+}
 
 const Root = styled(WithTooltip)`
   display: inline-block;
   padding: 0 10px;
 `;
 
-const InfoTooltip = ({ className, text, noIcon, place }: PropsType) => {
+const InfoTooltip: FC<PropsT> = ({ className, text, noIcon }) => {
   return (
     <Root className={className} text={text}>
       {!noIcon && <FaIcon regular icon="question-circle" />}

--- a/frontend/src/js/tooltip/WithTooltip.tsx
+++ b/frontend/src/js/tooltip/WithTooltip.tsx
@@ -1,20 +1,22 @@
-import * as React from "react";
+import React, { FC, ReactElement } from "react";
 import { Tooltip } from "react-tippy";
 import "react-tippy/dist/tippy.css";
 
 interface PropsT {
   className?: string;
-  place?: string;
-  text?: React.ReactNode;
+  place?: "bottom" | "left" | "right" | "top";
+  text?: string;
+  html?: ReactElement;
 }
 
-const WithTooltip: React.FC<PropsT> = ({
+const WithTooltip: FC<PropsT> = ({
   className,
   children,
   place,
-  text
+  text,
+  html,
 }) => {
-  if (!text) return <>{children}</>;
+  if (!text && !html) return <>{children}</>;
 
   return (
     <Tooltip
@@ -22,8 +24,9 @@ const WithTooltip: React.FC<PropsT> = ({
       position={place || "top"}
       arrow={true}
       duration={0}
-      delay={[0, 0]}
+      delay={0}
       title={text}
+      html={html}
     >
       {children}
     </Tooltip>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10454,10 +10454,10 @@ react-style-proptype@^3.2.2:
   dependencies:
     prop-types "^15.5.4"
 
-react-tippy@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/react-tippy/-/react-tippy-1.2.3.tgz#8aef183ec4986ca7c5c556465013d95196fecfd8"
-  integrity sha512-cEmhw29DbVP33n9ayo0nLzibuSz6o0A77cZtzno7zGsfOH8tUEGai/8a7TXRIKHPYDooW8iJkJBIPDnxmEu00g==
+react-tippy@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/react-tippy/-/react-tippy-1.4.0.tgz#e8a8b4085ec985e5c94fe128918b733b588a1465"
+  integrity sha512-r/hM5XK9Ztr2ZY7IWKuRmISTlUPS/R6ddz6PO2EuxCgW+4JBcGZRPU06XcVPRDCOIiio8ryBQFrXMhFMhsuaHA==
   dependencies:
     popper.js "^1.11.1"
 


### PR DESCRIPTION
- Add queryType to mock api secondaryIds
- Add possible secondaryID to mock api secondaryIds
- Highlight analysis-layer using a microscope icon, in previous queries
  list as well as in in the editor
- Prevent secondary id queries to be dragged and dropped (probably a
  temporary solution)
- Allow seeing secondary id description as a tooltip on the toggle button
- Upgrade react-tippy@latest along the way