### PR TITLE
Fixes a bug with BIG MULTI SELECT filters on expand

### DIFF
--- a/frontend/src/js/standard-query-editor/queryReducer.ts
+++ b/frontend/src/js/standard-query-editor/queryReducer.ts
@@ -488,12 +488,14 @@ const mergeFiltersFromSavedConcept = (
 
   if (!savedTable.filters) return null;
 
-  return savedTable.filters.map((filter) => {
+  return savedTable.filters.map((savedFilter) => {
     // TODO: Improve the api and don't use `.filter`, but `.id` or `.filterId`
-    const matchingFilter = table.filters!.find((f) => f.filter === filter.id);
+    const matchingFilter = table.filters!.find(
+      (f) => f.filter === savedFilter.id,
+    );
 
     if (!matchingFilter) {
-      return filter;
+      return savedFilter;
     }
 
     if (isRangeFilterConfig(matchingFilter)) {
@@ -505,44 +507,44 @@ const mergeFiltersFromSavedConcept = (
           ? { mode: "exact", value: { exact: matchingFilter.value.min } }
           : { mode: "range", value: matchingFilter.value };
 
-      return { ...filter, ...filterDetails };
+      return { ...savedFilter, ...filterDetails };
     }
 
     if (isMultiSelectFilterConfig(matchingFilter)) {
       const filterDetails = {
         ...matchingFilter,
-        type: filter.type, // matchingFilter.type is sometimes wrongly saying MULTI_SELECT
+        type: savedFilter.type, // matchingFilter.type is sometimes wrongly saying MULTI_SELECT
         value: matchingFilter.value
           .map((val) => {
-            if (!isMultiSelectFilter(filter)) {
+            if (!isMultiSelectFilter(savedFilter)) {
               console.error(
-                `Filter: ${filter} is not a multi-select filter, even though its matching filter was: ${matchingFilter}`,
+                `Filter: ${savedFilter} is not a multi-select filter, even though its matching filter was: ${matchingFilter}`,
               );
               return val;
             } else {
               // There is the possibility, that we have a BIG_MULTI_SELECT that loads options async.
               // Then filter.options would be empty and we wouldn't find it
-              return filter.options.find((op) => op.value === val);
+              return savedFilter.options.find((op) => op.value === val) || val;
             }
           })
           .filter(exists),
         // For BIG MULTI SELECT only, to be able to load all non-loaded options form the defaultValue later
         defaultValue: matchingFilter.value.filter((val) => {
-          if (!isMultiSelectFilter(filter)) {
+          if (!isMultiSelectFilter(savedFilter)) {
             console.error(
-              `Filter: ${filter} is not a multi-select filter, even though its matching filter was: ${matchingFilter}`,
+              `Filter: ${savedFilter} is not a multi-select filter, even though its matching filter was: ${matchingFilter}`,
             );
             return false;
           }
 
-          return !exists(filter.options.find((opt) => opt.value === val));
+          return !exists(savedFilter.options.find((opt) => opt.value === val));
         }),
       };
 
-      return { ...filter, ...filterDetails };
+      return { ...savedFilter, ...filterDetails };
     }
 
-    return { ...filter, ...matchingFilter };
+    return { ...savedFilter, ...matchingFilter };
   });
 };
 


### PR DESCRIPTION
When expanding a query, we were only setting the defaultValue
of a BIG_MULTI_SELECT filter. The actual filter.value was only
set / resolved once someone looked at the filter.
(=> when ResolvableMultiSelect rendered)

The problem was: The filter's value remained [] as long as the
ResolvableMultiSelect component never rendered.
And that was the case when the QueryNodeEditor wasn't opened
after expanding a query.

So these changes populate a BIG_MULTI_SELECT filter's `value`
even if the options haven't been loaded yet.