### PR TITLE
Jackson use Blackbird instead of Afterburner

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -92,25 +92,25 @@
     </build>
 
     <dependencies>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-to-slf4j</artifactId>
-            <version>2.19.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-afterburner</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-core</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-to-slf4j</artifactId>
+			<version>2.19.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.module</groupId>
+			<artifactId>jackson-module-blackbird</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>${lombok.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.dropwizard</groupId>
+			<artifactId>dropwizard-core</artifactId>
+		</dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>

--- a/backend/src/main/java/com/bakdata/conquery/io/jackson/Jackson.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/jackson/Jackson.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
+import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.apache.shiro.authz.Permission;
 
@@ -43,35 +43,35 @@ public class Jackson {
 	public static <T extends ObjectMapper> T configure(T objectMapper){
 
 		objectMapper
-			.enable(MapperFeature.PROPAGATE_TRANSIENT_MARKER)
-			.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
-			.enable(Feature.ALLOW_UNQUOTED_FIELD_NAMES)
-			.enable(Feature.ALLOW_COMMENTS)
-			.enable(Feature.ALLOW_UNQUOTED_CONTROL_CHARS)
-			//TODO this is just a hotfix to avoid reimports
-//			.enable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)
-			.enable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
-			.enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
-			.enable(DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS)
-			.enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY)
-			.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-			.enable(DeserializationFeature.FAIL_ON_UNRESOLVED_OBJECT_IDS)
-			.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
-			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-			.setLocale(Locale.ROOT)
-			.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET)
-			.enable(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS)
-			.enable(SerializationFeature.WRITE_NULL_MAP_VALUES)
-			.registerModule(new JavaTimeModule())
-			.registerModule(new ParameterNamesModule())
-			.registerModule(new GuavaModule())
-			.registerModule(new AfterburnerModule())
-			.registerModule(ConquerySerializersModule.INSTANCE)
-			.setSerializationInclusion(Include.ALWAYS)
-			.setDefaultPropertyInclusion(Include.ALWAYS)
-			//.setAnnotationIntrospector(new RestrictingAnnotationIntrospector())
-			.setInjectableValues(new MutableInjectableValues())
-			.addMixIn(Permission.class, ConqueryPermission.class);
+				.enable(MapperFeature.PROPAGATE_TRANSIENT_MARKER)
+				.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+				.enable(Feature.ALLOW_UNQUOTED_FIELD_NAMES)
+				.enable(Feature.ALLOW_COMMENTS)
+				.enable(Feature.ALLOW_UNQUOTED_CONTROL_CHARS)
+				//TODO this is just a hotfix to avoid reimports
+				//			.enable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)
+				.enable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
+				.enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+				.enable(DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS)
+				.enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY)
+				.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+				.enable(DeserializationFeature.FAIL_ON_UNRESOLVED_OBJECT_IDS)
+				.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+				.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+				.setLocale(Locale.ROOT)
+				.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET)
+				.enable(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS)
+				.enable(SerializationFeature.WRITE_NULL_MAP_VALUES)
+				.registerModule(new JavaTimeModule())
+				.registerModule(new ParameterNamesModule())
+				.registerModule(new GuavaModule())
+				.registerModule(new BlackbirdModule())
+				.registerModule(ConquerySerializersModule.INSTANCE)
+				.setSerializationInclusion(Include.ALWAYS)
+				.setDefaultPropertyInclusion(Include.ALWAYS)
+				//.setAnnotationIntrospector(new RestrictingAnnotationIntrospector())
+				.setInjectableValues(new MutableInjectableValues())
+				.addMixIn(Permission.class, ConqueryPermission.class);
 
 		objectMapper.setConfig(objectMapper.getSerializationConfig().withView(Object.class));
 		return objectMapper;


### PR DESCRIPTION
@awildturtok Afterburner sollte man nicht mehr mit java 11+ nutzen https://github.com/FasterXML/jackson-modules-base/tree/master/blackbird

Ich hatte jetzt auch schon einen IllegalAccessError, weil ich einen `record` deserialisieren wollte. Lokal hat es komischer weise geklappt