### PR TITLE
remove default view jackson view setting

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/io/jackson/Jackson.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/jackson/Jackson.java
@@ -72,6 +72,7 @@ public class Jackson {
 				//.setAnnotationIntrospector(new RestrictingAnnotationIntrospector())
 				.setInjectableValues(new MutableInjectableValues())
 				.addMixIn(Permission.class, ConqueryPermission.class);
+
 		return objectMapper;
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/io/jackson/Jackson.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/jackson/Jackson.java
@@ -72,8 +72,6 @@ public class Jackson {
 				//.setAnnotationIntrospector(new RestrictingAnnotationIntrospector())
 				.setInjectableValues(new MutableInjectableValues())
 				.addMixIn(Permission.class, ConqueryPermission.class);
-
-		objectMapper.setConfig(objectMapper.getSerializationConfig().withView(Object.class));
 		return objectMapper;
 	}
 

--- a/backend/src/test/java/com/bakdata/conquery/io/jackson/JacksonTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/io/jackson/JacksonTest.java
@@ -13,9 +13,7 @@ import lombok.Data;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 
 public class JacksonTest {
@@ -37,12 +35,12 @@ public class JacksonTest {
 	public static Stream<Arguments> arguments() {
 		return Stream
 				.of(
-						Arguments.of(null, "{\"external\":0}"),
+						Arguments.of(null, "{\"external\":0,\"apiPersistent\":1,\"internalOnly\":2,\"internalCommunication\":3,\"persistentManager\":5,\"persistentShard\":6,\"persistent\":7,\"api\":8}"),
 						Arguments.of(View.InternalCommunication.class, "{\"external\":0,\"internalOnly\":2,\"internalCommunication\":3}"),
 						Arguments.of(View.Persistence.Manager.class, "{\"external\":0,\"apiPersistent\":1,\"internalOnly\":2,\"persistentManager\":5,\"persistent\":7}"),
 						Arguments.of(View.Persistence.Shard.class, "{\"external\":0,\"internalOnly\":2,\"persistentShard\":6,\"persistent\":7}"),
 						Arguments.of(View.Api.class, "{\"external\":0,\"apiPersistent\":1,\"api\":8}")
-						);
+				);
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
@awildturtok ich habe keine Ahnung weshalb das gesetzt war, hast du eine Idee?

Mit der Zeile drinne, hatte ich das Problem, dass die Config nicht richtig geparsed wurde. Es ist aber komisch, weil es sonst bisher nicht aufgefallen ist z.B.  in den E2E tests:

```
$ java  -jar executable/target/executable.jar check
...
default configuration has an error:
  * Must have exactly one Column for Pseudomization.
```
in dem fall war fillAnon=false obwohl es true gesetzt wird default