### PR TITLE
Use streaming xlsx format

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/io/result/excel/ExcelRenderer.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/result/excel/ExcelRenderer.java
@@ -1,6 +1,5 @@
 package com.bakdata.conquery.io.result.excel;
 
-import com.bakdata.conquery.Conquery;
 import com.bakdata.conquery.ConqueryConstants;
 import com.bakdata.conquery.models.common.CDate;
 import com.bakdata.conquery.models.config.ExcelConfig;
@@ -16,9 +15,10 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.util.AreaReference;
 import org.apache.poi.ss.util.CellReference;
+import org.apache.poi.xssf.streaming.SXSSFSheet;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFTable;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.jetbrains.annotations.NotNull;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTTable;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTTableColumn;
@@ -44,12 +44,12 @@ public class ExcelRenderer {
             ResultType.NumericT.class, ExcelRenderer::writeNumericCell
     );
 
-    private final XSSFWorkbook workbook;
+    private final SXSSFWorkbook workbook;
     private final ImmutableMap<String, CellStyle> styles;
 
 
     public ExcelRenderer(ExcelConfig config) {
-        workbook = new XSSFWorkbook();
+        workbook = new SXSSFWorkbook();
         styles = config.generateStyles(workbook);
     }
 
@@ -67,7 +67,7 @@ public class ExcelRenderer {
 
 
         // TODO internationalize
-        XSSFSheet sheet = workbook.createSheet("Result");
+        SXSSFSheet sheet = workbook.createSheet("Result");
 
 
         // Create a table environment inside the excel sheet
@@ -81,6 +81,7 @@ public class ExcelRenderer {
 
 
         workbook.write(outputStream);
+        workbook.dispose();
 
     }
 
@@ -109,8 +110,8 @@ public class ExcelRenderer {
     }
 
     @NotNull
-    private XSSFTable createTableEnvironment(ManagedExecution<?> exec, XSSFSheet sheet) {
-        XSSFTable table = sheet.createTable(null);
+    private XSSFTable createTableEnvironment(ManagedExecution<?> exec, SXSSFSheet sheet) {
+        XSSFTable table = sheet.getWorkbook().getXSSFWorkbook().getSheet(sheet.getSheetName()).createTable(null);
 
         CTTable cttable = table.getCTTable();
         table.setName(exec.getLabelWithoutAutoLabelSuffix());
@@ -125,7 +126,7 @@ public class ExcelRenderer {
     }
 
     private void writeHeader(
-            XSSFSheet sheet,
+            SXSSFSheet sheet,
             List<String> idHeaders,
             List<ResultInfo> infos,
             PrintSettings cfg,

--- a/backend/src/main/java/com/bakdata/conquery/models/config/ExcelConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/ExcelConfig.java
@@ -6,8 +6,10 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.With;
 import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.DataFormat;
 import org.apache.poi.ss.usermodel.FillPatternType;
-import org.apache.poi.ss.usermodel.IndexedColors;
+import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.apache.poi.xssf.usermodel.XSSFDataFormat;
 import org.apache.poi.xssf.usermodel.XSSFFont;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
@@ -43,7 +45,7 @@ public class ExcelConfig {
 	private Map<String, CellStyler> styles = Collections.emptyMap();
 
 
-	public ImmutableMap<String, CellStyle> generateStyles(XSSFWorkbook workbook){
+	public ImmutableMap<String, CellStyle> generateStyles(SXSSFWorkbook workbook){
 		ImmutableMap.Builder<String, CellStyle> styles = ImmutableMap.builder();
 
 		// Build configured styles
@@ -79,8 +81,8 @@ public class ExcelConfig {
 
 		private String dataFormatString = null;
 
-		private CellStyle generateStyle(XSSFWorkbook workbook) {
-			XSSFDataFormat dataFormat = workbook.createDataFormat();
+		private CellStyle generateStyle(SXSSFWorkbook workbook) {
+			DataFormat dataFormat = workbook.createDataFormat();
 			CellStyle style = workbook.createCellStyle();
 			if (fillPattern != null){
 				style.setFillPattern(fillPattern);
@@ -94,7 +96,7 @@ public class ExcelConfig {
 			}
 
 			if (fontHeightInPoints != null || bold != null) {
-				XSSFFont xFont = workbook.createFont();
+				Font xFont = workbook.createFont();
 				xFont.setFontName(font);
 				if (fontHeightInPoints != null) {
 					xFont.setFontHeightInPoints(fontHeightInPoints);


### PR DESCRIPTION
Uses the apache POI streaming format SXSSF (instead of XSSF):

# Benchmark
## Table 
 - ~260000 rows 
 - ~31 column
- CSV-size: ~800 MB (takes some time to download as well)

## Download
- Rendering + Transfer

|         | Time | Size |
| --- | --- | --- |
| prev | ~14 min | 230 MB| 
| now | ~2 min | 240 MB| 

# Misc
- Auto Column size does not work atm, which is leading to pound-fills: 
![image](https://user-images.githubusercontent.com/12283268/120306856-9bef3d00-c2d2-11eb-8ab9-7dd1903b3a0a.png)
- Still the rendering is performed first and afterwards the transfer starts
- Medium table download time is on par with csv due to smaller transfer size (csv: 150 MB; xlsx:38 MB )
- Small tables download "instantly" 