### PR TITLE
give more context for unknown errors and log them manager node

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/models/error/ConqueryError.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/error/ConqueryError.java
@@ -20,6 +20,9 @@ import org.apache.commons.text.StringSubstitutor;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -110,19 +113,31 @@ public abstract class ConqueryError extends RuntimeException implements Conquery
 
 	@Slf4j
 	@CPSType(base = ConqueryError.class, id = "CQ_UNKNOWN_ERROR")
-	public static class UnknownError extends NoContextError {
+	public static class UnknownError extends ContextError {
+
+		private final static String UNKNOWN_ERROR_CLASS = "UNKNOWN_ERROR_CLASS";
+		private final static String UNKNOWN_ERROR_MESSAGE = "UNKNOWN_ERROR_MESSAGE";
+		private final static String UNKNOWN_ERROR_STACKTRACE = "UNKNOWN_ERROR_STACKTRACE";
 
 		/**
 		 * Constructor for deserialization.
 		 */
 		@JsonCreator
 		private UnknownError() {
-			super("An unknown error occured");
+			super("An unknown error occurred: ${" + UNKNOWN_ERROR_CLASS + "} - ${" + UNKNOWN_ERROR_MESSAGE + "}\n${" + UNKNOWN_ERROR_STACKTRACE + "}");
 		}
 
 		public UnknownError(Throwable e) {
 			this();
 			log.error("Encountered unknown Error[{}]", this.getId(), e);
+			getContext().put(UNKNOWN_ERROR_CLASS, e.getClass().getSimpleName());
+			getContext().put(UNKNOWN_ERROR_MESSAGE, e.getMessage());
+
+			StringWriter sw = new StringWriter();
+			PrintWriter pw = new PrintWriter(sw);
+			e.printStackTrace(pw);
+			String stackTrace = sw.toString();
+			getContext().put(UNKNOWN_ERROR_STACKTRACE, stackTrace);
 		}
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/error/ConqueryError.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/error/ConqueryError.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
@@ -127,15 +128,15 @@ public abstract class ConqueryError extends RuntimeException implements Conquery
 			super("An unknown error occurred: ${" + UNKNOWN_ERROR_CLASS + "} - ${" + UNKNOWN_ERROR_MESSAGE + "}\n${" + UNKNOWN_ERROR_STACKTRACE + "}");
 		}
 
-		public UnknownError(Throwable e) {
+		public UnknownError(@NonNull Throwable cause) {
 			this();
-			log.error("Encountered unknown Error[{}]", this.getId(), e);
-			getContext().put(UNKNOWN_ERROR_CLASS, e.getClass().getSimpleName());
-			getContext().put(UNKNOWN_ERROR_MESSAGE, e.getMessage());
+			log.error("Encountered unknown Error[{}]", this.getId(), cause);
+			getContext().put(UNKNOWN_ERROR_CLASS, cause.getClass().getSimpleName());
+			getContext().put(UNKNOWN_ERROR_MESSAGE, cause.getMessage());
 
 			StringWriter sw = new StringWriter();
 			PrintWriter pw = new PrintWriter(sw);
-			e.printStackTrace(pw);
+			cause.printStackTrace(pw);
 			String stackTrace = sw.toString();
 			getContext().put(UNKNOWN_ERROR_STACKTRACE, stackTrace);
 		}

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
@@ -170,8 +170,9 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 		}
 		else {
 			this.error = error;
-			// Log the error, so its id is atleast once in the logs
-			log.warn("The execution [{}] failed with:\n\t{}", this.getId(), this.error);
+			// Log the error, so its id is at least once in the logs
+			// Indent the unknown stacktrace so it can be better distinguished
+			log.warn("The execution [{}] failed with (the error is from one of the shard nodes):\n\t{}", this.getId(), this.error.getMessage().replaceAll("\\n", "\n\t"));
 		}
 
 		finish(storage, ExecutionState.FAILED);

--- a/backend/src/main/java/com/bakdata/conquery/models/query/QueryExecutor.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/QueryExecutor.java
@@ -82,8 +82,9 @@ public class QueryExecutor implements Closeable {
 			return true;
 		}
 		catch (Exception e) {
+			// Just trace here. If it's wrapped as an UnknownError, it will be logged anyway.
+			log.trace("Error while executing {}", executionContext.getExecutionId(), e);
 			ConqueryError err = asConqueryError(e);
-			log.warn("Error while executing {}", executionContext.getExecutionId(), err);
 			sendFailureToManagerNode(result, asConqueryError(err));
 			return false;
 		}

--- a/backend/src/test/java/com/bakdata/conquery/models/SerializationTests.java
+++ b/backend/src/test/java/com/bakdata/conquery/models/SerializationTests.java
@@ -322,7 +322,7 @@ public class SerializationTests {
 	@Test
 	public void executionQueryJobError() throws JSONException, IOException {
 		log.info("Beware, this test will print an ERROR message.");
-		ConqueryError error = new ConqueryError.ExecutionJobErrorWrapper(new Entity(5), new ConqueryError.UnknownError(null));
+		ConqueryError error = new ConqueryError.ExecutionJobErrorWrapper(new Entity(5), new ConqueryError.UnknownError(new Exception("This is just a test cause")));
 
 		SerializationTestUtil
 				.forType(ConqueryError.class)


### PR DESCRIPTION
The Log now looks like this:

Shard
```
[ERROR] [2021-11-10 22:10:27]	c.b.c.m.e.ConqueryError$UnknownError	Worker[MULTI_CONNECTOR_QUERY_SEPARATE_DATES$20Test.worker_MULTI_CONNECTOR_QUERY_SEPARATE_DATES$20Test_d966550b-516f-4deb-937e-1705aeca28bd, /127.0.0.1:50320]	Encountered unknown Error[35dba072-b44d-4b1d-9096-afe72fdbfff7]
java.lang.UnsupportedOperationException: This is intended
	at com.bakdata.conquery.models.query.QueryExecutor.execute(QueryExecutor.java:67)
	at com.bakdata.conquery.models.messages.namespaces.specific.ExecuteQuery.react(ExecuteQuery.java:71)
	at com.bakdata.conquery.models.messages.namespaces.specific.ExecuteQuery.react(ExecuteQuery.java:25)
	at com.bakdata.conquery.models.messages.network.specific.ForwardToWorker.react(ForwardToWorker.java:69)
	at com.bakdata.conquery.models.messages.network.specific.ForwardToWorker.react(ForwardToWorker.java:31)
	at com.bakdata.conquery.models.jobs.ReactingJob.execute(ReactingJob.java:19)
	at com.bakdata.conquery.models.jobs.JobExecutor.run(JobExecutor.java:118)
[INFO] [2021-11-10 22:10:27]	c.b.c.m.q.r.ShardResult	Worker[MULTI_CONNECTOR_QUERY_SEPARATE_DATES$20Test.worker_MULTI_CONNECTOR_QUERY_SEPARATE_DATES$20Test_17c3b77d-43bd-44d7-ab16-fa4d5e504004, /127.0.0.1:50321]	FAILED Query[MULTI_CONNECTOR_QUERY_SEPARATE_DATES$20Test.73fd3989-ba1c-40cf-a222-890a7806912b] within PT0.082007S
[INFO] [2021-11-10 22:10:27]	c.b.c.m.q.r.ShardResult	Worker[MULTI_CONNECTOR_QUERY_SEPARATE_DATES$20Test.worker_MULTI_CONNECTOR_QUERY_SEPARATE_DATES$20Test_d966550b-516f-4deb-937e-1705aeca28bd, /127.0.0.1:50320]	FAILED Query[MULTI_CONNECTOR_QUERY_SEPARATE_DATES$20Test.73fd3989-ba1c-40cf-a222-890a7806912b] within PT0.089008S
[INFO] [2021-11-10 22:10:27]	c.b.c.m.m.n.s.CollectQueryResult	Dataset[label=null, name=MULTI_CONNECTOR_QUERY_SEPARATE_DATES Test]	Received ShardResult(queryId=MULTI_CONNECTOR_QUERY_SEPARATE_DATES$20Test.73fd3989-ba1c-40cf-a222-890a7806912b, workerId=MULTI_CONNECTOR_QUERY_SEPARATE_DATES$20Test.worker_MULTI_CONNECTOR_QUERY_SEPARATE_DATES$20Test_17c3b77d-43bd-44d7-ab16-fa4d5e504004, startTime=2021-11-10T22:10:27.208389100, finishTime=2021-11-10T22:10:27.290396100) of size 0
```

Manager
```
[DEBUG] [2021-11-10 22:10:27]	c.b.c.m.q.ManagedQuery	Dataset[label=null, name=MULTI_CONNECTOR_QUERY_SEPARATE_DATES Test]	Received Result[size=0] for Query[MULTI_CONNECTOR_QUERY_SEPARATE_DATES$20Test.73fd3989-ba1c-40cf-a222-890a7806912b]
[WARN] [2021-11-10 22:10:27]	c.b.c.m.e.ManagedExecution	Dataset[label=null, name=MULTI_CONNECTOR_QUERY_SEPARATE_DATES Test]	The execution [MULTI_CONNECTOR_QUERY_SEPARATE_DATES$20Test.73fd3989-ba1c-40cf-a222-890a7806912b] failed with (the error is from one of the shard nodes):
	An unknown error occurred: UnsupportedOperationException - This is intended
	java.lang.UnsupportedOperationException: This is intended
		at com.bakdata.conquery.models.query.QueryExecutor.execute(QueryExecutor.java:67)
		at com.bakdata.conquery.models.messages.namespaces.specific.ExecuteQuery.react(ExecuteQuery.java:71)
		at com.bakdata.conquery.models.messages.namespaces.specific.ExecuteQuery.react(ExecuteQuery.java:25)
		at com.bakdata.conquery.models.messages.network.specific.ForwardToWorker.react(ForwardToWorker.java:69)
		at com.bakdata.conquery.models.messages.network.specific.ForwardToWorker.react(ForwardToWorker.java:31)
		at com.bakdata.conquery.models.jobs.ReactingJob.execute(ReactingJob.java:19)
		at com.bakdata.conquery.models.jobs.JobExecutor.run(JobExecutor.java:118)
```

