### PR TITLE
removes string permissions from frontend, replaces them by a flag

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/apiv1/ApiV1.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/ApiV1.java
@@ -41,7 +41,7 @@ public class ApiV1 implements ResourcesProvider {
 			@Override
 			protected void configure() {
 				bind(new ConceptsProcessor(manager.getDatasetRegistry())).to(ConceptsProcessor.class);
-				bind(new MeProcessor(manager.getStorage())).to(MeProcessor.class);
+				bind(new MeProcessor(manager.getStorage(), datasets)).to(MeProcessor.class);
 				bind(new QueryProcessor(datasets, manager.getStorage(), manager.getConfig())).to(QueryProcessor.class);
 				bind(new FormConfigProcessor(manager.getValidator(),manager.getStorage())).to(FormConfigProcessor.class);
 				bind(new StoredQueriesProcessor(manager.getDatasetRegistry(), manager.getStorage(), manager.getConfig())).to(StoredQueriesProcessor.class);

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/MeProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/MeProcessor.java
@@ -1,6 +1,8 @@
 package com.bakdata.conquery.apiv1;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.bakdata.conquery.io.cps.CPSType;
@@ -8,8 +10,12 @@ import com.bakdata.conquery.io.xodus.MetaStorage;
 import com.bakdata.conquery.models.auth.AuthorizationHelper;
 import com.bakdata.conquery.models.auth.entities.Group;
 import com.bakdata.conquery.models.auth.entities.User;
+import com.bakdata.conquery.models.auth.permissions.Ability;
 import com.bakdata.conquery.models.auth.permissions.DatasetPermission;
+import com.bakdata.conquery.models.datasets.Dataset;
+import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.identifiable.ids.specific.GroupId;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.resources.admin.ui.model.FEPermission;
 import com.bakdata.conquery.resources.api.MeResource;
 import lombok.*;
@@ -22,6 +28,7 @@ import lombok.*;
 public class MeProcessor {
 
 	private final MetaStorage storage;
+	private final DatasetRegistry datasetRegistry;
 
 	/**
 	 * Generates a summary of a user. It contains its name, the groups it belongs to and its permissions on a dataset.
@@ -29,6 +36,28 @@ public class MeProcessor {
 	 * @return The information about the user
 	 */
 	public FEMeInformation getUserInformation(@NonNull User user){
+		// Compute dataset ablilities
+		Map<DatasetId, FEDatasetAbility> datasetAblilites= new HashMap<>();
+		for(Dataset dataset : datasetRegistry.getAllDatasets()){
+			boolean[] result = user.isPermitted(List.of(
+					DatasetPermission.onInstance(Ability.READ, dataset.getId()),
+					DatasetPermission.onInstance(Ability.PRESERVE_ID, dataset.getId())
+			));
+
+			if(!result[0] /* READ */) {
+				// User is not allowed to use dataset
+				continue;
+			}
+
+			// User can use the dataset and can possibly upload ids for resolving
+			datasetAblilites.put(
+					dataset.getId(),
+					FEDatasetAbility.builder()
+							.canUpload(result[1] /*PRESERVE_ID*/)
+							.build());
+		}
+
+		// Build user information
 		return FEMeInformation.builder()
 				.userName(user.getLabel())
 				.hideLogoutButton(!user.isDisplayLogout())
@@ -37,7 +66,7 @@ public class MeProcessor {
 								.stream()
 								.map(g -> new IdLabel<GroupId>(g.getId(),g.getLabel()))
 								.collect(Collectors.toList()))
-				.permissions( FEPermission.from(AuthorizationHelper.getEffectiveUserPermissions(user.getId(), List.of(DatasetPermission.DOMAIN), storage).values()))
+				.datasetAbilities(datasetAblilites)
 				.build();
 	}
 
@@ -49,8 +78,17 @@ public class MeProcessor {
 	public static class FEMeInformation {
 		String userName;
 		boolean hideLogoutButton;
-		List<FEPermission> permissions;
+		Map<DatasetId, FEDatasetAbility> datasetAbilities;
 		List<IdLabel<GroupId>> groups;
+	}
+
+	/**
+	 * Front end container to describe what the user can do on a
+	 * dataset by simple flags.
+	 */
+	@Builder
+	private static class FEDatasetAbility {
+		private final boolean canUpload;
 	}
 
 }


### PR DESCRIPTION
The user information that can be retrieved from the /me-endpoint does not hold anymore the raw string permissions, that are used by the backend. Instead there is a new member that is a map with an entry per dataset, that is availible to the user:
```
{
    "userName": "INITIAL USER",
    "datasetAbilities": {
        <datasetid>: {
            "canUpload" : <true/false>
        }
    },
    "groups": []
}

```

Currently the only dataset ability is `canUpload` which allows the user to upload an id list which is resolved to a query group.

@Kadrian 