### PR TITLE
Add selected item already in state reducer,

### DIFF
--- a/frontend/src/js/ui-components/InputMultiSelect/InputMultiSelect.tsx
+++ b/frontend/src/js/ui-components/InputMultiSelect/InputMultiSelect.tsx
@@ -181,6 +181,10 @@ const InputMultiSelect = ({
             ? { value: inputValue, label: inputValue }
             : changes.selectedItem;
 
+          if (selectedItem) {
+            addSelectedItem(selectedItem);
+          }
+
           return {
             ...changes,
             selectedItem,
@@ -209,8 +213,6 @@ const InputMultiSelect = ({
         case useCombobox.stateChangeTypes.InputBlur:
         case useCombobox.stateChangeTypes.ItemClick:
           if (action.selectedItem) {
-            addSelectedItem(action.selectedItem);
-
             const wasNewItemCreated =
               creatable &&
               action.selectedItem.value === inputValue &&
@@ -379,7 +381,7 @@ const InputMultiSelect = ({
           <List>
             {!creatable && filteredOptions.length === 0 && <EmptyPlaceholder />}
             {filteredOptions.map((option, index) => (
-              <Fragment key={`${option.value}${option.label}`}>
+              <Fragment key={`${index}${option.value}${option.label}`}>
                 <ListItem
                   index={index}
                   highlightedIndex={highlightedIndex}


### PR DESCRIPTION
Since onStateChange only gets called on state diff,
and selectedItem isn't cleared when an item is removed,
it won't "change", when it's removed and re-added again.
So we didn't get the change.

There also doesn't seem to be a way to clear selectedItem, except for
reset, which would also reset the menu (--> close it).

Solution: we don't use onStateChange anymore, but a side effect of
the stateReducer instead. Doesn't feel great, but seems to work.

The downshift docs are wrong, recommending to call addSelectedItem in
onStateChange, because all of their examples work with a closing menu,
after selecting one item.

We're keeping the menu open.