### PR TITLE
When switching form, clear form BEFORE switching

### DIFF
--- a/frontend/src/js/external-forms/FormsNavigation.tsx
+++ b/frontend/src/js/external-forms/FormsNavigation.tsx
@@ -86,6 +86,7 @@ const FormsNavigation = ({ reset }: Props) => {
           value={options.find((o) => o.value === activeForm) || null}
           onChange={(value) => {
             if (value) {
+              reset();
               onChangeToForm(value.value as string);
             }
           }}

--- a/frontend/src/js/external-forms/FormsTab.tsx
+++ b/frontend/src/js/external-forms/FormsTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useDispatch, useSelector, useStore } from "react-redux";
 
@@ -92,18 +92,6 @@ const useInitializeForm = () => {
   const onReset = useCallback(() => {
     methods.reset(defaultValues);
   }, [methods, defaultValues]);
-
-  const previousConfig = usePrevious(config);
-  // Layout effect to re-initialize the new form before all other children effects
-  // that load values into the fields, for example.
-  useLayoutEffect(
-    function resetOnFormChange() {
-      if (previousConfig?.type !== config?.type) {
-        onReset();
-      }
-    },
-    [previousConfig, config, onReset],
-  );
 
   return { methods, config, datasetOptions, onReset };
 };

--- a/frontend/src/js/external-forms/form/Field.tsx
+++ b/frontend/src/js/external-forms/form/Field.tsx
@@ -27,7 +27,12 @@ import FormConceptGroup from "../form-concept-group/FormConceptGroup";
 import type { FormConceptGroupT } from "../form-concept-group/formConceptGroupState";
 import FormQueryDropzone from "../form-query-dropzone/FormQueryDropzone";
 import FormTabNavigation from "../form-tab-navigation/FormTabNavigation";
-import { getInitialValue, isFormField, isOptionalField } from "../helper";
+import {
+  getFieldKey,
+  getInitialValue,
+  isFormField,
+  isOptionalField,
+} from "../helper";
 import { getErrorForField } from "../validators";
 
 import type { DynamicFormValues } from "./Form";
@@ -88,6 +93,7 @@ const ConnectedField = <T extends Object>({
     rules: {
       validate: (value) => getErrorForField(t, formField, value) || true,
     },
+    shouldUnregister: true,
   });
 
   // TODO: REFINE COLORS
@@ -334,8 +340,7 @@ const Field = ({ field, ...commonProps }: PropsT) => {
             }}
           >
             {field.fields.map((f, i) => {
-              const key =
-                isFormField(f) && f.type !== "GROUP" ? f.name : f.type + i;
+              const key = getFieldKey(formType, f, i);
               const nestedFieldOptional = isOptionalField(f);
 
               return (
@@ -379,10 +384,7 @@ const Field = ({ field, ...commonProps }: PropsT) => {
                 {tabToShow && tabToShow.fields.length > 0 ? (
                   <NestedFields>
                     {tabToShow.fields.map((f, i) => {
-                      const key =
-                        isFormField(f) && f.type !== "GROUP"
-                          ? f.name
-                          : f.type + i;
+                      const key = getFieldKey(formType, f, i);
                       const nestedFieldOptional = isOptionalField(f);
 
                       return (

--- a/frontend/src/js/external-forms/form/Form.tsx
+++ b/frontend/src/js/external-forms/form/Form.tsx
@@ -6,7 +6,7 @@ import type { SelectOptionT } from "../../api/types";
 import { useActiveLang } from "../../localization/useActiveLang";
 import FormHeader from "../FormHeader";
 import type { Form as FormType } from "../config-types";
-import { isFormField, isOptionalField } from "../helper";
+import { getFieldKey, isOptionalField } from "../helper";
 
 import Field from "./Field";
 
@@ -37,10 +37,7 @@ const Form = memo(({ config, datasetOptions, methods }: Props) => {
         <SxFormHeader description={config.description[activeLang]!} />
       )}
       {config.fields.map((field, i) => {
-        const key =
-          isFormField(field) && field.type !== "GROUP"
-            ? field.name
-            : field.type + i;
+        const key = getFieldKey(config.type, field, i);
         const optional = isOptionalField(field);
 
         return (

--- a/frontend/src/js/external-forms/helper.ts
+++ b/frontend/src/js/external-forms/helper.ts
@@ -5,6 +5,16 @@ import type { FormField, GeneralField, Group } from "./config-types";
 
 const nonFormFieldTypes = new Set(["HEADLINE", "DESCRIPTION"]);
 
+export const getFieldKey = (
+  formType: string,
+  field: GeneralField,
+  idx: number,
+) => {
+  return isFormField(field) && field.type !== "GROUP"
+    ? formType + field.name
+    : formType + field.type + idx;
+};
+
 export const isOptionalField = (field: GeneralField) => {
   return (
     isFormField(field) &&


### PR DESCRIPTION
Because reset AFTER didn't work properly, likely because react-hook-form's useController doesn't have the updated control prop form useForm when running the useLayoutEffect.