### PR TITLE
use maven properties with externally supplied version

### DIFF
--- a/.github/workflows/release_backend.yml
+++ b/.github/workflows/release_backend.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
+          # This should be deep enough to fetch at least one light weight tag
+          fetch-depth: 500 
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # maven
 *.xml.versionsBackup
+.flattened-pom.xml
 
 # vscode
 launch.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,22 +11,21 @@ FROM maven:3.8-openjdk-17-slim AS builder
 
 WORKDIR /app
 
-# Get the version from previous step
-COPY --from=version-extractor /app/git_describe.txt .
-
 # Fetch dependencies first
 COPY ./pom.xml .
 COPY ./backend/pom.xml ./backend/
 COPY ./executable/pom.xml ./executable/
 COPY ./autodoc/pom.xml ./autodoc/
 
-RUN mvn dependency:resolve -Dsilent=true -DexcludeGroupIds="com.bakdata.conquery" -DexcludeArtifactIds="backend:jar" -pl backend -am
+RUN mvn dependency:go-offline -Dsilent=true -DexcludeGroupIds="com.bakdata.conquery" -pl backend -am
 
-
-# Then copy the rest and build
-
+# Then copy the rest
 COPY . .
 
+# Get the version from previous step
+COPY --from=version-extractor /app/git_describe.txt .
+
+# Build
 RUN ./scripts/build_backend_version.sh `cat git_describe.txt`
 
 

--- a/autodoc/pom.xml
+++ b/autodoc/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>com.bakdata.conquery</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.0.0-SNAPSHOT</version>
+		<version>${revision}</version>
 	</parent>
 	<artifactId>autodoc</artifactId>
 	<build>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bakdata.conquery</groupId>
         <artifactId>parent</artifactId>
-        <version>0.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>backend</artifactId>
 

--- a/executable/pom.xml
+++ b/executable/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.bakdata.conquery</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.0.0-SNAPSHOT</version>
+		<version>${revision}</version>
 	</parent>
 	<artifactId>executable</artifactId>
 
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>com.bakdata.conquery</groupId>
 			<artifactId>backend</artifactId>
-			<version>0.0.0-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.bakdata.conquery</groupId>
 	<artifactId>parent</artifactId>
@@ -25,7 +25,7 @@
 		<maven-dependency-plugin.version>3.3.0</maven-dependency-plugin.version>
 		<maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssXXX</maven.build.timestamp.format>
 		<build.time>${maven.build.timestamp}</build.time>
-    	<revision>0.0.0-SNAPSHOT</revision>
+		<revision>0.0.0-SNAPSHOT</revision>
 	</properties>
 
 	<modules>
@@ -58,7 +58,8 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
 					<trimStackTrace>false</trimStackTrace>
-					<argLine>-Xmx4G
+					<argLine>
+						-Xmx4G
 						<!-- TODO this should be refined. We only need this for arrow as of now. -->
 						--add-opens java.base/java.lang=ALL-UNNAMED
 						--add-opens java.base/java.util=ALL-UNNAMED
@@ -87,6 +88,31 @@
 							<!-- Allow transitive dependencies for now -->
 							<failOnWarning>false</failOnWarning>
 						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<version>1.3.0</version>
+				<configuration>
+					<updatePomFile>true</updatePomFile>
+					<flattenMode>resolveCiFriendliesOnly</flattenMode>
+				</configuration>
+				<executions>
+					<execution>
+						<id>flatten</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>flatten</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>flatten.clean</id>
+						<phase>clean</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
 					</execution>
 				</executions>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.bakdata.conquery</groupId>
 	<artifactId>parent</artifactId>
-	<version>0.0.0-SNAPSHOT</version>
+	<version>${revision}</version>
 
 	<packaging>pom</packaging>
 	<name>Conquery Parent</name>
@@ -25,6 +25,7 @@
 		<maven-dependency-plugin.version>3.3.0</maven-dependency-plugin.version>
 		<maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssXXX</maven.build.timestamp.format>
 		<build.time>${maven.build.timestamp}</build.time>
+    	<revision>0.0.0-SNAPSHOT</revision>
 	</properties>
 
 	<modules>
@@ -91,103 +92,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
-	<profiles>
-		<profile>
-			<id>setVersion</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>pl.project13.maven</groupId>
-						<artifactId>git-commit-id-plugin</artifactId>
-						<version>4.9.10</version>
-						<inherited>false</inherited>
-						<executions>
-							<execution>
-								<id>get-the-git-infos</id>
-								<goals>
-									<goal>revision</goal>
-								</goals>
-							</execution>
-						</executions>
-						<configuration>
-							<failOnUnableToExtractRepoInfo>true</failOnUnableToExtractRepoInfo>
-							<dateFormat>${maven.build.timestamp.format}</dateFormat>
-							<skipPoms>false</skipPoms>
-							<gitDescribe>
-								<skip>false</skip>
-								<!-- do not only use annotated tags -->
-								<tags>true</tags>
-							</gitDescribe>
-							<offline>true</offline>
-							<includeOnlyProperties>
-								<includeOnlyProperty>^git.commit.id.describe</includeOnlyProperty>
-							</includeOnlyProperties>
-						</configuration>
-					</plugin>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>build-helper-maven-plugin</artifactId>
-						<version>3.3.0</version>
-						<inherited>false</inherited>
-						<executions>
-							<execution>
-								<id>regex-property-snapshot</id>
-								<goals>
-									<goal>regex-property</goal>
-								</goals>
-								<phase>initialize</phase>
-								<configuration>
-									<name>newVersion</name>
-									<value>${git.commit.id.describe}</value>
-									<regex>^v(\d\.\d\.\d-[\w\d]+-)(.*)</regex>
-									<replacement>$1$2-SNAPSHOT</replacement>
-									<failIfNoMatch>false</failIfNoMatch>
-								</configuration>
-							</execution>
-							<execution>
-								<id>regex-property</id>
-								<goals>
-									<goal>regex-property</goal>
-								</goals>
-								<phase>initialize</phase>
-								<configuration>
-									<name>newVersion</name>
-									<value>${newVersion}</value>
-									<regex>^v(\d\.\d\.\d-[\w\d]+$)</regex>
-									<replacement>$1</replacement>
-									<failIfNoMatch>false</failIfNoMatch>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>versions-maven-plugin</artifactId>
-						<version>2.8.1</version>
-						<inherited>false</inherited>
-						<executions>
-							<execution>
-								<id>set</id>
-								<phase>initialize</phase>
-								<goals>
-									<goal>set</goal>
-								</goals>
-								<configuration>
-									<newVersion>${newVersion}</newVersion>
-								</configuration>
-							</execution>
-							<execution>
-								<id>commit</id>
-								<phase>initialize</phase>
-								<goals>
-									<goal>commit</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
 </project>

--- a/scripts/build_backend_version.sh
+++ b/scripts/build_backend_version.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
 
+if [ -z $1 ]
+then
+	echo "No version supplied. Try to extract it using 'git describe --tags'"
+	if git_descibe=`git describe --tags`
+	then
+		version=${git_descibe#v}
+		echo "Found version $version"
+	fi
+else
+	version=$1
+fi
+
+
 set -x
 
-git_descibe=`git describe --tags`
-
-mvn -T 1C clean package -Dmaven.test.skip=true -DskipTests -Drevision=${git_descibe#v} -pl executable -am
+mvn -T 1C clean package -Dmaven.test.skip=true -DskipTests "-Drevision=$version" -pl executable -am

--- a/scripts/build_backend_version.sh
+++ b/scripts/build_backend_version.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-mvn clean initialize -P setVersion
+set -x
 
-mvn -T 1C package -Dmaven.test.skip=true -DskipTests -pl executable -am
+mvn clean
+
+mvn -T 1C package -Dmaven.test.skip=true -DskipTests -Drevision=2.0.0-`git describe --tags` -pl executable -am

--- a/scripts/build_backend_version.sh
+++ b/scripts/build_backend_version.sh
@@ -2,6 +2,6 @@
 
 set -x
 
-mvn clean
+git_descibe=`git describe --tags`
 
-mvn -T 1C package -Dmaven.test.skip=true -DskipTests -Drevision=2.0.0-`git describe --tags` -pl executable -am
+mvn -T 1C clean package -Dmaven.test.skip=true -DskipTests -Drevision=${git_descibe#v} -pl executable -am

--- a/scripts/build_backend_version.sh
+++ b/scripts/build_backend_version.sh
@@ -7,6 +7,9 @@ then
 	then
 		version=${git_descibe#v}
 		echo "Found version $version"
+	else
+		echo "Could not determine a version"
+		exit 1
 	fi
 else
 	version=$1


### PR DESCRIPTION
Until now the version of an backend build was from within maven.
This was done by executing a special phase with maven and the git-commit-id:
```
mvn initialize -P setVersion
```

This phase overwrites all checked-in pom.xml files, while setting the version string which was derived from `git describe`. Hence a build is not idempotent.

This pr orients on this aproach https://maven.apache.org/maven-ci-friendly.html, which allows the version of the build to be set from extern like so:
```
mvn package -Drevision=<version> -pl executable -am
```
If no version is specified it falls back to `0.0.0-SHAPSHOT` (e.g. in ci backend tests)

Because the backend package is used as a dependency, a phase for flattening the pom is added.