### PR TITLE
adds ETag header to cors allow list

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/io/jetty/CORSResponseFilter.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/jetty/CORSResponseFilter.java
@@ -9,7 +9,7 @@ public class CORSResponseFilter implements ContainerResponseFilter {
 	@Override
 	public void filter(ContainerRequestContext requestContext, ContainerResponseContext rCtx) {
 		rCtx.getHeaders().add("Access-Control-Allow-Origin", "*");
-		rCtx.getHeaders().add("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization");
+		rCtx.getHeaders().add("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization, ETag");
 		rCtx.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PATCH,DELETE, PUT");
 	}
 


### PR DESCRIPTION
To allow efficient frontend caching (mainly for concepts) during development

@Kadrian 