### PR TITLE
changes the content type for permission related queries

### DIFF
--- a/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/templates/permissionCreator.html.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/templates/permissionCreator.html.ftl
@@ -103,7 +103,7 @@
 			{
 				method: 'post',
 				credentials: 'same-origin',
-				headers: {'Content-Type': 'text/plain'},
+				headers: {'Content-Type': 'application/json'},
 				body: permission
 			});
 		location.reload();

--- a/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/templates/permissionTable.html.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/templates/permissionTable.html.ftl
@@ -57,7 +57,7 @@
             {
                 method: 'delete',
                 credentials: 'same-origin',
-                headers: {'Content-Type': 'text/plain'},
+                headers: {'Content-Type': 'application/json'},
                 body: permission
             })
             .then(function(){location.reload()});


### PR DESCRIPTION
Creating or deleting Permissions didn't work because the wrong content type was send in the request.
Fixes admin-ui request content types: text/plain -> application/json