### PR TITLE
pretty print result by default

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/resources/api/ResultExcelResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/ResultExcelResource.java
@@ -42,7 +42,7 @@ public class ResultExcelResource {
 		@QueryParam("pretty") Optional<Boolean> pretty) {
 		checkSingleTableResult(execution);
 		log.info("Result for {} download on dataset {} by user {} ({}).", execution.getId(), datasetId, user.getId(), user.getName());
-		return processor.getExcelResult(user, (ManagedExecution<?> & SingleTableResult) execution, datasetId, pretty.orElse(false));
+		return processor.getExcelResult(user, (ManagedExecution<?> & SingleTableResult) execution, datasetId, pretty.orElse(true));
 	}
 
 	public static <E extends ManagedExecution<?> & SingleTableResult> URL getDownloadURL(UriBuilder uriBuilder, E exec) throws MalformedURLException {


### PR DESCRIPTION
because the default was false, booleans were printed as 0/1 instead of a localized confimation 