### PR TITLE
Fix develop docker build

### DIFF
--- a/frontend/src/js/header/Header.tsx
+++ b/frontend/src/js/header/Header.tsx
@@ -73,20 +73,21 @@ const useVersion = () => {
   );
 
   const frontendDateTimeStamp = preval`module.exports = new Date().toISOString();`;
-  const frontendGitCommit = preval`
-    const { execSync } = require('child_process');
-    module.exports = execSync('git rev-parse --short HEAD').toString();
-  `;
-  const frontendGitTag = preval`
-    const { execSync } = require('child_process');
-    module.exports = execSync('git describe --all --exact-match \`git rev-parse HEAD\`').toString();
-  `;
+  // TODO: GET THIS TO WORK WHEN BUILDING INSIDE A DODCKER CONTAINER
+  // const frontendGitCommit = preval`
+  //   const { execSync } = require('child_process');
+  //   module.exports = execSync('git rev-parse --short HEAD').toString();
+  // `;
+  // const frontendGitTag = preval`
+  //   const { execSync } = require('child_process');
+  //   module.exports = execSync('git describe --all --exact-match \`git rev-parse HEAD\`').toString();
+  // `;
 
   return {
     backendVersion,
-    frontendGitCommit,
+    frontendGitCommit: "",
     frontendDateTimeStamp,
-    frontendGitTag,
+    frontendGitTag: "",
   };
 };
 


### PR DESCRIPTION
- Temporarily disable asking git for verison info at build time,
  because there is no `git` inside the node apline image + it wouldn't
  be great to copy the `.git` folder from our root folder into the
  image. TODO: Figure out how to fix this to show better frontend
  version information.