### PR TITLE
ARX-Form preconfigured privacy models

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/models/forms/arx/ArxExecution.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/arx/ArxExecution.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import com.bakdata.conquery.apiv1.forms.ArxForm;
+import com.bakdata.conquery.apiv1.forms.arx.ArxForm;
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.io.storage.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.User;
@@ -144,14 +144,11 @@ public class ArxExecution extends ManagedInternalForm implements SingleTableResu
 
 		// Configure ARX
 		ARXConfiguration config = ARXConfiguration.create();
-		config.addPrivacyModel(new KAnonymity(form.getKAnonymityParam()));
+		config.addPrivacyModel(form.getPrivacyModel().getPrivacyCriterion());
 		config.setSuppressionLimit(form.getSuppressionLimit());
 
 		// Run ARX
 		ARXAnonymizer anonymizer = new ARXAnonymizer();
-		anonymizer.setMaximumSnapshotSizeDataset(form.getMaximumSnapshotSizeDataset());
-		anonymizer.setMaximumSnapshotSizeSnapshot(form.getMaximumSnapshotSizeSnapshot());
-		anonymizer.setHistorySize(form.getHistorySize());
 
 		result = anonymizer.anonymize(data, config);
 

--- a/backend/src/main/resources/com/bakdata/conquery/frontend/forms/arx_form.frontend_conf.json
+++ b/backend/src/main/resources/com/bakdata/conquery/frontend/forms/arx_form.frontend_conf.json
@@ -4,9 +4,9 @@
         "de": "ARX Anonymisierung"
     },
     "description": {
-        "en": "With this form, the actual result of the provided query is anonymized using [ARX](https://arx.deidentifier.org/).",
-        "de": "Mit diesem Formular wird das eigentliche Ergebnis der übergebenen Anfrage mittels [ARX](https://arx.deidentifier.org/) anonymisiert."
-    },
+		"en": "With this form, the actual result of the provided query is anonymized using ARX.",
+		"de": "Mit diesem Formular wird das eigentliche Ergebnis der übergebenen Anfrage mittels ARX anonymisiert."
+	},
     "type": "ARX_FORM",
     "fields": [
         {
@@ -29,85 +29,57 @@
             }
         },
         {
-            "name": "kAnonymityParam",
-            "type": "NUMBER",
-            "defaultValue": 2,
-            "min": 2,
-            "label": {
-                "en": "k Parameter für k-Anonymität",
-                "de": "k Parameter für k-Anonymität"
-            },
-            "placeholder": {
-                "de": "k"
-            },
-            "pattern": "^\\d+$",
-            "validations": [
-                "NOT_EMPTY",
-                "GREATER_THAN_ZERO"
-            ]
-        },
-        {
             "name": "suppressionLimit",
             "type": "NUMBER",
             "defaultValue": 0.02,
             "min": 0,
             "max": 1,
-            "label": {
-                "en": "Suppression Limit",
-                "de": "Unterdrückungslimit"
-            },
-            "pattern": "^\\d+.?\\d*$",
-            "validations": [
-                "NOT_EMPTY",
-                "GREATER_THAN_ZERO"
-            ]
-        },
-        {
-            "name": "maximumSnapshotSizeDataset",
-            "type": "NUMBER",
-            "defaultValue": 0.2,
-            "min": 0,
-            "max": 1,
-            "label": {
-                "en": "Maximum Snapshot Size Dataset",
-                "de": "Maximum Snapshot Size Dataset"
-            },
-            "pattern": "^\\d+.?\\d*$",
-            "validations": [
-                "NOT_EMPTY",
-                "GREATER_THAN_ZERO"
-            ]
-        },
-        {
-            "name": "maximumSnapshotSizeSnapshot",
-            "type": "NUMBER",
-            "defaultValue": 0.2,
-            "min": 0,
-            "max": 1,
-            "label": {
-                "en": "Maximum Snapshot Size Snapshot",
-                "de": "Maximum Snapshot Size Snapshot"
-            },
-            "pattern": "^\\d+.?\\d*$",
-            "validations": [
-                "NOT_EMPTY",
-                "GREATER_THAN_ZERO"
-            ]
-        },
-        {
-            "name": "historySize",
-            "type": "NUMBER",
-            "defaultValue": 200,
-            "min": 1,
-            "label": {
-                "en": "History Size",
-                "de": "History Size"
-            },
-            "pattern": "^\\d+$",
-            "validations": [
-                "NOT_EMPTY",
-                "GREATER_THAN_ZERO"
-            ]
-        }
-    ]
+			"label": {
+				"en": "Suppression Limit",
+				"de": "Unterdrückungslimit"
+			},
+			"pattern": "^\\d+.?\\d*$",
+			"validations": [
+				"NOT_EMPTY",
+				"GREATER_THAN_ZERO"
+			]
+		},
+		{
+			"name": "privacyModel",
+			"type": "SELECT",
+			"label": {
+				"en": "Privacy Model",
+				"de": "Datenschutz Modell"
+			},
+			"defaultValue": "K_ANONYMITY_11",
+			"options": [
+				{
+					"label": {
+						"de": "K-Anonymität 5",
+						"en": "K-Anonymity 5"
+					},
+					"value": "K_ANONYMITY_5"
+				},
+				{
+					"label": {
+						"de": "K-Anonymität 11",
+						"en": "K-Anonymity 11"
+					},
+					"value": "K_ANONYMITY_11"
+				},
+				{
+					"label": {
+						"de": "Pitman 1%",
+						"en": "Pitman 1%"
+					},
+					"value": "PITMAN_1_PERCENT"
+				}
+			],
+			"validations": [
+				"NOT_EMPTY"
+			],
+			"tooltip": {
+			}
+		}
+	]
 }

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/ConqueryTestSpec.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/ConqueryTestSpec.java
@@ -33,7 +33,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, property = "type")
 @Slf4j @CPSBase
 public abstract class ConqueryTestSpec {
 	

--- a/backend/src/test/resources/tests/form/ARX_FORM/DECIMAL/DECIMAL.test.json
+++ b/backend/src/test/resources/tests/form/ARX_FORM/DECIMAL/DECIMAL.test.json
@@ -1,36 +1,37 @@
 {
-    "type": "FORM_TEST",
-    "expectedCsv": {
-        "results": "tests/form/ARX_FORM/DECIMAL/expected.csv"
-    },
-    "form": {
-        "type": "ARX_FORM",
-        "queryGroup": "00000000-0000-0000-0000-000000000001"
-    },
-    "content": {
-        "autoConcept": true,
-        "tables": [
-            "/tests/form/shared/decimal.table.json"
-        ],
-        "previousQueries": [
-            {
-                "type": "CONCEPT_QUERY",
-                "dateAggregationMode": "NONE",
-                "root": {
-                    "ids": [
-                        "decimal_AUTO"
-                    ],
-                    "type": "CONCEPT",
-                    "tables": [
-                        {
-                            "id": "decimal_AUTO.connector",
-                            "selects": [
-                                "decimal_AUTO.connector.decimal_FIRST"
-                            ]
-                        }
-                    ]
-                }
-            }
-        ]
-    }
+	"type": "FORM_TEST",
+	"expectedCsv": {
+		"results": "tests/form/ARX_FORM/DECIMAL/expected.csv"
+	},
+	"form": {
+		"type": "ARX_FORM",
+		"queryGroup": "00000000-0000-0000-0000-000000000001",
+		"privacyModel": "K_ANONYMITY_2"
+	},
+	"content": {
+		"autoConcept": true,
+		"tables": [
+			"/tests/form/shared/decimal.table.json"
+		],
+		"previousQueries": [
+			{
+				"type": "CONCEPT_QUERY",
+				"dateAggregationMode": "NONE",
+				"root": {
+					"ids": [
+						"decimal_AUTO"
+					],
+					"type": "CONCEPT",
+					"tables": [
+						{
+							"id": "decimal_AUTO.connector",
+							"selects": [
+								"decimal_AUTO.connector.decimal_FIRST"
+							]
+						}
+					]
+				}
+			}
+		]
+	}
 }

--- a/backend/src/test/resources/tests/form/ARX_FORM/HIERARCHY/form.test.json
+++ b/backend/src/test/resources/tests/form/ARX_FORM/HIERARCHY/form.test.json
@@ -5,9 +5,10 @@
         "results": "tests/form/ARX_FORM/HIERARCHY/expected.csv"
     },
     "form": {
-        "type": "ARX_FORM",
-        "queryGroup": "00000000-0000-0000-0000-000000000001"
-    },
+		"type": "ARX_FORM",
+		"queryGroup": "00000000-0000-0000-0000-000000000001",
+		"privacyModel": "K_ANONYMITY_2"
+	},
     "concepts": [
         "/tests/form/shared/hierarchy.concept.json"
     ],

--- a/backend/src/test/resources/tests/form/ARX_FORM/INTEGER/INTEGER.test.json
+++ b/backend/src/test/resources/tests/form/ARX_FORM/INTEGER/INTEGER.test.json
@@ -4,9 +4,10 @@
         "results": "tests/form/ARX_FORM/INTEGER/expected.csv"
     },
     "form": {
-        "type": "ARX_FORM",
-        "queryGroup": "00000000-0000-0000-0000-000000000001"
-    },
+		"type": "ARX_FORM",
+		"queryGroup": "00000000-0000-0000-0000-000000000001",
+		"privacyModel": "K_ANONYMITY_2"
+	},
     "content": {
         "autoConcept": true,
         "tables": [

--- a/backend/src/test/resources/tests/form/ARX_FORM/SIMPLE/SIMPLE.test.json
+++ b/backend/src/test/resources/tests/form/ARX_FORM/SIMPLE/SIMPLE.test.json
@@ -5,9 +5,10 @@
         "results": "tests/form/ARX_FORM/SIMPLE/expected.csv"
     },
     "form": {
-        "type": "ARX_FORM",
-        "queryGroup": "00000000-0000-0000-0000-000000000001"
-    },
+		"type": "ARX_FORM",
+		"queryGroup": "00000000-0000-0000-0000-000000000001",
+		"privacyModel": "K_ANONYMITY_2"
+	},
     "content": {
         "autoConcept": true,
         "tables": [


### PR DESCRIPTION
adds 4 privacy models:
- K-5 Anonymity
- K-11 Anonymity
- Pitman 1%
- K-2 Anonymity for tests