### PR TITLE
updates shiro

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -186,7 +186,7 @@
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-core</artifactId>
-			<version>1.9.0</version>
+			<version>1.9.1</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>


### PR DESCRIPTION
Security Fix
CVE-2022-32532:
Apache Shiro before 1.9.1, A RegexRequestMatcher can be misconfigured to be bypassed on some servlet containers. Applications using RegExPatternMatcher with `.` in the regular expression are possibly vulnerable to an authorization bypass.

