### PR TITLE
Feature/auto label

### DIFF
--- a/frontend/src/js/query-node-editor/QueryNodeEditor.tsx
+++ b/frontend/src/js/query-node-editor/QueryNodeEditor.tsx
@@ -25,7 +25,6 @@ import ContentColumn from "./ContentColumn";
 import MenuColumn from "./MenuColumn";
 import NodeName from "./NodeName";
 import ResetAndClose from "./ResetAndClose";
-
 import { useAutoLabel } from "./useAutoLabel";
 
 const Root = styled("div")`

--- a/frontend/src/js/query-node-editor/QueryNodeEditor.tsx
+++ b/frontend/src/js/query-node-editor/QueryNodeEditor.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
 import type { PostPrefixForSuggestionsParams } from "../api/api";
@@ -162,12 +162,15 @@ const QueryNodeEditor = ({ node, ...props }: QueryNodeEditorPropsT) => {
     node,
     onUpdateLabel: props.onUpdateLabel,
   });
-  const nodeLabel =
-    autoLabelEnabled && autoLabel
-      ? autoLabel
-      : nodeIsConceptQueryNode(node)
-      ? node.label
-      : node.label || node.id;
+  const nodeLabel = useMemo(
+    () =>
+      !nodeIsConceptQueryNode(node)
+        ? node.label || node.id
+        : autoLabelEnabled && autoLabel && node.ids.length > 1
+        ? autoLabel
+        : node.label,
+    [autoLabel, autoLabelEnabled, node],
+  );
 
   return (
     <Root

--- a/frontend/src/js/query-node-editor/QueryNodeEditor.tsx
+++ b/frontend/src/js/query-node-editor/QueryNodeEditor.tsx
@@ -26,8 +26,7 @@ import MenuColumn from "./MenuColumn";
 import NodeName from "./NodeName";
 import ResetAndClose from "./ResetAndClose";
 
-// TEMPORARILY DISABLED UNTIL FEATURE IS COMPLETE
-// import { useAutoLabel } from "./useAutoLabel";
+import { useAutoLabel } from "./useAutoLabel";
 
 const Root = styled("div")`
   padding: 10px;
@@ -160,20 +159,16 @@ const QueryNodeEditor = ({ node, ...props }: QueryNodeEditorPropsT) => {
       ? RIGHT_SIDE_WIDTH_COMPACT
       : RIGHT_SIDE_WIDTH);
 
-  // TEMPORARILY DISABLED UNTIL FEATURE IS COMPLETE
-  // const { autoLabel, autoLabelEnabled, setAutoLabelEnabled } = useAutoLabel({
-  //   node,
-  //   onUpdateLabel: props.onUpdateLabel,
-  // });
-  // const nodeLabel =
-  //   autoLabelEnabled && autoLabel
-  //     ? autoLabel
-  //     : nodeIsConceptQueryNode(node)
-  //     ? node.label
-  //     : node.label || node.id;
-  const nodeLabel = nodeIsConceptQueryNode(node)
-    ? node.label
-    : node.label || node.id;
+  const { autoLabel, autoLabelEnabled, setAutoLabelEnabled } = useAutoLabel({
+    node,
+    onUpdateLabel: props.onUpdateLabel,
+  });
+  const nodeLabel =
+    autoLabelEnabled && autoLabel
+      ? autoLabel
+      : nodeIsConceptQueryNode(node)
+      ? node.label
+      : node.label || node.id;
 
   return (
     <Root
@@ -191,8 +186,7 @@ const QueryNodeEditor = ({ node, ...props }: QueryNodeEditorPropsT) => {
             allowEditing={nodeIsConceptQueryNode(node)}
             label={nodeLabel}
             onUpdateLabel={(label) => {
-              // TEMPORARILY DISABLED UNTIL FEATURE IS COMPLETE
-              // setAutoLabelEnabled(false);
+              setAutoLabelEnabled(false);
               props.onUpdateLabel(label);
             }}
           />

--- a/frontend/src/js/query-node-editor/useAutoLabel.ts
+++ b/frontend/src/js/query-node-editor/useAutoLabel.ts
@@ -11,13 +11,10 @@ interface AutoLabelProps {
 
 export function useAutoLabel({ node, onUpdateLabel }: AutoLabelProps) {
   const MAX_AUTOLABEL_LENGTH = 30;
-  const DELIMITER = ' ';
+  const DELIMITER = " ";
 
   const formatConceptLabels = (labels: string[]) =>
-    labels
-      .sort()
-      .join(DELIMITER)
-      .substring(0, MAX_AUTOLABEL_LENGTH);
+    labels.sort().join(DELIMITER).substring(0, MAX_AUTOLABEL_LENGTH);
 
   const autoLabel = useMemo(() => {
     return nodeIsConceptQueryNode(node)
@@ -28,8 +25,7 @@ export function useAutoLabel({ node, onUpdateLabel }: AutoLabelProps) {
   }, [node]);
 
   const [autoLabelEnabled, setAutoLabelEnabled] = useState(
-    nodeIsConceptQueryNode(node) &&
-      formatConceptLabels(node.label.split(DELIMITER)) === autoLabel,
+    nodeIsConceptQueryNode(node) && node.label === autoLabel,
   );
 
   const onUpdateLabelRef = useRef(onUpdateLabel);

--- a/frontend/src/js/query-node-editor/useAutoLabel.ts
+++ b/frontend/src/js/query-node-editor/useAutoLabel.ts
@@ -10,7 +10,7 @@ interface AutoLabelProps {
 }
 
 export function useAutoLabel({ node, onUpdateLabel }: AutoLabelProps) {
-  const MAX_AUTOLABEL_LENGTH = 30;
+  const MAX_AUTOLABEL_LENGTH = 250;
   const DELIMITER = " ";
 
   const formatConceptLabels = (labels: string[]) =>

--- a/frontend/src/js/query-node-editor/useAutoLabel.ts
+++ b/frontend/src/js/query-node-editor/useAutoLabel.ts
@@ -11,11 +11,12 @@ interface AutoLabelProps {
 
 export function useAutoLabel({ node, onUpdateLabel }: AutoLabelProps) {
   const MAX_AUTOLABEL_LENGTH = 30;
+  const DELIMITER = ' ';
 
   const formatConceptLabels = (labels: string[]) =>
     labels
-      .map((label) => label.match(/[a-zA-Z0-9]*/g)?.join(""))
-      .join("_")
+      .sort()
+      .join(DELIMITER)
       .substring(0, MAX_AUTOLABEL_LENGTH);
 
   const autoLabel = useMemo(() => {
@@ -28,7 +29,7 @@ export function useAutoLabel({ node, onUpdateLabel }: AutoLabelProps) {
 
   const [autoLabelEnabled, setAutoLabelEnabled] = useState(
     nodeIsConceptQueryNode(node) &&
-      formatConceptLabels(node.label.split("_")) === autoLabel,
+      formatConceptLabels(node.label.split(DELIMITER)) === autoLabel,
   );
 
   const onUpdateLabelRef = useRef(onUpdateLabel);


### PR DESCRIPTION
- delimiter for autolabel elements is now space
- special characters aren't ignored anymore
- elements are sorted in alphabetical order
- autolabel is only applied for nodes with more than one element