### PR TITLE
Use Bitset as entity events into global List Preprocessing

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/models/config/ParserConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/ParserConfig.java
@@ -1,5 +1,7 @@
 package com.bakdata.conquery.models.config;
 
+import javax.validation.constraints.Max;
+
 import lombok.Data;
 import lombok.Setter;
 
@@ -13,4 +15,7 @@ public class ParserConfig {
 	 * @see Math#ulp(float)
 	 */
 	private double minPrecision = Double.MIN_VALUE;
+
+	@Max(Integer.MAX_VALUE)
+	private int preallocateBufferBytes = 5_000_000;
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/ColumnValues.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/ColumnValues.java
@@ -1,0 +1,44 @@
+package com.bakdata.conquery.models.events.parser;
+
+import java.util.BitSet;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * per Column Store to encode null in auxiliary bitset, allowing primitive storage.
+ */
+@SuppressWarnings("Unchecked")
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class ColumnValues<T> {
+
+	private final T nullValue;
+	private final BitSet nulls = new BitSet();
+	private int size = 0;
+
+	public boolean isNull(int event) {
+		return nulls.get(event);
+	}
+
+	public abstract T get(int event);
+
+	public int add(T value) {
+		int event = size++;
+
+		if (value == null) {
+			nulls.set(event);
+			write(event, nullValue);
+		}
+		else {
+			write(event, value);
+		}
+
+		return event;
+	}
+
+	protected abstract void write(int position, T obj);
+
+	public void close() {
+
+	}
+}

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/Parser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/Parser.java
@@ -93,6 +93,6 @@ public abstract class Parser<MAJOR_JAVA_TYPE, STORE_TYPE extends ColumnStore> {
 	public abstract void setValue(STORE_TYPE store, int event, MAJOR_JAVA_TYPE value);
 
 
-	public abstract ColumnValues createColumnValues();
+	public abstract ColumnValues createColumnValues(ParserConfig parserConfig);
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/Parser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/Parser.java
@@ -95,9 +95,8 @@ public abstract class Parser<MAJOR_JAVA_TYPE, STORE_TYPE extends ColumnStore> {
 	 */
 	public abstract void setValue(STORE_TYPE store, int event, MAJOR_JAVA_TYPE value);
 
-	public abstract List<MAJOR_JAVA_TYPE> createPrimitiveList();
 
-	public abstract MAJOR_JAVA_TYPE getNullValue();
+	public abstract ColumnValues createColumnValues();
 
 	/**
 	 * per Column Store to encode null in auxiliary bitset, allowing primitive storage.
@@ -105,8 +104,8 @@ public abstract class Parser<MAJOR_JAVA_TYPE, STORE_TYPE extends ColumnStore> {
 	@SuppressWarnings("Unchecked")
 	@RequiredArgsConstructor
 	public static class ColumnValues {
-		private final Object nullValue;
 		private final List values;
+		private final Object nullValue;
 
 		private final BitSet nulls = new BitSet();
 

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/Parser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/Parser.java
@@ -1,5 +1,6 @@
 package com.bakdata.conquery.models.events.parser;
 
+import java.util.BitSet;
 import java.util.List;
 
 import javax.annotation.Nonnull;
@@ -97,4 +98,39 @@ public abstract class Parser<MAJOR_JAVA_TYPE, STORE_TYPE extends ColumnStore> {
 	public abstract List<MAJOR_JAVA_TYPE> createPrimitiveList();
 
 	public abstract MAJOR_JAVA_TYPE getNullValue();
+
+	/**
+	 * per Column Store to encode null in auxiliary bitset, allowing primitive storage.
+	 */
+	@SuppressWarnings("Unchecked")
+	@RequiredArgsConstructor
+	public static class ColumnValues {
+		private final Object nullValue;
+		private final List values;
+
+		private final BitSet nulls = new BitSet();
+
+		public boolean isNull(int event) {
+			return nulls.get(event);
+		}
+
+		public Object get(int event) {
+			return values.get(event);
+		}
+
+		public int add(Object value) {
+			int event = values.size();
+
+
+			if (value == null) {
+				nulls.set(event);
+				values.add(nullValue);
+			}
+			else {
+				values.add(value);
+			}
+
+			return event;
+		}
+	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/Parser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/Parser.java
@@ -1,5 +1,7 @@
 package com.bakdata.conquery.models.events.parser;
 
+import java.util.List;
+
 import javax.annotation.Nonnull;
 
 import com.bakdata.conquery.models.config.ParserConfig;
@@ -92,4 +94,7 @@ public abstract class Parser<MAJOR_JAVA_TYPE, STORE_TYPE extends ColumnStore> {
 	 */
 	public abstract void setValue(STORE_TYPE store, int event, MAJOR_JAVA_TYPE value);
 
+	public abstract List<MAJOR_JAVA_TYPE> createPrimitiveList();
+
+	public abstract MAJOR_JAVA_TYPE getNullValue();
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/BooleanParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/BooleanParser.java
@@ -46,7 +46,7 @@ public class BooleanParser extends Parser<Boolean, BooleanStore> {
 	}
 
 	@Override
-	public ColumnValues createColumnValues() {
+	public ColumnValues createColumnValues(ParserConfig parserConfig) {
 		return new ColumnValues<Boolean>(Boolean.FALSE) {
 			private final BitSet values = new BitSet();
 

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/BooleanParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/BooleanParser.java
@@ -1,5 +1,7 @@
 package com.bakdata.conquery.models.events.parser.specific;
 
+import java.util.BitSet;
+
 import javax.annotation.Nonnull;
 
 import com.bakdata.conquery.models.config.ParserConfig;
@@ -7,7 +9,6 @@ import com.bakdata.conquery.models.events.parser.Parser;
 import com.bakdata.conquery.models.events.stores.primitive.BitSetStore;
 import com.bakdata.conquery.models.events.stores.root.BooleanStore;
 import com.bakdata.conquery.models.exceptions.ParsingException;
-import it.unimi.dsi.fastutil.booleans.BooleanArrayList;
 import lombok.ToString;
 
 @ToString(callSuper = true)
@@ -45,7 +46,19 @@ public class BooleanParser extends Parser<Boolean, BooleanStore> {
 
 	@Override
 	public ColumnValues createColumnValues() {
-		return new ColumnValues(new BooleanArrayList(), false);
+		return new ColumnValues<Boolean>(Boolean.FALSE) {
+			private final BitSet values = new BitSet();
+
+			@Override
+			public Boolean get(int event) {
+				return values.get(event);
+			}
+
+			@Override
+			protected void write(int event, Boolean obj) {
+				values.set(event, obj ? (byte) 1 : (byte) 0);
+			}
+		};
 	}
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/BooleanParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/BooleanParser.java
@@ -1,5 +1,7 @@
 package com.bakdata.conquery.models.events.parser.specific;
 
+import java.util.List;
+
 import javax.annotation.Nonnull;
 
 import com.bakdata.conquery.models.config.ParserConfig;
@@ -7,6 +9,7 @@ import com.bakdata.conquery.models.events.parser.Parser;
 import com.bakdata.conquery.models.events.stores.primitive.BitSetStore;
 import com.bakdata.conquery.models.events.stores.root.BooleanStore;
 import com.bakdata.conquery.models.exceptions.ParsingException;
+import it.unimi.dsi.fastutil.booleans.BooleanArrayList;
 import lombok.ToString;
 
 @ToString(callSuper = true)
@@ -40,5 +43,15 @@ public class BooleanParser extends Parser<Boolean, BooleanStore> {
 	@Override
 	public void setValue(BooleanStore store, int event, Boolean value) {
 		store.setBoolean(event, value);
+	}
+
+	@Override
+	public List<Boolean> createPrimitiveList() {
+		return new BooleanArrayList();
+	}
+
+	@Override
+	public Boolean getNullValue() {
+		return false;
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/BooleanParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/BooleanParser.java
@@ -1,7 +1,5 @@
 package com.bakdata.conquery.models.events.parser.specific;
 
-import java.util.List;
-
 import javax.annotation.Nonnull;
 
 import com.bakdata.conquery.models.config.ParserConfig;
@@ -46,12 +44,8 @@ public class BooleanParser extends Parser<Boolean, BooleanStore> {
 	}
 
 	@Override
-	public List<Boolean> createPrimitiveList() {
-		return new BooleanArrayList();
+	public ColumnValues createColumnValues() {
+		return new ColumnValues(new BooleanArrayList(), false);
 	}
 
-	@Override
-	public Boolean getNullValue() {
-		return false;
-	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/BooleanParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/BooleanParser.java
@@ -5,6 +5,7 @@ import java.util.BitSet;
 import javax.annotation.Nonnull;
 
 import com.bakdata.conquery.models.config.ParserConfig;
+import com.bakdata.conquery.models.events.parser.ColumnValues;
 import com.bakdata.conquery.models.events.parser.Parser;
 import com.bakdata.conquery.models.events.stores.primitive.BitSetStore;
 import com.bakdata.conquery.models.events.stores.root.BooleanStore;
@@ -57,6 +58,11 @@ public class BooleanParser extends Parser<Boolean, BooleanStore> {
 			@Override
 			protected void write(int event, Boolean obj) {
 				values.set(event, obj ? (byte) 1 : (byte) 0);
+			}
+
+			@Override
+			public void close() {
+				values.clear();
 			}
 		};
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/BufferBackedColumnValues.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/BufferBackedColumnValues.java
@@ -1,0 +1,46 @@
+package com.bakdata.conquery.models.events.parser.specific;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+
+import com.bakdata.conquery.models.events.parser.ColumnValues;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class BufferBackedColumnValues<T> extends ColumnValues<T> {
+
+	@Getter
+	private final MappedByteBuffer buffer;
+	@Getter
+	private final File bufferFile;
+	private final RandomAccessFile randomAccessFile;
+
+	@SneakyThrows
+	public BufferBackedColumnValues(T nullValue, int bufferSizeBytes) {
+		super(nullValue);
+
+		bufferFile = Files.createTempFile("columnvalues", "conquery").toFile();
+		bufferFile.deleteOnExit();
+
+
+		randomAccessFile = new RandomAccessFile(bufferFile, "rw");
+		buffer = randomAccessFile.getChannel().map(FileChannel.MapMode.READ_WRITE, 0, bufferSizeBytes);
+	}
+
+	@SneakyThrows
+	@Override
+	public void close() {
+		buffer.clear();
+
+		randomAccessFile.getChannel().close();
+		randomAccessFile.close();
+
+
+		Files.delete(bufferFile.toPath());
+	}
+}

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateParser.java
@@ -1,7 +1,5 @@
 package com.bakdata.conquery.models.events.parser.specific;
 
-import java.util.List;
-
 import javax.annotation.Nonnull;
 
 import com.bakdata.conquery.models.common.CDate;
@@ -60,12 +58,8 @@ public class DateParser extends Parser<Integer, DateStore> {
 	}
 
 	@Override
-	public List<Integer> createPrimitiveList() {
-		return new IntArrayList();
+	public ColumnValues createColumnValues() {
+		return new ColumnValues(new IntArrayList(), 0);
 	}
 
-	@Override
-	public Integer getNullValue() {
-		return 0;
-	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateParser.java
@@ -1,5 +1,7 @@
 package com.bakdata.conquery.models.events.parser.specific;
 
+import java.nio.IntBuffer;
+
 import javax.annotation.Nonnull;
 
 import com.bakdata.conquery.models.common.CDate;
@@ -10,7 +12,7 @@ import com.bakdata.conquery.models.events.stores.root.DateStore;
 import com.bakdata.conquery.models.events.stores.root.IntegerStore;
 import com.bakdata.conquery.models.exceptions.ParsingException;
 import com.bakdata.conquery.util.DateFormats;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
+import lombok.SneakyThrows;
 import lombok.ToString;
 
 @ToString(callSuper = true)
@@ -57,9 +59,22 @@ public class DateParser extends Parser<Integer, DateStore> {
 		store.setDate(event, value);
 	}
 
+	@SneakyThrows
 	@Override
 	public ColumnValues createColumnValues() {
-		return new ColumnValues(new IntArrayList(), 0);
+		return new ColumnValues<Integer>(0) {
+			private final IntBuffer buffer = ColumnValues.allocateBuffer().asIntBuffer();
+
+			@Override
+			public Integer get(int event) {
+				return buffer.get(event);
+			}
+
+			@Override
+			protected void write(int event, Integer obj) {
+				buffer.put(obj);
+			}
+		};
 	}
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateParser.java
@@ -6,6 +6,7 @@ import javax.annotation.Nonnull;
 
 import com.bakdata.conquery.models.common.CDate;
 import com.bakdata.conquery.models.config.ParserConfig;
+import com.bakdata.conquery.models.events.parser.ColumnValues;
 import com.bakdata.conquery.models.events.parser.Parser;
 import com.bakdata.conquery.models.events.stores.primitive.IntegerDateStore;
 import com.bakdata.conquery.models.events.stores.root.DateStore;
@@ -73,6 +74,11 @@ public class DateParser extends Parser<Integer, DateStore> {
 			@Override
 			protected void write(int event, Integer obj) {
 				buffer.put(obj);
+			}
+
+			@Override
+			public void close() {
+
 			}
 		};
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateParser.java
@@ -1,5 +1,7 @@
 package com.bakdata.conquery.models.events.parser.specific;
 
+import java.util.List;
+
 import javax.annotation.Nonnull;
 
 import com.bakdata.conquery.models.common.CDate;
@@ -10,6 +12,7 @@ import com.bakdata.conquery.models.events.stores.root.DateStore;
 import com.bakdata.conquery.models.events.stores.root.IntegerStore;
 import com.bakdata.conquery.models.exceptions.ParsingException;
 import com.bakdata.conquery.util.DateFormats;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import lombok.ToString;
 
 @ToString(callSuper = true)
@@ -54,5 +57,15 @@ public class DateParser extends Parser<Integer, DateStore> {
 	@Override
 	public void setValue(DateStore store, int event, Integer value) {
 		store.setDate(event, value);
+	}
+
+	@Override
+	public List<Integer> createPrimitiveList() {
+		return new IntArrayList();
+	}
+
+	@Override
+	public Integer getNullValue() {
+		return 0;
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateParser.java
@@ -62,9 +62,9 @@ public class DateParser extends Parser<Integer, DateStore> {
 
 	@SneakyThrows
 	@Override
-	public ColumnValues createColumnValues() {
-		return new ColumnValues<Integer>(0) {
-			private final IntBuffer buffer = ColumnValues.allocateBuffer().asIntBuffer();
+	public ColumnValues createColumnValues(ParserConfig parserConfig) {
+		return new BufferBackedColumnValues<Integer>(0, parserConfig.getPreallocateBufferBytes()) {
+			private final IntBuffer buffer = getBuffer().asIntBuffer();
 
 			@Override
 			public Integer get(int event) {
@@ -76,10 +76,6 @@ public class DateParser extends Parser<Integer, DateStore> {
 				buffer.put(obj);
 			}
 
-			@Override
-			public void close() {
-
-			}
 		};
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateRangeParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateRangeParser.java
@@ -1,7 +1,6 @@
 package com.bakdata.conquery.models.events.parser.specific;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import javax.annotation.Nonnull;
 
@@ -97,12 +96,8 @@ public class DateRangeParser extends Parser<CDateRange, DateRangeStore> {
 	}
 
 	@Override
-	public List<CDateRange> createPrimitiveList() {
-		return new ArrayList();
+	public ColumnValues createColumnValues() {
+		return new ColumnValues(new ArrayList<CDateRange>(), null);
 	}
 
-	@Override
-	public CDateRange getNullValue() {
-		return null;
-	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateRangeParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateRangeParser.java
@@ -99,7 +99,7 @@ public class DateRangeParser extends Parser<CDateRange, DateRangeStore> {
 	}
 
 	@Override
-	public ColumnValues createColumnValues() {
+	public ColumnValues createColumnValues(ParserConfig parserConfig) {
 		return new ColumnValues<CDateRange>( null) {
 			final List<CDateRange> decimals = new ArrayList<>();
 

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateRangeParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateRangeParser.java
@@ -7,6 +7,7 @@ import javax.annotation.Nonnull;
 
 import com.bakdata.conquery.models.common.daterange.CDateRange;
 import com.bakdata.conquery.models.config.ParserConfig;
+import com.bakdata.conquery.models.events.parser.ColumnValues;
 import com.bakdata.conquery.models.events.parser.Parser;
 import com.bakdata.conquery.models.events.stores.root.DateRangeStore;
 import com.bakdata.conquery.models.events.stores.specific.DateRangeTypeDateRange;

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateRangeParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateRangeParser.java
@@ -1,6 +1,7 @@
 package com.bakdata.conquery.models.events.parser.specific;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import javax.annotation.Nonnull;
 
@@ -12,6 +13,7 @@ import com.bakdata.conquery.models.events.stores.specific.DateRangeTypeDateRange
 import com.bakdata.conquery.models.events.stores.specific.DateRangeTypeQuarter;
 import com.bakdata.conquery.models.exceptions.ParsingException;
 import com.bakdata.conquery.util.DateFormats;
+import com.google.common.base.Preconditions;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -97,7 +99,20 @@ public class DateRangeParser extends Parser<CDateRange, DateRangeStore> {
 
 	@Override
 	public ColumnValues createColumnValues() {
-		return new ColumnValues(new ArrayList<CDateRange>(), null);
+		return new ColumnValues<CDateRange>( null) {
+			final List<CDateRange> decimals = new ArrayList<>();
+
+			@Override
+			public CDateRange get(int event) {
+				return decimals.get(event);
+			}
+
+			@Override
+			protected void write(int event, CDateRange obj) {
+				Preconditions.checkArgument(event == decimals.size());
+				decimals.add(obj);
+			}
+		};
 	}
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateRangeParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DateRangeParser.java
@@ -1,5 +1,8 @@
 package com.bakdata.conquery.models.events.parser.specific;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.annotation.Nonnull;
 
 import com.bakdata.conquery.models.common.daterange.CDateRange;
@@ -91,5 +94,15 @@ public class DateRangeParser extends Parser<CDateRange, DateRangeStore> {
 	@Override
 	public void setValue(DateRangeStore store, int event, CDateRange value) {
 		store.setDateRange(event, value);
+	}
+
+	@Override
+	public List<CDateRange> createPrimitiveList() {
+		return new ArrayList();
+	}
+
+	@Override
+	public CDateRange getNullValue() {
+		return null;
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DecimalParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DecimalParser.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.bakdata.conquery.models.config.ParserConfig;
+import com.bakdata.conquery.models.events.parser.ColumnValues;
 import com.bakdata.conquery.models.events.parser.Parser;
 import com.bakdata.conquery.models.events.stores.primitive.DecimalArrayStore;
 import com.bakdata.conquery.models.events.stores.root.DecimalStore;

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DecimalParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DecimalParser.java
@@ -3,6 +3,7 @@ package com.bakdata.conquery.models.events.parser.specific;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.List;
 
 import com.bakdata.conquery.models.config.ParserConfig;
 import com.bakdata.conquery.models.events.parser.Parser;
@@ -69,7 +70,19 @@ public class DecimalParser extends Parser<BigDecimal, DecimalStore> {
 
 	@Override
 	public ColumnValues createColumnValues() {
-		return new ColumnValues(new ArrayList(), BigDecimal.ZERO);
+		return new ColumnValues<BigDecimal>(BigDecimal.ZERO) {
+			final List<BigDecimal> decimals = new ArrayList<>();
+
+			@Override
+			public BigDecimal get(int event) {
+				return decimals.get(event);
+			}
+
+			@Override
+			protected void write(int event, BigDecimal obj) {
+				decimals.add(obj);
+			}
+		};
 	}
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DecimalParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DecimalParser.java
@@ -3,7 +3,6 @@ package com.bakdata.conquery.models.events.parser.specific;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.List;
 
 import com.bakdata.conquery.models.config.ParserConfig;
 import com.bakdata.conquery.models.events.parser.Parser;
@@ -69,13 +68,8 @@ public class DecimalParser extends Parser<BigDecimal, DecimalStore> {
 	}
 
 	@Override
-	public List<BigDecimal> createPrimitiveList() {
-		return new ArrayList<>();
-	}
-
-	@Override
-	public BigDecimal getNullValue() {
-		return BigDecimal.ZERO;
+	public ColumnValues createColumnValues() {
+		return new ColumnValues(new ArrayList(), BigDecimal.ZERO);
 	}
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DecimalParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DecimalParser.java
@@ -70,7 +70,7 @@ public class DecimalParser extends Parser<BigDecimal, DecimalStore> {
 	}
 
 	@Override
-	public ColumnValues createColumnValues() {
+	public ColumnValues createColumnValues(ParserConfig parserConfig) {
 		return new ColumnValues<BigDecimal>(BigDecimal.ZERO) {
 			final List<BigDecimal> decimals = new ArrayList<>();
 

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DecimalParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/DecimalParser.java
@@ -2,6 +2,8 @@ package com.bakdata.conquery.models.events.parser.specific;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.bakdata.conquery.models.config.ParserConfig;
 import com.bakdata.conquery.models.events.parser.Parser;
@@ -64,6 +66,16 @@ public class DecimalParser extends Parser<BigDecimal, DecimalStore> {
 	@Override
 	public void setValue(DecimalStore store, int event, BigDecimal value) {
 		store.setDecimal(event, value);
+	}
+
+	@Override
+	public List<BigDecimal> createPrimitiveList() {
+		return new ArrayList<>();
+	}
+
+	@Override
+	public BigDecimal getNullValue() {
+		return BigDecimal.ZERO;
 	}
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/IntegerParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/IntegerParser.java
@@ -1,7 +1,5 @@
 package com.bakdata.conquery.models.events.parser.specific;
 
-import java.util.List;
-
 import com.bakdata.conquery.models.config.ParserConfig;
 import com.bakdata.conquery.models.events.parser.Parser;
 import com.bakdata.conquery.models.events.stores.primitive.ByteArrayStore;
@@ -103,13 +101,8 @@ public class IntegerParser extends Parser<Long, IntegerStore> {
 	}
 
 	@Override
-	public List<Long> createPrimitiveList() {
-		return new LongArrayList();
-	}
-
-	@Override
-	public Long getNullValue() {
-		return 0L;
+	public ColumnValues createColumnValues() {
+		return new ColumnValues(new LongArrayList(), 0);
 	}
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/IntegerParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/IntegerParser.java
@@ -3,6 +3,7 @@ package com.bakdata.conquery.models.events.parser.specific;
 import java.nio.LongBuffer;
 
 import com.bakdata.conquery.models.config.ParserConfig;
+import com.bakdata.conquery.models.events.parser.ColumnValues;
 import com.bakdata.conquery.models.events.parser.Parser;
 import com.bakdata.conquery.models.events.stores.primitive.ByteArrayStore;
 import com.bakdata.conquery.models.events.stores.primitive.IntArrayStore;

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/IntegerParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/IntegerParser.java
@@ -1,5 +1,7 @@
 package com.bakdata.conquery.models.events.parser.specific;
 
+import java.nio.LongBuffer;
+
 import com.bakdata.conquery.models.config.ParserConfig;
 import com.bakdata.conquery.models.events.parser.Parser;
 import com.bakdata.conquery.models.events.stores.primitive.ByteArrayStore;
@@ -10,7 +12,6 @@ import com.bakdata.conquery.models.events.stores.root.IntegerStore;
 import com.bakdata.conquery.models.events.stores.specific.RebasingStore;
 import com.bakdata.conquery.models.exceptions.ParsingException;
 import com.bakdata.conquery.util.NumberParsing;
-import it.unimi.dsi.fastutil.longs.LongArrayList;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -102,7 +103,19 @@ public class IntegerParser extends Parser<Long, IntegerStore> {
 
 	@Override
 	public ColumnValues createColumnValues() {
-		return new ColumnValues(new LongArrayList(), 0);
+		return new ColumnValues<Long>(0L) {
+			private final LongBuffer buffer = ColumnValues.allocateBuffer().asLongBuffer();
+
+			@Override
+			public Long get(int event) {
+				return buffer.get(event);
+			}
+
+			@Override
+			protected void write(int event, Long obj) {
+				buffer.put(obj);
+			}
+		};
 	}
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/IntegerParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/IntegerParser.java
@@ -1,5 +1,7 @@
 package com.bakdata.conquery.models.events.parser.specific;
 
+import java.util.List;
+
 import com.bakdata.conquery.models.config.ParserConfig;
 import com.bakdata.conquery.models.events.parser.Parser;
 import com.bakdata.conquery.models.events.stores.primitive.ByteArrayStore;
@@ -10,6 +12,7 @@ import com.bakdata.conquery.models.events.stores.root.IntegerStore;
 import com.bakdata.conquery.models.events.stores.specific.RebasingStore;
 import com.bakdata.conquery.models.exceptions.ParsingException;
 import com.bakdata.conquery.util.NumberParsing;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -97,6 +100,16 @@ public class IntegerParser extends Parser<Long, IntegerStore> {
 	@Override
 	public void setValue(IntegerStore store, int event, Long value) {
 		store.setInteger(event, value);
+	}
+
+	@Override
+	public List<Long> createPrimitiveList() {
+		return new LongArrayList();
+	}
+
+	@Override
+	public Long getNullValue() {
+		return 0L;
 	}
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/IntegerParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/IntegerParser.java
@@ -103,9 +103,9 @@ public class IntegerParser extends Parser<Long, IntegerStore> {
 	}
 
 	@Override
-	public ColumnValues createColumnValues() {
-		return new ColumnValues<Long>(0L) {
-			private final LongBuffer buffer = ColumnValues.allocateBuffer().asLongBuffer();
+	public ColumnValues createColumnValues(ParserConfig parserConfig) {
+		return new BufferBackedColumnValues<Long>(0L, parserConfig.getPreallocateBufferBytes()) {
+			private final LongBuffer buffer = getBuffer().asLongBuffer();
 
 			@Override
 			public Long get(int event) {

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/MoneyParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/MoneyParser.java
@@ -65,9 +65,9 @@ public class MoneyParser extends Parser<Long, MoneyStore> {
 	}
 
 	@Override
-	public ColumnValues createColumnValues() {
-		return new ColumnValues<Long>(0L) {
-			private final LongBuffer buffer = ColumnValues.allocateBuffer().asLongBuffer();
+	public ColumnValues createColumnValues(ParserConfig parserConfig) {
+		return new BufferBackedColumnValues<Long>(0L, parserConfig.getPreallocateBufferBytes()) {
+			private final LongBuffer buffer = getBuffer().asLongBuffer();
 
 
 			@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/MoneyParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/MoneyParser.java
@@ -1,7 +1,6 @@
 package com.bakdata.conquery.models.events.parser.specific;
 
 import java.math.BigDecimal;
-import java.util.List;
 
 import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.config.ParserConfig;
@@ -65,13 +64,8 @@ public class MoneyParser extends Parser<Long, MoneyStore> {
 	}
 
 	@Override
-	public List<Long> createPrimitiveList() {
-		return new LongArrayList();
-	}
-
-	@Override
-	public Long getNullValue() {
-		return 0L;
+	public ColumnValues createColumnValues() {
+		return new ColumnValues(new LongArrayList(), 0);
 	}
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/MoneyParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/MoneyParser.java
@@ -5,6 +5,7 @@ import java.nio.LongBuffer;
 
 import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.config.ParserConfig;
+import com.bakdata.conquery.models.events.parser.ColumnValues;
 import com.bakdata.conquery.models.events.parser.Parser;
 import com.bakdata.conquery.models.events.stores.root.IntegerStore;
 import com.bakdata.conquery.models.events.stores.root.MoneyStore;

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/MoneyParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/MoneyParser.java
@@ -1,6 +1,7 @@
 package com.bakdata.conquery.models.events.parser.specific;
 
 import java.math.BigDecimal;
+import java.nio.LongBuffer;
 
 import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.config.ParserConfig;
@@ -11,7 +12,6 @@ import com.bakdata.conquery.models.events.stores.specific.MoneyIntStore;
 import com.bakdata.conquery.models.exceptions.ParsingException;
 import com.bakdata.conquery.util.NumberParsing;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import it.unimi.dsi.fastutil.longs.LongArrayList;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -65,7 +65,20 @@ public class MoneyParser extends Parser<Long, MoneyStore> {
 
 	@Override
 	public ColumnValues createColumnValues() {
-		return new ColumnValues(new LongArrayList(), 0);
+		return new ColumnValues<Long>(0L) {
+			private final LongBuffer buffer = ColumnValues.allocateBuffer().asLongBuffer();
+
+
+			@Override
+			public Long get(int event) {
+				return buffer.get(event);
+			}
+
+			@Override
+			protected void write(int event, Long obj) {
+				buffer.put(obj);
+			}
+		};
 	}
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/MoneyParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/MoneyParser.java
@@ -1,6 +1,7 @@
 package com.bakdata.conquery.models.events.parser.specific;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.config.ParserConfig;
@@ -11,6 +12,7 @@ import com.bakdata.conquery.models.events.stores.specific.MoneyIntStore;
 import com.bakdata.conquery.models.exceptions.ParsingException;
 import com.bakdata.conquery.util.NumberParsing;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -60,6 +62,16 @@ public class MoneyParser extends Parser<Long, MoneyStore> {
 	@Override
 	public void setValue(MoneyStore store, int event, Long value) {
 		store.setMoney(event, value);
+	}
+
+	@Override
+	public List<Long> createPrimitiveList() {
+		return new LongArrayList();
+	}
+
+	@Override
+	public Long getNullValue() {
+		return 0L;
 	}
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/RealParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/RealParser.java
@@ -1,7 +1,5 @@
 package com.bakdata.conquery.models.events.parser.specific;
 
-import java.util.List;
-
 import com.bakdata.conquery.models.config.ParserConfig;
 import com.bakdata.conquery.models.events.parser.Parser;
 import com.bakdata.conquery.models.events.stores.primitive.DoubleArrayStore;
@@ -63,12 +61,8 @@ public class RealParser extends Parser<Double, RealStore> {
 	}
 
 	@Override
-	public List<Double> createPrimitiveList() {
-		return new DoubleArrayList();
+	public ColumnValues createColumnValues() {
+		return new ColumnValues(new DoubleArrayList(), 0d);
 	}
 
-	@Override
-	public Double getNullValue() {
-		return 0d;
-	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/RealParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/RealParser.java
@@ -1,5 +1,7 @@
 package com.bakdata.conquery.models.events.parser.specific;
 
+import java.nio.DoubleBuffer;
+
 import com.bakdata.conquery.models.config.ParserConfig;
 import com.bakdata.conquery.models.events.parser.Parser;
 import com.bakdata.conquery.models.events.stores.primitive.DoubleArrayStore;
@@ -7,7 +9,6 @@ import com.bakdata.conquery.models.events.stores.primitive.FloatArrayStore;
 import com.bakdata.conquery.models.events.stores.root.RealStore;
 import com.bakdata.conquery.models.exceptions.ParsingException;
 import com.bakdata.conquery.util.NumberParsing;
-import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
@@ -62,7 +63,21 @@ public class RealParser extends Parser<Double, RealStore> {
 
 	@Override
 	public ColumnValues createColumnValues() {
-		return new ColumnValues(new DoubleArrayList(), 0d);
+		return new ColumnValues<Double>(0d) {
+
+			private final DoubleBuffer buffer = ColumnValues.allocateBuffer().asDoubleBuffer();
+
+
+			@Override
+			public Double get(int event) {
+				return buffer.get(event);
+			}
+
+			@Override
+			protected void write(int event, Double obj) {
+				buffer.put(obj);
+			}
+		};
 	}
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/RealParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/RealParser.java
@@ -3,6 +3,7 @@ package com.bakdata.conquery.models.events.parser.specific;
 import java.nio.DoubleBuffer;
 
 import com.bakdata.conquery.models.config.ParserConfig;
+import com.bakdata.conquery.models.events.parser.ColumnValues;
 import com.bakdata.conquery.models.events.parser.Parser;
 import com.bakdata.conquery.models.events.stores.primitive.DoubleArrayStore;
 import com.bakdata.conquery.models.events.stores.primitive.FloatArrayStore;

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/RealParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/RealParser.java
@@ -63,11 +63,10 @@ public class RealParser extends Parser<Double, RealStore> {
 	}
 
 	@Override
-	public ColumnValues createColumnValues() {
-		return new ColumnValues<Double>(0d) {
+	public ColumnValues createColumnValues(ParserConfig parserConfig) {
+		return new BufferBackedColumnValues<Double>(0d, parserConfig.getPreallocateBufferBytes()) {
 
-			private final DoubleBuffer buffer = ColumnValues.allocateBuffer().asDoubleBuffer();
-
+			private final DoubleBuffer buffer = getBuffer().asDoubleBuffer();
 
 			@Override
 			public Double get(int event) {

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/RealParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/RealParser.java
@@ -1,5 +1,7 @@
 package com.bakdata.conquery.models.events.parser.specific;
 
+import java.util.List;
+
 import com.bakdata.conquery.models.config.ParserConfig;
 import com.bakdata.conquery.models.events.parser.Parser;
 import com.bakdata.conquery.models.events.stores.primitive.DoubleArrayStore;
@@ -7,6 +9,7 @@ import com.bakdata.conquery.models.events.stores.primitive.FloatArrayStore;
 import com.bakdata.conquery.models.events.stores.root.RealStore;
 import com.bakdata.conquery.models.exceptions.ParsingException;
 import com.bakdata.conquery.util.NumberParsing;
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
@@ -57,5 +60,15 @@ public class RealParser extends Parser<Double, RealStore> {
 	@Override
 	public void setValue(RealStore store, int event, Double value) {
 		store.setReal(event, value);
+	}
+
+	@Override
+	public List<Double> createPrimitiveList() {
+		return new DoubleArrayList();
+	}
+
+	@Override
+	public Double getNullValue() {
+		return 0d;
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/StringParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/StringParser.java
@@ -13,6 +13,7 @@ import java.util.stream.Stream;
 
 import com.bakdata.conquery.models.config.ParserConfig;
 import com.bakdata.conquery.models.events.EmptyStore;
+import com.bakdata.conquery.models.events.parser.ColumnValues;
 import com.bakdata.conquery.models.events.parser.Parser;
 import com.bakdata.conquery.models.events.parser.specific.string.MapTypeGuesser;
 import com.bakdata.conquery.models.events.parser.specific.string.NumberTypeGuesser;

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/StringParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/StringParser.java
@@ -139,13 +139,8 @@ public class StringParser extends Parser<Integer, StringStore> {
 	}
 
 	@Override
-	public List<Integer> createPrimitiveList() {
-		return new IntArrayList();
-	}
-
-	@Override
-	public Integer getNullValue() {
-		return 0;
+	public ColumnValues createColumnValues() {
+		return new ColumnValues(new IntArrayList(), 0);
 	}
 
 	/**

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/StringParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/StringParser.java
@@ -29,6 +29,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.jakewharton.byteunits.BinaryByteUnit;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
@@ -135,6 +136,16 @@ public class StringParser extends Parser<Integer, StringStore> {
 	@Override
 	public void setValue(StringStore store, int event, Integer value) {
 		store.setString(event, value);
+	}
+
+	@Override
+	public List<Integer> createPrimitiveList() {
+		return new IntArrayList();
+	}
+
+	@Override
+	public Integer getNullValue() {
+		return 0;
 	}
 
 	/**

--- a/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/StringParser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/parser/specific/StringParser.java
@@ -180,10 +180,10 @@ public class StringParser extends Parser<Integer, StringStore> {
 
 	@SneakyThrows
 	@Override
-	public ColumnValues<Integer> createColumnValues() {
-		return new ColumnValues<Integer>( 0) {
-			private final IntBuffer buffer = ColumnValues.allocateBuffer().asIntBuffer();
+	public ColumnValues<Integer> createColumnValues(ParserConfig parserConfig) {
+		return new BufferBackedColumnValues<Integer>(0, parserConfig.getPreallocateBufferBytes()){
 
+			private final IntBuffer buffer = getBuffer().asIntBuffer();
 
 			@Override
 			public Integer get(int event) {

--- a/backend/src/main/java/com/bakdata/conquery/models/preproc/Preprocessed.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/preproc/Preprocessed.java
@@ -265,6 +265,10 @@ public class Preprocessed {
 		public void add(int event){
 			Preconditions.checkArgument(event >= start, "Events must be added in order");
 			offsets.set(event - start);
+
+			if (event - start > 500) {
+				log.debug("Bitset is going to be big >  {}", event - start);
+			}
 		}
 
 		public int length() {

--- a/backend/src/main/java/com/bakdata/conquery/models/preproc/Preprocessed.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/preproc/Preprocessed.java
@@ -4,9 +4,7 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.BitSet;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
@@ -57,7 +55,7 @@ public class Preprocessed {
 	private final TableImportDescriptor descriptor;
 
 	// by-column
-	private final ColumnValues[] values;
+	private final Parser.ColumnValues[] values;
 
 	// by-entity
 	private final Int2ObjectMap<EntityPositions> entries;
@@ -77,7 +75,7 @@ public class Preprocessed {
 
 		// pid and columns
 		entries = new Int2ObjectAVLTreeMap<>();
-		values = new ColumnValues[columns.length];
+		values = new Parser.ColumnValues[columns.length];
 
 		for (int index = 0; index < input.getWidth(); index++) {
 			ColumnDescription columnDescription = input.getColumnDescription(index);
@@ -85,7 +83,7 @@ public class Preprocessed {
 			columns[index].setParser(columnDescription.getType().createParser(parserConfig));
 
 			final Parser parser = columns[index].getParser();
-			values[index] = new ColumnValues(parser.getNullValue(), parser.createPrimitiveList());
+			values[index] = new Parser.ColumnValues(parser.getNullValue(), parser.createPrimitiveList());
 		}
 	}
 
@@ -158,7 +156,7 @@ public class Preprocessed {
 			final ColumnStore store = ppColumn.findBestType();
 			Int2ObjectMap<EntityPositions> indices = entries;
 
-			final ColumnValues columnValues = values[colIdx];
+			final Parser.ColumnValues columnValues = values[colIdx];
 
 			int start = 0;
 
@@ -295,41 +293,6 @@ public class Preprocessed {
 		@Override
 		public IntIterator iterator() {
 			return offsets.iterator();
-		}
-	}
-
-	/**
-	 * per Column Store to encode null in auxiliary bitset, allowing primitive storage.
-	 */
-	@SuppressWarnings("Unchecked")
-	@RequiredArgsConstructor
-	private static class ColumnValues {
-		private final Object nullValue;
-		private final List values;
-
-		private final BitSet nulls = new BitSet();
-
-		public boolean isNull(int event) {
-			return nulls.get(event);
-		}
-
-		public Object get(int event) {
-			return values.get(event);
-		}
-
-		public int add(Object value) {
-			int event = values.size();
-
-
-			if (value == null) {
-				nulls.set(event);
-				values.add(nullValue);
-			}
-			else {
-				values.add(value);
-			}
-
-			return event;
 		}
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/preproc/Preprocessed.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/preproc/Preprocessed.java
@@ -12,6 +12,7 @@ import com.bakdata.conquery.io.HCFile;
 import com.bakdata.conquery.io.jackson.Jackson;
 import com.bakdata.conquery.models.config.ParserConfig;
 import com.bakdata.conquery.models.dictionary.Dictionary;
+import com.bakdata.conquery.models.events.parser.ColumnValues;
 import com.bakdata.conquery.models.events.parser.MajorTypeId;
 import com.bakdata.conquery.models.events.parser.Parser;
 import com.bakdata.conquery.models.events.parser.specific.StringParser;
@@ -55,7 +56,7 @@ public class Preprocessed {
 	private final TableImportDescriptor descriptor;
 
 	// by-column
-	private final Parser.ColumnValues[] values;
+	private final ColumnValues[] values;
 
 	// by-entity
 	private final Int2ObjectMap<EntityPositions> entries;
@@ -75,7 +76,7 @@ public class Preprocessed {
 
 		// pid and columns
 		entries = new Int2ObjectAVLTreeMap<>();
-		values = new Parser.ColumnValues[columns.length];
+		values = new ColumnValues[columns.length];
 
 		for (int index = 0; index < input.getWidth(); index++) {
 			ColumnDescription columnDescription = input.getColumnDescription(index);
@@ -156,7 +157,7 @@ public class Preprocessed {
 			final ColumnStore store = ppColumn.findBestType();
 			Int2ObjectMap<EntityPositions> indices = entries;
 
-			final Parser.ColumnValues columnValues = values[colIdx];
+			final ColumnValues columnValues = values[colIdx];
 
 			int start = 0;
 

--- a/backend/src/main/java/com/bakdata/conquery/models/preproc/Preprocessed.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/preproc/Preprocessed.java
@@ -84,7 +84,7 @@ public class Preprocessed {
 			columns[index].setParser(columnDescription.getType().createParser(parserConfig));
 
 			final Parser parser = columns[index].getParser();
-			values[index] = parser.createColumnValues();
+			values[index] = parser.createColumnValues(parserConfig);
 		}
 	}
 
@@ -119,6 +119,10 @@ public class Preprocessed {
 		writeHeader(outFile.writeHeader());
 
 		writeData(outFile.writeContent(), entityStart, entityLength, columnStores, primaryDictionary, dicts);
+
+		for (ColumnValues columnValues : values) {
+			columnValues.close();
+		}
 	}
 
 	/**

--- a/backend/src/main/java/com/bakdata/conquery/models/preproc/Preprocessed.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/preproc/Preprocessed.java
@@ -83,7 +83,7 @@ public class Preprocessed {
 			columns[index].setParser(columnDescription.getType().createParser(parserConfig));
 
 			final Parser parser = columns[index].getParser();
-			values[index] = new Parser.ColumnValues(parser.getNullValue(), parser.createPrimitiveList());
+			values[index] = parser.createColumnValues();
 		}
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/preproc/Preprocessed.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/preproc/Preprocessed.java
@@ -4,7 +4,6 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.List;
@@ -16,6 +15,7 @@ import com.bakdata.conquery.io.jackson.Jackson;
 import com.bakdata.conquery.models.config.ParserConfig;
 import com.bakdata.conquery.models.dictionary.Dictionary;
 import com.bakdata.conquery.models.events.parser.MajorTypeId;
+import com.bakdata.conquery.models.events.parser.Parser;
 import com.bakdata.conquery.models.events.parser.specific.StringParser;
 import com.bakdata.conquery.models.events.parser.specific.string.MapTypeGuesser;
 import com.bakdata.conquery.models.events.stores.root.ColumnStore;
@@ -83,7 +83,8 @@ public class Preprocessed {
 			columns[index].setParser(columnDescription.getType().createParser(parserConfig));
 
 			entries[index] = new Int2ObjectAVLTreeMap<>();
-			values[index] = new ColumnValues(null);
+			final Parser parser = columns[index].getParser();
+			values[index] = new ColumnValues(parser.getNullValue(), parser.createPrimitiveList());
 		}
 	}
 
@@ -297,8 +298,9 @@ public class Preprocessed {
 	@RequiredArgsConstructor
 	private static class ColumnValues {
 		private final Object nullValue;
+		private final List values;
+
 		private final BitSet nulls = new BitSet();
-		private final List values = new ArrayList();
 
 		public boolean isNull(int event) {
 			return nulls.get(event);


### PR DESCRIPTION
This should remove constant calls to `ArrayList.grow` as all data is stored into a single list that should grow appropriately fast. This should also reduce memory pressure, as we can now specify the type of storage List (eg IntList, DoubleList) instead of always using the generic `List<Object>` with some amount of overhead.