### PR TITLE
Default connectors for entity preview

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
@@ -1,6 +1,5 @@
 package com.bakdata.conquery.apiv1;
 
-import static com.bakdata.conquery.io.result.ResultUtil.determineCharset;
 import static com.bakdata.conquery.models.auth.AuthorizationHelper.buildDatasetAbilityMap;
 
 import java.net.URL;
@@ -12,6 +11,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -32,7 +32,6 @@ import com.bakdata.conquery.apiv1.query.concept.filter.CQUnfilteredTable;
 import com.bakdata.conquery.apiv1.query.concept.specific.CQAnd;
 import com.bakdata.conquery.apiv1.query.concept.specific.CQDateRestriction;
 import com.bakdata.conquery.apiv1.query.concept.specific.external.CQExternal;
-import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.io.result.ResultRender.ResultRendererProvider;
 import com.bakdata.conquery.io.storage.MetaStorage;
 import com.bakdata.conquery.metrics.ExecutionMetrics;
@@ -132,7 +131,7 @@ public class QueryProcessor {
 		}
 
 		// Execute the query
-		return executionManager.runQuery(datasetRegistry, query, subject.getUser(), dataset, config);
+		return executionManager.runQuery(datasetRegistry, query, subject.getUser(), dataset, config, false);
 	}
 
 	/**
@@ -164,7 +163,9 @@ public class QueryProcessor {
 
 		// If the user is not the owner of the execution, we definitely create a new Execution, so the owner can cancel it
 		if (!user.isOwner(execution)) {
-			final ManagedExecution<?> newExecution = executionManager.createExecution(datasetRegistry, execution.getSubmitted(), user, execution.getDataset());
+			final ManagedExecution<?>
+					newExecution =
+					executionManager.createExecution(datasetRegistry, execution.getSubmitted(), user, execution.getDataset(), false);
 			newExecution.setLabel(execution.getLabel());
 			newExecution.setTags(execution.getTags().clone());
 			storage.updateExecution(newExecution);
@@ -201,6 +202,7 @@ public class QueryProcessor {
 						 .filter(q -> q.getDataset().equals(datasetId))
 						 // to exclude subtypes from somewhere else
 						 .filter(QueryProcessor::canFrontendRender)
+						 .filter(Predicate.not(ManagedExecution::isSystem))
 						 .filter(q -> q.getState().equals(ExecutionState.DONE) || q.getState().equals(ExecutionState.NEW))
 						 .filter(q -> subject.isPermitted(q, Ability.READ))
 						 .map(mq -> {
@@ -244,6 +246,7 @@ public class QueryProcessor {
 	 * Test if the query is structured in a way the Frontend can render it.
 	 */
 	private static boolean canFrontendRender(ManagedExecution<?> q) {
+		//TODO FK: should this be used to fill into canExpand instead of hiding the Executions?
 		if (!(q instanceof ManagedQuery)) {
 			return false;
 		}
@@ -371,7 +374,7 @@ public class QueryProcessor {
 		// We only create the Query, really no need to execute it as it's only useful for composition.
 		final ManagedQuery execution =
 				((ManagedQuery) datasetRegistry.get(dataset.getId()).getExecutionManager()
-											   .createExecution(datasetRegistry, query, subject.getUser(), dataset));
+											   .createExecution(datasetRegistry, query, subject.getUser(), dataset, false));
 
 		execution.setLastResultCount((long) statistic.getResolved().size());
 
@@ -392,9 +395,10 @@ public class QueryProcessor {
 	/**
 	 * Execute a {@link TableExportQuery} for a single Entity on some Connectors.
 	 *
+	 * @return
 	 * @implNote we don't do anything special here, this request could also be made manually. We however want to encapsulate this behaviour to shield the frontend from knowing too much about the query engine.
 	 */
-	public Response getSingleEntityExport(Subject subject, String idKind, String entity, List<Connector> sources, String format, Dataset dataset, Range<LocalDate> dateRange) {
+	public List<URL> getSingleEntityExport(Subject subject, UriBuilder uriBuilder, String idKind, String entity, List<Connector> sources, Dataset dataset, Range<LocalDate> dateRange) {
 
 		final ConceptQuery
 				entitySelectQuery =
@@ -407,7 +411,10 @@ public class QueryProcessor {
 					   .collect(Collectors.toList())
 		);
 
-		final ManagedQuery execution = (ManagedQuery) postQuery(dataset, exportQuery, subject);
+		final ManagedQuery execution =
+				((ManagedQuery) datasetRegistry.get(dataset.getId()).getExecutionManager()
+											   .createExecution(datasetRegistry, exportQuery, subject.getUser(), dataset, true));
+
 
 		// collect id immediately so it does not get sucked into closure
 		final ManagedExecutionId id = execution.getId();
@@ -416,18 +423,16 @@ public class QueryProcessor {
 			log.trace("Still waiting for {}", id);
 		}
 
+		if (execution.getState() == ExecutionState.FAILED) {
+			//TODO I am not sure how to relay errors properly to the Frontend, they are not Exceptions for some reason
+			throw new IllegalStateException(execution.getError().toString());
+		}
+
 		// Use the provided format name to find the respective provider.
-		final ResultRendererProvider rendererProvider =
-				config.getResultProviders().stream()
-					  .filter(provider -> provider.getClass().getAnnotation(CPSType.class).id().equalsIgnoreCase(format))
-					  .findFirst()
-					  .orElseThrow(() -> new BadRequestException(String.format("No configured provider for `%s` found.", format)));
+		return config.getResultProviders().stream()
+					 .map(resultRendererProvider -> resultRendererProvider.generateResultURLs(execution, uriBuilder, true))
+					 .flatMap(Collection::stream)
+					 .collect(Collectors.toList());
 
-		final Response response = rendererProvider.createResult(
-				subject, execution, dataset, true, determineCharset(null, null),
-				() -> storage.removeExecution(id)
-		);
-
-		return response;
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/Connector.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/Connector.java
@@ -67,9 +67,18 @@ public abstract class Connector extends Labeled<ConnectorId> implements SelectHo
 	@Valid
 	private List<Select> selects = new ArrayList<>();
 
+	/**
+	 * Determines if the connector is preselected for the user when creating a new {@link com.bakdata.conquery.apiv1.query.concept.specific.CQConcept}.
+	 */
 	@JsonProperty("default")
 	private boolean isDefault = true;
 
+	/**
+	 * If true, Frontend should use Connector as default when using {@link com.bakdata.conquery.resources.api.QueryResource.EntityPreview}.
+	 */
+	private  boolean defaultForEntityPreview = false;
+
+	@JsonIgnore
 	public List<Select> getDefaultSelects() {
 		return getSelects()
 					   .stream().filter(Select::isDefault)

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
@@ -234,7 +234,7 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 	 */
 	public ExecutionState awaitDone(int time, TimeUnit unit) {
 		if (getState() != ExecutionState.RUNNING) {
-			return ExecutionState.RUNNING;
+			return getState();
 		}
 		Uninterruptibles.awaitUninterruptibly(execution, time, unit);
 

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
@@ -52,6 +52,7 @@ import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.models.worker.Namespace;
 import com.bakdata.conquery.util.QueryUtils;
 import com.bakdata.conquery.util.QueryUtils.NamespacedIdentifiableCollector;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.base.Preconditions;
@@ -94,6 +95,7 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 	private String[] tags = ArrayUtils.EMPTY_STRING_ARRAY;
 	private boolean shared = false;
 
+	@JsonAlias("machineGenerated")
 	private boolean system;
 
 

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
@@ -94,7 +94,7 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 	private String[] tags = ArrayUtils.EMPTY_STRING_ARRAY;
 	private boolean shared = false;
 
-	private boolean machineGenerated;
+	private boolean system;
 
 
 	// we don't want to store or send query results or other result metadata
@@ -398,7 +398,7 @@ public abstract class ManagedExecution<R extends ShardResult> extends Identifiab
 	protected abstract String makeDefaultLabel(PrintSettings cfg);
 
 	protected String makeAutoLabel(PrintSettings cfg) {
-		return makeDefaultLabel(cfg) +  AUTO_LABEL_SUFFIX;
+		return makeDefaultLabel(cfg) + AUTO_LABEL_SUFFIX;
 	}
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/query/ExecutionManager.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/ExecutionManager.java
@@ -59,8 +59,8 @@ public class ExecutionManager {
 	}
 
 
-	public ManagedExecution<?> runQuery(DatasetRegistry datasets, QueryDescription query, User user, Dataset submittedDataset, ConqueryConfig config) {
-		final ManagedExecution<?> execution = createExecution(datasets, query, user, submittedDataset);
+	public ManagedExecution<?> runQuery(DatasetRegistry datasets, QueryDescription query, User user, Dataset submittedDataset, ConqueryConfig config, boolean system) {
+		final ManagedExecution<?> execution = createExecution(datasets, query, user, submittedDataset, system);
 		execute(datasets, execution, config);
 
 		return execution;
@@ -91,15 +91,15 @@ public class ExecutionManager {
 		}
 	}
 
-	public ManagedExecution<?> createExecution(DatasetRegistry datasets, QueryDescription query, User user, Dataset submittedDataset) {
-		return createQuery(datasets, query, UUID.randomUUID(), user, submittedDataset);
+	public ManagedExecution<?> createExecution(DatasetRegistry datasets, QueryDescription query, User user, Dataset submittedDataset, boolean system) {
+		return createQuery(datasets, query, UUID.randomUUID(), user, submittedDataset, system);
 	}
 
 
-	public ManagedExecution<?> createQuery(DatasetRegistry datasets, QueryDescription query, UUID queryId, User user, Dataset submittedDataset) {
+	public ManagedExecution<?> createQuery(DatasetRegistry datasets, QueryDescription query, UUID queryId, User user, Dataset submittedDataset, boolean system) {
 		// Transform the submitted query into an initialized execution
 		ManagedExecution<?> managed = query.toManagedExecution(user, submittedDataset);
-
+		managed.setSystem(system);
 		managed.setQueryId(queryId);
 
 		// Store the execution

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptResource.java
@@ -63,6 +63,8 @@ public class ConceptResource extends HConcepts {
 		throw new WebApplicationException("can only resolved elements on tree concepts", Status.BAD_REQUEST);
 	}
 
+
+
 	@Getter
 	@Setter
 	@RequiredArgsConstructor(onConstructor_ = @JsonCreator)

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.bakdata.conquery.apiv1.IdLabel;
 import com.bakdata.conquery.apiv1.frontend.FEList;
@@ -121,13 +122,12 @@ public class ConceptsProcessor {
 						 .collect(Collectors.toList());
 	}
 
-	public List<ConnectorId> getEntityPreviewDefaultConnectors(Dataset dataset){
+	public Stream<ConnectorId> getEntityPreviewDefaultConnectors(Dataset dataset){
 		return namespaces.get(dataset.getId()).getStorage().getAllConcepts().stream()
 				.map(Concept::getConnectors)
 				.flatMap(Collection::stream)
 				.filter(Connector::isDefaultForEntityPreview)
-				.map(Identifiable::getId)
-				.collect(Collectors.toList());
+				.map(Identifiable::getId);
 	}
 
 	/**

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java
@@ -22,11 +22,13 @@ import com.bakdata.conquery.models.auth.entities.Subject;
 import com.bakdata.conquery.models.auth.permissions.Ability;
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.datasets.concepts.Concept;
+import com.bakdata.conquery.models.datasets.concepts.Connector;
 import com.bakdata.conquery.models.datasets.concepts.FrontEndConceptBuilder;
 import com.bakdata.conquery.models.datasets.concepts.filters.specific.SelectFilter;
 import com.bakdata.conquery.models.datasets.concepts.tree.ConceptTreeChild;
 import com.bakdata.conquery.models.datasets.concepts.tree.TreeConcept;
 import com.bakdata.conquery.models.exceptions.ConceptConfigurationException;
+import com.bakdata.conquery.models.identifiable.Identifiable;
 import com.bakdata.conquery.models.identifiable.ids.specific.ConceptElementId;
 import com.bakdata.conquery.models.identifiable.ids.specific.ConnectorId;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
@@ -117,6 +119,15 @@ public class ConceptsProcessor {
 										   .thenComparing(Dataset::getLabel))
 						 .map(d -> new IdLabel<>(d.getId(), d.getLabel()))
 						 .collect(Collectors.toList());
+	}
+
+	public List<ConnectorId> getEntityPreviewDefaultConnectors(Dataset dataset){
+		return namespaces.get(dataset.getId()).getStorage().getAllConcepts().stream()
+				.map(Concept::getConnectors)
+				.flatMap(Collection::stream)
+				.filter(Connector::isDefaultForEntityPreview)
+				.map(Identifiable::getId)
+				.collect(Collectors.toList());
 	}
 
 	/**

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/DatasetResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/DatasetResource.java
@@ -2,7 +2,7 @@ package com.bakdata.conquery.resources.api;
 
 import static com.bakdata.conquery.resources.ResourceConstants.DATASET;
 
-import java.util.List;
+import java.util.stream.Stream;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -31,9 +31,12 @@ public class DatasetResource extends HDatasets {
 		return processor.getRoot(getNamespace().getStorage(), subject);
 	}
 
+	/**
+	 * Provides list of default {@link ConnectorId}s to use for {@link QueryResource.EntityPreview#getSources()}.
+	 */
 	@GET
-	@Path("entity-preview-default-connectors")
-	public List<ConnectorId> getEntityPreviewDefaultConnectors() {
+	@Path("entity-preview")
+	public Stream<ConnectorId> getEntityPreviewDefaultConnectors() {
 		return processor.getEntityPreviewDefaultConnectors(getDataset());
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/DatasetResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/DatasetResource.java
@@ -2,14 +2,17 @@ package com.bakdata.conquery.resources.api;
 
 import static com.bakdata.conquery.resources.ResourceConstants.DATASET;
 
+import java.util.List;
+
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
-import com.bakdata.conquery.io.jersey.ExtraMimeTypes;
 import com.bakdata.conquery.apiv1.frontend.FERoot;
+import com.bakdata.conquery.io.jersey.ExtraMimeTypes;
+import com.bakdata.conquery.models.identifiable.ids.specific.ConnectorId;
 import com.bakdata.conquery.resources.hierarchies.HDatasets;
 import lombok.Setter;
 
@@ -26,5 +29,11 @@ public class DatasetResource extends HDatasets {
 	@Path("concepts")
 	public FERoot getRoot() {
 		return processor.getRoot(getNamespace().getStorage(), subject);
+	}
+
+	@GET
+	@Path("entity-preview-default-connectors")
+	public List<ConnectorId> getEntityPreviewDefaultConnectors() {
+		return processor.getEntityPreviewDefaultConnectors(getDataset());
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/QueryResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/QueryResource.java
@@ -81,7 +81,7 @@ public class QueryResource {
 
 		subject.authorize(dataset, Ability.READ);
 
-		ManagedExecution<?> execution = processor.postQuery(dataset, query, subject);
+		ManagedExecution<?> execution = processor.postQuery(dataset, query, subject, false);
 
 		return Response.ok(processor.getQueryFullStatus(execution, subject, RequestAwareUriBuilder.fromRequest(servletRequest), allProviders.orElse(false)))
 					   .status(Status.CREATED)

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/QueryResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/QueryResource.java
@@ -4,6 +4,7 @@ package com.bakdata.conquery.resources.api;
 import static com.bakdata.conquery.resources.ResourceConstants.DATASET;
 import static com.bakdata.conquery.resources.ResourceConstants.QUERY;
 
+import java.net.URL;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -25,6 +26,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriBuilder;
 
 import com.bakdata.conquery.apiv1.AdditionalMediaTypes;
 import com.bakdata.conquery.apiv1.ExecutionStatus;
@@ -35,12 +37,10 @@ import com.bakdata.conquery.apiv1.RequestAwareUriBuilder;
 import com.bakdata.conquery.apiv1.query.ExternalUpload;
 import com.bakdata.conquery.apiv1.query.ExternalUploadResult;
 import com.bakdata.conquery.apiv1.query.QueryDescription;
-import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.io.jackson.serializer.NsIdRefCollection;
 import com.bakdata.conquery.models.auth.entities.Subject;
 import com.bakdata.conquery.models.auth.permissions.Ability;
 import com.bakdata.conquery.models.common.Range;
-import com.bakdata.conquery.models.config.CsvResultRenderer;
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.datasets.concepts.Connector;
 import com.bakdata.conquery.models.exceptions.JSONException;
@@ -158,13 +158,11 @@ public class QueryResource {
 		private final List<Connector> sources;
 	}
 
-	private static final String CSV_RESULT_ID = CsvResultRenderer.class.getAnnotation(CPSType.class).id();
-
 	@POST
 	@Path("/entity")
-	public Response getEntityData(@Auth Subject subject, EntityPreview query, @QueryParam("format") Optional<String> format, @Context HttpServletRequest request) {
-
-		return processor.getSingleEntityExport(subject, query.getIdKind(), query.getEntity(), query.getSources(), format.orElse(CSV_RESULT_ID), dataset, query.getTime());
+	public List<URL> getEntityData(@Auth Subject subject, EntityPreview query, @Context HttpServletRequest request) {
+		final UriBuilder uriBuilder = RequestAwareUriBuilder.fromRequest(request);
+		return processor.getSingleEntityExport(subject, uriBuilder, query.getIdKind(), query.getEntity(), query.getSources(), dataset, query.getTime());
 	}
 
 

--- a/backend/src/main/java/com/bakdata/conquery/tasks/QueryCleanupTask.java
+++ b/backend/src/main/java/com/bakdata/conquery/tasks/QueryCleanupTask.java
@@ -12,11 +12,11 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import com.bakdata.conquery.apiv1.query.concept.specific.CQReusedQuery;
 import com.bakdata.conquery.io.storage.MetaStorage;
 import com.bakdata.conquery.models.execution.ManagedExecution;
 import com.bakdata.conquery.models.forms.managed.ManagedForm;
 import com.bakdata.conquery.models.query.ManagedQuery;
-import com.bakdata.conquery.apiv1.query.concept.specific.CQReusedQuery;
 import com.bakdata.conquery.util.QueryUtils;
 import io.dropwizard.servlets.tasks.Task;
 import lombok.extern.slf4j.Slf4j;
@@ -85,6 +85,15 @@ public class QueryCleanupTask extends Task {
 					((ManagedForm) execution).getFlatSubQueries().values()
 											 .forEach(q -> q.getQuery().visit(reusedChecker));
 				}
+
+
+				if (execution.isSystem()) {
+					// System Queries will always be deleted.
+					toDelete.add(execution);
+					continue;
+				}
+
+				log.trace("{} is not system", execution.getId());
 
 				if (execution.isShared()) {
 					continue;

--- a/backend/src/test/java/com/bakdata/conquery/integration/common/LoadingUtil.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/common/LoadingUtil.java
@@ -68,10 +68,10 @@ public class LoadingUtil {
 			final CsvParser parser = support.getConfig().getCsv().withParseHeaders(false).withSkipHeader(false).createParser();
 			String[][] data = parser.parseAll(queryResults.stream()).toArray(new String[0][]);
 
-			ConceptQuery q = new ConceptQuery(new CQExternal(Arrays.asList("ID", "DATE_SET"), data));
+			ConceptQuery query = new ConceptQuery(new CQExternal(Arrays.asList("ID", "DATE_SET"), data));
 
 			ManagedExecution<?> managed = support.getNamespace().getExecutionManager()
-												 .createQuery(support.getDatasetRegistry(), q, queryId, user, support.getNamespace().getDataset());
+												 .createQuery(support.getDatasetRegistry(), query, queryId, user, support.getNamespace().getDataset(), false);
 
 			user.addPermission(managed.createPermission(AbilitySets.QUERY_CREATOR));
 
@@ -86,11 +86,11 @@ public class LoadingUtil {
 			Query query = mapper.readerFor(Query.class).readValue(queryNode);
 			UUID queryId = new UUID(0L, id++);
 
-			ManagedExecution<?>
-					managed =
+			ManagedExecution<?> managed =
 					support.getNamespace()
 						   .getExecutionManager()
-						   .createQuery(support.getDatasetRegistry(), query, queryId, user, support.getNamespace().getDataset());
+						   .createQuery(support.getDatasetRegistry(), query, queryId, user, support.getNamespace().getDataset(), false);
+
 			user.addPermission(ExecutionPermission.onInstance(AbilitySets.QUERY_CREATOR, managed.getId()));
 
 			if (managed.getState() == ExecutionState.FAILED) {

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/FormTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/FormTest.java
@@ -113,7 +113,7 @@ public class FormTest extends ConqueryTestSpec {
 
 		ManagedExecution<?>
 				managedForm =
-				support.getNamespace().getExecutionManager().runQuery(namespaces, form, support.getTestUser(), support.getDataset(), support.getConfig());
+				support.getNamespace().getExecutionManager().runQuery(namespaces, form, support.getTestUser(), support.getDataset(), support.getConfig(), false);
 
 		managedForm.awaitDone(10, TimeUnit.MINUTES);
 		if (managedForm.getState() != ExecutionState.DONE) {

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/EntityExportTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/EntityExportTest.java
@@ -4,6 +4,7 @@ import static com.bakdata.conquery.integration.common.LoadingUtil.importSecondar
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
+import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -32,7 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.description.LazyTextDescription;
 
 /**
- * Adapted from {@link com.bakdata.conquery.integration.tests.deletion.ImportDeletionTest}, tests {@link #getEntityData(Subject, QueryResource.EntityPreview, HttpServletRequest)}.
+ * Adapted from {@link com.bakdata.conquery.integration.tests.deletion.ImportDeletionTest}, tests {@link QueryResource#getEntityData(Subject, QueryResource.EntityPreview, HttpServletRequest)}.
  */
 @Slf4j
 public class EntityExportTest implements ProgrammaticIntegrationTest {
@@ -85,10 +86,13 @@ public class EntityExportTest implements ProgrammaticIntegrationTest {
 				.describedAs(new LazyTextDescription(() -> allEntityDataResponse.readEntity(String.class)))
 				.isEqualTo(Response.Status.Family.SUCCESSFUL);
 
-		final String rawData = allEntityDataResponse.readEntity(String.class);
+		final URL[] rawData = allEntityDataResponse.readEntity(URL[].class);
 
-		assertThat(rawData.lines().collect(Collectors.toList()))
-				.isEqualTo(List.of("result,dates,test_table test_column,test_table2 test_column", "3,2013-11-10,A1,"));
+
+		//TODO not really sure how much validation I can do here.
+		assertThat(rawData).isNotEmpty();
+
+
 
 	}
 

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/EntityExportTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/EntityExportTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
@@ -33,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.description.LazyTextDescription;
 
 /**
- * Adapted from {@link com.bakdata.conquery.integration.tests.deletion.ImportDeletionTest}, tests {@link com.bakdata.conquery.resources.api.QueryResource#getEntityData(Subject, QueryResource.EntityPreview, Optional, HttpServletRequest)}.
+ * Adapted from {@link com.bakdata.conquery.integration.tests.deletion.ImportDeletionTest}, tests {@link #getEntityData(Subject, QueryResource.EntityPreview, HttpServletRequest)}.
  */
 @Slf4j
 public class EntityExportTest implements ProgrammaticIntegrationTest {

--- a/docs/Concept JSONs.md
+++ b/docs/Concept JSONs.md
@@ -793,6 +793,7 @@ Supported Fields:
 
 |  | Field | Type | Default | Example | Description |
 | --- | --- | --- | --- | --- | --- |
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/Connector.java#L76-L78) | defaultForEntityPreview | `boolean` | ? |  | If true, Frontend should use Connector as default when using {@link com.bakdata.conquery.resources.api.QueryResource.EntityPreview}. | 
 | [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/Connector.java#L63) | selects | list of [Select](#Base-Select) | ? |  |  | 
 | [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/Connector.java#L45) | validityDates | list of [ValidityDate](#Type-ValidityDate) | ? |  |  | 
 | [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/identifiable/Labeled.java#L25-L29) | label | `String` | ? | "someLabel" | shown in the frontend | 

--- a/docs/REST API JSONs.md
+++ b/docs/REST API JSONs.md
@@ -33,7 +33,7 @@ Returns: [FrontendConfig](#Type-FrontendConfig)
 
 </p></details>
 
-### GET datasets/{dataset}/concepts<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/DatasetResource.java#L25)</sup></sub></sup>
+### GET datasets/{dataset}/concepts<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/DatasetResource.java#L28)</sup></sub></sup>
 
 
 <details><summary>Details</summary><p>
@@ -101,6 +101,19 @@ Returns: [ResolvedConceptsResult](#Type-ResolvedConceptsResult)
 
 </p></details>
 
+### GET datasets/{dataset}/entity-preview<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/DatasetResource.java#L34-L36)</sup></sub></sup>
+Provides list of default {@link ConnectorId}s to use for {@link QueryResource.EntityPreview#getSources()}.
+
+<details><summary>Details</summary><p>
+
+Java Type: `com.bakdata.conquery.resources.api.DatasetResource`
+
+Method: `getEntityPreviewDefaultConnectors`
+
+Returns: `Stream<ConnectorId>`
+
+</p></details>
+
 ### GET datasets/{dataset}/queries<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/QueryResource.java#L70)</sup></sub></sup>
 
 
@@ -130,7 +143,7 @@ Returns: `Response`
 
 </p></details>
 
-### POST datasets/{dataset}/queries/entity<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/QueryResource.java#L163)</sup></sub></sup>
+### POST datasets/{dataset}/queries/entity<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/QueryResource.java#L161)</sup></sub></sup>
 
 
 <details><summary>Details</summary><p>
@@ -140,8 +153,7 @@ Java Type: `com.bakdata.conquery.resources.api.QueryResource`
 Method: `getEntityData`
 
 Expects: `EntityPreview`
-Expects: `Optional<String>`
-Returns: `Response`
+Returns: list of `URL`
 
 </p></details>
 
@@ -815,7 +827,7 @@ Supported Fields:
 | [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/apiv1/query/concept/filter/CQTable.java#L31) | selects | list of ID of `Select` | `[]` |  |  | 
 </p></details>
 
-### Type ConceptCodeList<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptResource.java#L66)</sup></sub></sup>
+### Type ConceptCodeList<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptResource.java#L68)</sup></sub></sup>
 
 
 <details><summary>Details</summary><p>
@@ -826,7 +838,7 @@ Supported Fields:
 
 |  | Field | Type | Default | Example | Description |
 | --- | --- | --- | --- | --- | --- |
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptResource.java#L70) | concepts | list of `String` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptResource.java#L72) | concepts | list of `String` | ? |  |  | 
 </p></details>
 
 ### Type CurrencyConfig<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/config/FrontendConfig.java#L202)</sup></sub></sup>
@@ -1074,7 +1086,7 @@ Supported Fields:
 | [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/apiv1/ExecutionStatus.java#L25) | tags | list of `String` | `null` |  |  | 
 </p></details>
 
-### Type ResolvedConceptsResult<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L282)</sup></sub></sup>
+### Type ResolvedConceptsResult<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L293)</sup></sub></sup>
 
 
 <details><summary>Details</summary><p>
@@ -1085,12 +1097,12 @@ Supported Fields:
 
 |  | Field | Type | Default | Example | Description |
 | --- | --- | --- | --- | --- | --- |
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L287) | resolvedConcepts | `Set<ConceptElementId<?>>` | ? |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L288) | resolvedFilter | [ResolvedFilterResult](#Type-ResolvedFilterResult) | ? |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L289) | unknownCodes | `Collection<String>` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L298) | resolvedConcepts | `Set<ConceptElementId<?>>` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L299) | resolvedFilter | [ResolvedFilterResult](#Type-ResolvedFilterResult) | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L300) | unknownCodes | `Collection<String>` | ? |  |  | 
 </p></details>
 
-### Type ResolvedFilterResult<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L272)</sup></sub></sup>
+### Type ResolvedFilterResult<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L283)</sup></sub></sup>
 
 
 <details><summary>Details</summary><p>
@@ -1101,9 +1113,9 @@ Supported Fields:
 
 |  | Field | Type | Default | Example | Description |
 | --- | --- | --- | --- | --- | --- |
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L278) | filterId | ID of `Filter` | ? |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L277) | tableId | ID of `Connector` | ? |  |  | 
-| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L279) | value | `Collection<FEValue>` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L289) | filterId | ID of `Filter` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L288) | tableId | ID of `Connector` | ? |  |  | 
+| [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L290) | value | `Collection<FEValue>` | ? |  |  | 
 </p></details>
 
 ### Type ValidityDateContainer<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/apiv1/query/concept/filter/ValidityDateContainer.java#L9)</sup></sub></sup>


### PR DESCRIPTION
This PR implements two options to communicate the default connectors for entityPreview to the Frontend. Either by embedding the boolean flag, or exposing them by an additional endpoint.

I favor embedding, but I suspect it's much easier for the frontend to just poll a single endpoint.