### PR TITLE
Rebuild how we store keycloak auth tokens

### DIFF
--- a/frontend/src/js/api/useApi.ts
+++ b/frontend/src/js/api/useApi.ts
@@ -1,16 +1,9 @@
-import { useKeycloak } from "@react-keycloak/web";
 import axios, { AxiosRequestConfig } from "axios";
-import { useEffect, useRef } from "react";
+import { useContext, useEffect, useRef } from "react";
 import { useHistory } from "react-router-dom";
 
-import { getStoredAuthToken } from "../authorization/helper";
+import { AuthTokenContext } from "../authorization/AuthTokenProvider";
 import { isIDPEnabled, isLoginDisabled } from "../environment";
-
-export const useAuthToken = () => {
-  const { keycloak } = useKeycloak();
-
-  return isIDPEnabled ? keycloak.token || "" : getStoredAuthToken() || "";
-};
 
 export const useApiUnauthorized = <T>(
   requestConfig: Partial<AxiosRequestConfig> = {},
@@ -24,12 +17,17 @@ export const useApiUnauthorized = <T>(
 
 export const useApi = <T>(requestConfig: Partial<AxiosRequestConfig> = {}) => {
   const history = useHistory();
-  const authToken = useAuthToken();
-  const authTokenRef = useRef<string>(authToken);
+  const { authToken } = useContext(AuthTokenContext);
 
-  useEffect(() => {
-    authTokenRef.current = authToken;
-  }, [authToken]);
+  // In order to always have the up to date token,
+  // especially when polling for a long time within nested loops
+  const authTokenRef = useRef<string>(authToken);
+  useEffect(
+    function updateRef() {
+      authTokenRef.current = authToken;
+    },
+    [authToken],
+  );
 
   return async (
     finalRequestConfig: Partial<AxiosRequestConfig> = {},

--- a/frontend/src/js/authorization/AuthTokenProvider.tsx
+++ b/frontend/src/js/authorization/AuthTokenProvider.tsx
@@ -1,0 +1,25 @@
+import { createContext, useState } from "react";
+
+import { isIDPEnabled } from "../environment";
+
+import { getStoredAuthToken } from "./helper";
+
+export interface AuthTokenContextValue {
+  authToken: string;
+  setAuthToken: (token: string) => void;
+}
+
+export const AuthTokenContext = createContext<AuthTokenContextValue>({
+  authToken: "",
+  setAuthToken: () => null,
+});
+
+export const useAuthTokenContextValue = (): AuthTokenContextValue => {
+  const [authToken, setAuthToken] = useState<string>(
+    isIDPEnabled ? "" : getStoredAuthToken() || "",
+  );
+
+  return { authToken, setAuthToken };
+};
+
+export const AuthTokenContextProvider = AuthTokenContext.Provider;

--- a/frontend/src/js/authorization/KeycloakProvider.tsx
+++ b/frontend/src/js/authorization/KeycloakProvider.tsx
@@ -1,0 +1,35 @@
+import { ReactKeycloakProvider } from "@react-keycloak/web";
+import React, { FC, useContext } from "react";
+
+import keycloak from "../../keycloak";
+import { isIDPEnabled } from "../environment";
+
+import { AuthTokenContext } from "./AuthTokenProvider";
+
+const KeycloakProvider: FC = ({ children }) => {
+  const { setAuthToken } = useContext(AuthTokenContext);
+
+  return (
+    <ReactKeycloakProvider
+      authClient={keycloak}
+      onEvent={(event: unknown, error: unknown) => {
+        // USEFUL FOR DEBUGGING
+        // console.log("onKeycloakEvent", event, error);
+      }}
+      onTokens={(tokens) => {
+        if (tokens.token) {
+          setAuthToken(tokens.token);
+        }
+      }}
+      initOptions={{
+        pkceMethod: "S256",
+        onLoad: isIDPEnabled ? "login-required" : "check-sso",
+        // silentCheckSsoRedirectUri:
+        //   window.location.origin + "/silent-check-sso.html",
+      }}
+    >
+      {children}
+    </ReactKeycloakProvider>
+  );
+};
+export default KeycloakProvider;

--- a/frontend/src/js/authorization/WithAuthToken.tsx
+++ b/frontend/src/js/authorization/WithAuthToken.tsx
@@ -1,9 +1,10 @@
 import { useKeycloak } from "@react-keycloak/web";
-import React, { FC } from "react";
+import React, { FC, useContext } from "react";
 import { useHistory } from "react-router-dom";
 
 import { isLoginDisabled, isIDPEnabled } from "../environment";
 
+import { AuthTokenContext } from "./AuthTokenProvider";
 import { storeAuthToken, getStoredAuthToken } from "./helper";
 
 interface PropsT {
@@ -14,7 +15,8 @@ interface PropsT {
 
 const WithAuthToken: FC<PropsT> = ({ location, children }) => {
   const history = useHistory();
-  const { keycloak, initialized } = useKeycloak();
+  const { initialized } = useKeycloak();
+  const { authToken } = useContext(AuthTokenContext);
   const goToLogin = () => history.push("/login");
 
   const { search } = location;
@@ -23,7 +25,7 @@ const WithAuthToken: FC<PropsT> = ({ location, children }) => {
 
   if (accessToken) storeAuthToken(accessToken);
 
-  if (isIDPEnabled && (!initialized || !keycloak.token)) {
+  if (isIDPEnabled && (!initialized || !authToken)) {
     return null;
   }
 

--- a/frontend/src/js/button/DownloadButton.tsx
+++ b/frontend/src/js/button/DownloadButton.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
-import React, { ReactNode, FC } from "react";
+import React, { ReactNode, FC, useContext } from "react";
 
-import { useAuthToken } from "../api/useApi";
+import { AuthTokenContext } from "../authorization/AuthTokenProvider";
 
 import IconButton, { IconButtonPropsT } from "./IconButton";
 
@@ -21,7 +21,7 @@ const DownloadButton: FC<PropsT> = ({
   children,
   ...restProps
 }) => {
-  const authToken = useAuthToken();
+  const { authToken } = useContext(AuthTokenContext);
 
   const href = `${url}?access_token=${encodeURIComponent(
     authToken,

--- a/frontend/src/js/button/PreviewButton.tsx
+++ b/frontend/src/js/button/PreviewButton.tsx
@@ -1,11 +1,11 @@
 import styled from "@emotion/styled";
 import { StateT } from "app-types";
-import React, { FC } from "react";
+import React, { FC, useContext } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector, useDispatch } from "react-redux";
 
 import type { ColumnDescription } from "../api/types";
-import { useAuthToken } from "../api/useApi";
+import { AuthTokenContext } from "../authorization/AuthTokenProvider";
 import { openPreview } from "../preview/actions";
 import WithTooltip from "../tooltip/WithTooltip";
 
@@ -27,7 +27,7 @@ const PreviewButton: FC<PropsT> = ({
   className,
   ...restProps
 }) => {
-  const authToken = useAuthToken();
+  const { authToken } = useContext(AuthTokenContext);
   const isLoading = useSelector<StateT, boolean>(
     (state) => state.preview.isLoading,
   );


### PR DESCRIPTION
Results returned from useKeycloak aren't updating when there are new
/ refreshed tokens coming in. For that reason, we have to use the
`onTokens` callback and store tokens within global state (using a
custom react context in this case).

That way, components that use the token (like the download / preview button)
may re-render.