### PR TITLE
make distiction between two execution status types: overview and full

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
@@ -19,7 +19,6 @@ import com.bakdata.conquery.models.auth.permissions.DatasetPermission;
 import com.bakdata.conquery.models.auth.permissions.QueryPermission;
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.execution.ExecutionStatus;
-import com.bakdata.conquery.models.execution.ExecutionStatus.CreationFlag;
 import com.bakdata.conquery.models.execution.ManagedExecution;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
@@ -150,7 +149,7 @@ public class QueryProcessor {
 	}
 
 	public ExecutionStatus getStatus(ManagedExecution<?> query, UriBuilder urlb, User user) {
-		return query.buildStatus(storage, urlb, user, datasetRegistry, CreationFlag.WITH_COLUMN_DESCIPTION);
+		return query.buildStatusFull(storage, urlb, user, datasetRegistry);
 	}
 
 	public ExecutionStatus cancel(Dataset dataset, ManagedExecution<?> query, UriBuilder urlb) {

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/StoredQueriesProcessor.java
@@ -18,7 +18,6 @@ import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.exceptions.JSONException;
 import com.bakdata.conquery.models.execution.ExecutionState;
 import com.bakdata.conquery.models.execution.ExecutionStatus;
-import com.bakdata.conquery.models.execution.ExecutionStatus.CreationFlag;
 import com.bakdata.conquery.models.execution.ManagedExecution;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
@@ -55,9 +54,8 @@ public class StoredQueriesProcessor {
 			.flatMap(mq -> {
 				try {
 					return Stream.of(
-						mq.buildStatus(
+						mq.buildStatusOverview(
 							storage,
-							uriBuilder,
 							user,
 							datasetRegistry));
 				}
@@ -88,12 +86,12 @@ public class StoredQueriesProcessor {
 		storage.removeExecution(queryId);
 	}
 	
-	public ExecutionStatus getQueryWithSource(ManagedExecutionId queryId, User user, UriBuilder url) {
+	public ExecutionStatus getQueryFullStatus(ManagedExecutionId queryId, User user, UriBuilder url) {
 		ManagedExecution<?> query = storage.getExecution(queryId);
 		if (query == null) {
 			return null;
 		}
-		return query.buildStatus(storage, url, user, datasetRegistry, EnumSet.of(CreationFlag.WITH_COLUMN_DESCIPTION, CreationFlag.WITH_SOURCE, CreationFlag.WITH_GROUPS));
+		return query.buildStatusFull(storage, url, user, datasetRegistry);
 	}
 
 	public void patchQuery(User user, ManagedExecutionId executionId, MetaDataPatch patch) throws JSONException {

--- a/backend/src/main/java/com/bakdata/conquery/commands/ManagerNode.java
+++ b/backend/src/main/java/com/bakdata/conquery/commands/ManagerNode.java
@@ -149,7 +149,6 @@ public class ManagerNode extends IoHandlerAdapter implements Managed {
 			sn.getStorage().setMetaStorage(storage);
 		}
 
-
 		
 		authController = new AuthorizationController(environment, config.getAuthorization(), config.getAuthentication(), storage);
 		authController.init();

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java
@@ -61,6 +61,7 @@ public abstract class ExecutionStatus {
 	@NoArgsConstructor
 	@Data
 	@EqualsAndHashCode(callSuper = true)
+	@FieldNameConstants
 	public static class Full extends ExecutionStatus {
 
 		/**

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java
@@ -14,68 +14,83 @@ import com.bakdata.conquery.models.identifiable.ids.specific.SecondaryIdDescript
 import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
 import com.bakdata.conquery.models.query.ColumnDescriptor;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import lombok.experimental.FieldNameConstants;
+import lombok.experimental.SuperBuilder;
 
 @NoArgsConstructor
 @ToString
-@AllArgsConstructor
 @Data
 @FieldNameConstants
-public class ExecutionStatus {
+public abstract class ExecutionStatus {
 
-		private String[] tags;
-		private String label;
-		@JsonProperty("isPristineLabel")
-		private boolean isPristineLabel;
-		private ZonedDateTime createdAt;
-		private ZonedDateTime lastUsed;
-		private UserId owner;
-		private String ownerName;
-		private boolean shared;
-		private boolean own;
-		private boolean system;
+	private String[] tags;
+	private String label;
+	@JsonProperty("isPristineLabel")
+	private boolean isPristineLabel;
+	private ZonedDateTime createdAt;
+	private ZonedDateTime lastUsed;
+	private UserId owner;
+	private String ownerName;
+	private boolean shared;
+	private boolean own;
+	private boolean system;
 
-		private ManagedExecutionId id;
-		private ExecutionState status;
-		private Long numberOfResults;
-		private Long requiredTime;
+	private ManagedExecutionId id;
+	private ExecutionState status;
+	private Long numberOfResults;
+	private Long requiredTime;
+
+	private String queryType;
+	private SecondaryIdDescriptionId secondaryId;
+
+	/**
+	 * Light weight description of an execution. Rendering the overview should not cause heavy computations.
+	 */
+	@NoArgsConstructor
+	public static class Overview extends ExecutionStatus {
+
+	}
+
+
+	/**
+	 * This status holds extensive information about the query description and meta data that is computational heavy
+	 * and can produce a larger payload to requests.
+	 * It should only be rendered, when a client asks for a specific execution, not if a list of executions is requested.
+	 */
+	@NoArgsConstructor
+	@Data
+	@EqualsAndHashCode(callSuper = true)
+	public static class Full extends ExecutionStatus {
+
+		/**
+		 * The url under from which the result of the execution can be downloaded as soon as it finished successfully.
+		 */
 		private URL resultUrl;
 
-		private String queryType;
-		private SecondaryIdDescriptionId secondaryId;
-		
-		/**
-		 * Holds a description for each column, present in the result.
-		 */
-		private List<ColumnDescriptor> columnDescriptions;
-		
-		/**
-		 * Indicates if the concepts that are included in the query description can be accessed by the user.
-		 */
-		private boolean canExpand;
-		
-		/**
-		 * Is set to the query description if the user can expand all included concepts.
-		 */
-		private QueryDescription query;
-		
-		/**
-		 * Is set when the QueryFailed
-		 */
-		private ConqueryErrorInfo error;
-		
-		/**
-		 * The groups this execution is shared with.
-		 */
-		private Collection<GroupId> groups;
-		
-		public static enum CreationFlag{
-			WITH_COLUMN_DESCIPTION,
-			WITH_GROUPS,
-			WITH_SOURCE;
-		}
+        /**
+         * Holds a description for each column, present in the result.
+         */
+        private List<ColumnDescriptor> columnDescriptions;
+
+        /**
+         * Indicates if the concepts that are included in the query description can be accessed by the user.
+         */
+        private boolean canExpand;
+
+        /**
+         * Is set to the query description if the user can expand all included concepts.
+         */
+        private QueryDescription query;
+
+        /**
+         * Is set when the QueryFailed
+         */
+        private ConqueryErrorInfo error;
+
+        /**
+         * The groups this execution is shared with.
+         */
+        private Collection<GroupId> groups;
+	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
@@ -37,7 +37,6 @@ import com.bakdata.conquery.models.auth.permissions.DatasetPermission;
 import com.bakdata.conquery.models.auth.permissions.QueryPermission;
 import com.bakdata.conquery.models.error.ConqueryErrorInfo;
 import com.bakdata.conquery.models.exceptions.JSONException;
-import com.bakdata.conquery.models.execution.ExecutionStatus.CreationFlag;
 import com.bakdata.conquery.models.forms.managed.ManagedForm;
 import com.bakdata.conquery.models.identifiable.IdentifiableImpl;
 import com.bakdata.conquery.models.identifiable.ids.NamespacedId;
@@ -217,7 +216,7 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 		}
 	}
 
-	protected void setStatusBase(@NonNull MetaStorage storage, UriBuilder url, @NonNull  User user, @NonNull ExecutionStatus status) {
+	protected void setStatusBase(@NonNull MetaStorage storage, @NonNull  User user, @NonNull ExecutionStatus status) {
 		status.setLabel(label == null ? queryId.toString() : getLabelWithoutAutoLabelSuffix());
 		status.setPristineLabel(label == null || queryId.toString().equals(label) || isAutoLabeled());
 		status.setId(getId());
@@ -229,11 +228,6 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 		status.setStatus(state);
 		status.setOwner(Optional.ofNullable(owner).orElse(null));
 		status.setOwnerName(Optional.ofNullable(owner).map(owner -> storage.getUser(owner)).map(User::getLabel).orElse(null));
-		status.setResultUrl(getDownloadURL(url, user).orElse(null));
-		if (state.equals(ExecutionState.FAILED) && error != null) {
-			// Use plain format here to have a uniform serialization.
-			status.setError(error.asPlain());
-		}
 	}
 	
 
@@ -252,36 +246,39 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 	@Nullable
 	protected abstract URL getDownloadURLInternal(UriBuilder url) throws MalformedURLException, IllegalArgumentException, UriBuilderException;
 
-	public ExecutionStatus buildStatus(@NonNull MetaStorage storage, UriBuilder url, User user, DatasetRegistry datasetRegistry) {
-		return buildStatus(storage, url, user, datasetRegistry, EnumSet.noneOf(ExecutionStatus.CreationFlag.class));
-	}
-	public ExecutionStatus buildStatus(@NonNull MetaStorage storage, UriBuilder url, User user, DatasetRegistry datasetRegistry, @NonNull ExecutionStatus.CreationFlag creationFlag) {
-		return buildStatus(storage, url, user, datasetRegistry, EnumSet.of(creationFlag));
-	}
-	
-	public ExecutionStatus buildStatus(@NonNull MetaStorage storage, UriBuilder url, User user, DatasetRegistry datasetRegistry, @NonNull EnumSet<ExecutionStatus.CreationFlag> creationFlags) {
-		ExecutionStatus status = new ExecutionStatus();
-		setStatusBase(storage, url, user, status);
-		for(CreationFlag flag : creationFlags) {
-			switch (flag) {
-				case WITH_COLUMN_DESCIPTION:
-					setAdditionalFieldsForStatusWithColumnDescription(storage, url, user, status,  datasetRegistry);
-					break;
-				case WITH_SOURCE:
-					setAdditionalFieldsForStatusWithSource(storage, url, user, status);
-					break;
-				case WITH_GROUPS:
-					setAdditionalFieldsForStatusWithGroups(storage, user, status);
-					break;
-				default:
-					throw new IllegalArgumentException(String.format("Unhandled creation flag %s", flag));
-			}
-		}
+	/**
+	 * Renders a lightweight status with meta information about this query. Computation an size should be small for this.
+	 */
+	public ExecutionStatus.Overview buildStatusOverview(@NonNull MetaStorage storage, User user, DatasetRegistry datasetRegistry) {
+		ExecutionStatus.Overview status = new ExecutionStatus.Overview();
+		setStatusBase(storage, user, status);
+
 		return status;
-		
 	}
 
-	private void setAdditionalFieldsForStatusWithGroups(@NonNull MetaStorage storage, User user, ExecutionStatus status) {
+	/**
+	 * Renders an extensive status of this query (see {@link ExecutionStatus.Full}. The rendering can be computation intensive and can produce a large
+	 * object. The use  of the full status is only intended if a client requested specific information about this execution.
+	 */
+	public ExecutionStatus.Full buildStatusFull(@NonNull MetaStorage storage, UriBuilder url, User user, DatasetRegistry datasetRegistry) {
+		ExecutionStatus.Full status = new ExecutionStatus.Full();
+		setStatusBase(storage, user, status);
+
+		setAdditionalFieldsForStatusWithColumnDescription(storage, url, user, status,  datasetRegistry);
+		setAdditionalFieldsForStatusWithSource(storage, url, user, status);
+		setAdditionalFieldsForStatusWithGroups(storage, user, status);
+
+		if (state.equals(ExecutionState.FAILED) && error != null) {
+			// Use plain format here to have a uniform serialization.
+			status.setError(error.asPlain());
+		}
+
+		status.setResultUrl(getDownloadURL(url, user).orElse(null));
+
+		return status;
+	}
+
+	private void setAdditionalFieldsForStatusWithGroups(@NonNull MetaStorage storage, User user, ExecutionStatus.Full status) {
 		/* Calculate which groups can see this query.
 		 * This usually is usually not done very often and should be reasonable fast, so don't cache this.
 		 */
@@ -298,14 +295,14 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 		status.setGroups(permittedGroups);
 	}
 
-	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MetaStorage storage, UriBuilder url, User user, ExecutionStatus status, DatasetRegistry datasetRegistry) {
+	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MetaStorage storage, UriBuilder url, User user, ExecutionStatus.Full status, DatasetRegistry datasetRegistry) {
 		// Implementation specific
 	}
 
 	/**
 	 * Sets additional fields of an {@link ExecutionStatus} when a more specific status is requested.
 	 */
-	protected void setAdditionalFieldsForStatusWithSource(@NonNull MetaStorage storage, UriBuilder url, User user, ExecutionStatus status) {
+	protected void setAdditionalFieldsForStatusWithSource(@NonNull MetaStorage storage, UriBuilder url, User user, ExecutionStatus.Full status) {
 		QueryDescription query = getSubmitted();
 		NamespacedIdCollector namespacesIdCollector = new NamespacedIdCollector();
 		query.visit(namespacesIdCollector);

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
@@ -225,7 +225,7 @@ public class ManagedForm extends ManagedExecution<FormSharedResult> {
 	}
 	
 	@Override
-	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MetaStorage storage, UriBuilder url, User user, ExecutionStatus status, DatasetRegistry datasetRegistry) {
+	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MetaStorage storage, UriBuilder url, User user, ExecutionStatus.Full status, DatasetRegistry datasetRegistry) {
 		super.setAdditionalFieldsForStatusWithColumnDescription(storage, url, user, status, datasetRegistry);
 		// Set the ColumnDescription if the Form only consits of a single subquery
 		if(subQueries == null) {

--- a/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
@@ -152,8 +152,8 @@ public class ManagedQuery extends ManagedExecution<ShardResult> {
 	}
 	
 	@Override
-	protected void setStatusBase(@NonNull MetaStorage storage, UriBuilder url, @NonNull User user, @NonNull ExecutionStatus status) {
-		super.setStatusBase(storage, url, user, status);
+	protected void setStatusBase(@NonNull MetaStorage storage, @NonNull User user, @NonNull ExecutionStatus status) {
+		super.setStatusBase(storage, user, status);
 		status.setNumberOfResults(lastResultCount);
 
 		status.setQueryType(query.getClass().getAnnotation(CPSType.class).id());
@@ -164,7 +164,7 @@ public class ManagedQuery extends ManagedExecution<ShardResult> {
 	}
 	
 	@Override
-	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MetaStorage storage, UriBuilder url, User user, ExecutionStatus status, DatasetRegistry datasetRegistry) {
+	protected void setAdditionalFieldsForStatusWithColumnDescription(@NonNull MetaStorage storage, UriBuilder url, User user, ExecutionStatus.Full status, DatasetRegistry datasetRegistry) {
 		super.setAdditionalFieldsForStatusWithColumnDescription(storage, url, user, status, datasetRegistry);
 		if (columnDescriptions == null) {
 			columnDescriptions = generateColumnDescriptions(datasetRegistry);

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/StoredQueriesResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/StoredQueriesResource.java
@@ -50,7 +50,7 @@ public class StoredQueriesResource extends HDatasets {
 		authorize(user, datasetId, Ability.READ);
 		authorize(user, queryId, Ability.READ);
 		
-		ExecutionStatus status = processor.getQueryWithSource(queryId, user, RequestAwareUriBuilder.fromRequest(servletRequest));
+		ExecutionStatus status = processor.getQueryFullStatus(queryId, user, RequestAwareUriBuilder.fromRequest(servletRequest));
 		if (status == null) {
 			throw new WebApplicationException("Unknown query " + queryId, Status.NOT_FOUND);
 		}
@@ -63,7 +63,7 @@ public class StoredQueriesResource extends HDatasets {
 		authorize(user, datasetId, Ability.READ);
 		processor.patchQuery(user, queryId, patch);
 		
-		return processor.getQueryWithSource(queryId, user, RequestAwareUriBuilder.fromRequest(servletRequest));
+		return processor.getQueryFullStatus(queryId, user, RequestAwareUriBuilder.fromRequest(servletRequest));
 	}
 
 	@DELETE

--- a/backend/src/test/java/com/bakdata/conquery/api/StoredQueriesProcessorTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/api/StoredQueriesProcessorTest.java
@@ -145,7 +145,21 @@ public class StoredQueriesProcessorTest {
 	}
 
 	private static ExecutionStatus makeState(ManagedExecutionId id, User owner, User callingUser, ExecutionState state, String typeLabel, SecondaryIdDescriptionId secondaryId) {
-		return new ExecutionStatus(new String[0], id.getExecution().toString(), true, LocalDateTime.MIN.atZone(ZoneId.systemDefault()), null, owner.getId(), null, false, owner.equals(callingUser), false, id, state, null, null, null, typeLabel, secondaryId, null, false, null, null, null);
+		ExecutionStatus.Overview status = new ExecutionStatus.Overview();
+
+		status.setTags(new String[0]);
+		status.setLabel(id.getExecution().toString());
+		status.setPristineLabel(true);
+		status.setCreatedAt(LocalDateTime.MIN.atZone(ZoneId.systemDefault()));
+		status.setOwner(owner.getId());
+		status.setShared(false);
+		status.setOwn(owner.equals(callingUser));
+		status.setId(id);
+		status.setStatus(state);
+		status.setQueryType(typeLabel);
+		status.setSecondaryId(secondaryId); // This is probably not interesting on the overview (only if there is an filter for the search)
+
+		return status;
 	}
 
 }

--- a/backend/src/test/java/com/bakdata/conquery/api/form/config/FormConfigTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/api/form/config/FormConfigTest.java
@@ -87,7 +87,6 @@ public class FormConfigTest {
 	
 	@BeforeAll
 	public void setupTestClass() throws Exception{
-		SharedMetricRegistries.setDefault(FormConfigTest.class.getName());
 		storageMock = Mockito.mock(MetaStorage.class);
 
 		dataset.setName("test");

--- a/docs/REST API JSONs.md
+++ b/docs/REST API JSONs.md
@@ -715,7 +715,7 @@ Supported Fields:
 | [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/config/FrontendConfig$CurrencyConfig.java) | thousandSeparator | `String` | `"."` |  |  | 
 </p></details>
 
-### Type ExecutionStatus<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L23)</sup></sub></sup>
+### Type ExecutionStatus<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L21)</sup></sub></sup>
 
 
 <details><summary>Details</summary><p>
@@ -726,27 +726,21 @@ Supported Fields:
 
 |  | Field | Type | Default | Example | Description |
 | --- | --- | --- | --- | --- | --- |
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L56-L58) | canExpand | `boolean` | `false` |  | Indicates if the concepts that are included in the query description can be accessed by the user. | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L51-L53) | columnDescriptions | list of `ColumnDescriptor` | `null` |  | Holds a description for each column, present in the result. | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L34) | createdAt | `ZonedDateTime` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L66-L68) | error | `ConqueryErrorInfo` | `null` |  | Is set when the QueryFailed | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L71-L73) | groups | `Collection<GroupId>` | `null` |  | The groups this execution is shared with. | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L42) | id | ID of `ManagedExecution` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L31) | label | `String` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L35) | lastUsed | `ZonedDateTime` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L44) | numberOfResults | `long` or `null` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L39) | own | `boolean` | `false` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L36) | owner | ID of `User` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L37) | ownerName | `String` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L61-L63) | query | [QueryDescription](#Base-QueryDescription) | `null` |  | Is set to the query description if the user can expand all included concepts. | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L48) | queryType | `String` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L45) | requiredTime | `long` or `null` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L46) | resultUrl | `URL` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L49) | secondaryId | ID of `SecondaryIdDescription` | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L38) | shared | `boolean` | `false` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L43) | status | one of NEW, RUNNING, CANCELED, FAILED, DONE | `null` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L40) | system | `boolean` | `false` |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L30) | tags | list of `String` | `null` |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L31) | createdAt | `ZonedDateTime` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L39) | id | ID of `ManagedExecution` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L28) | label | `String` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L32) | lastUsed | `ZonedDateTime` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L41) | numberOfResults | `long` or `null` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L36) | own | `boolean` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L33) | owner | ID of `User` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L34) | ownerName | `String` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L44) | queryType | `String` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L42) | requiredTime | `long` or `null` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L45) | secondaryId | ID of `SecondaryIdDescription` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L35) | shared | `boolean` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L40) | status | one of NEW, RUNNING, CANCELED, FAILED, DONE | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L37) | system | `boolean` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/execution/ExecutionStatus.java#L27) | tags | list of `String` | ? |  |  | 
 </p></details>
 
 ### Type FERoot<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/api/description/FERoot.java#L11-L13)</sup></sub></sup>


### PR DESCRIPTION
We make a distinction for a status of an execution that is requested by a client (since there is no GraphQL yet ;)):

1. Overview: Is intended for the Query-List View in the Frontend. It only holds meta data about the execution and results only in a little computation and a small payload per query.
2. Full: Includes the Query itself and Information about the Result, the Groups it is shared with and so on. It's intended use is when the Frontend requests informations about a specific execution/query.